### PR TITLE
Feature(theme): automatic dark mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,14 @@ Live showcase: https://ffhl-stats.vercel.app/
 - 💾 **Smart Caching**: Automatic data caching with 5-minute TTL
 - 🌐 **Internationalization**: Multi-language support with ngx-translate
 - 🎨 **Material Design**: Clean UI with Angular Material components
+- 🌓 **Automatic Dark Mode**: Follows device/browser `prefers-color-scheme` (no manual toggle)
+- 📦 **Installable PWA**: Installable on desktop/mobile; app shell is cached for offline-friendly reloads (live stats still require the backend)
 - 📱 **Mobile Responsive**: Optimized for all screen sizes with adaptive layouts and collapsible controls
+
+More details:
+
+- **Theming / Automatic Dark Mode**: [docs/project-overview.md](docs/project-overview.md)
+- **PWA / Installable App**: [docs/project-overview.md](docs/project-overview.md)
 
 ## Installation and use
 

--- a/angular.json
+++ b/angular.json
@@ -32,7 +32,7 @@
               }
             ],
             "styles": [
-              "@angular/material/prebuilt-themes/azure-blue.css",
+              "src/theme.scss",
               "src/styles.scss"
             ],
             "scripts": []
@@ -107,7 +107,7 @@
               }
             ],
             "styles": [
-              "@angular/material/prebuilt-themes/azure-blue.css",
+              "src/theme.scss",
               "src/styles.scss"
             ],
             "scripts": []

--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -39,6 +39,27 @@ npm run build
 - Optimized and minified
 - Ready for deployment
 
+### Theming / Automatic Dark Mode
+
+The UI follows the device/browser color scheme automatically (no manual toggle).
+
+Key files:
+
+- `src/theme.scss`: Angular Material theme configuration (emits `--mat-sys-*` tokens via `theme-type: color-scheme`)
+- `src/styles.scss`: global styles + targeted overrides for overlays/tabs/toggles to ensure dark mode renders consistently
+
+#### Debugging dark mode
+
+In DevTools Console:
+
+- Check preference: `window.matchMedia('(prefers-color-scheme: dark)').matches`
+- Check a token: `getComputedStyle(document.documentElement).getPropertyValue('--mat-sys-surface')`
+
+If the page looks like it’s using a stale/light bundle (common during theming work):
+
+- Hard refresh: `Cmd+Shift+R`
+- If still wrong under `ng serve`, restart `npm start` (browser/dev-server caching can keep older CSS around)
+
 ### PWA (Installable App)
 
 The app is configured as a PWA in production builds.

--- a/docs/project-overview.md
+++ b/docs/project-overview.md
@@ -106,6 +106,20 @@ FilterService → Component → Table Display
 - Testing: `npm test` (unit tests)
 - E2E: Playwright tests in e2e/
 
+### Theming / Automatic Dark Mode
+
+The UI uses Angular Material theming with automatic light/dark mode based on the device/browser preference.
+
+- Theme entrypoint: `src/theme.scss`
+- Global styles + a few component overrides: `src/styles.scss`
+- Build/test wiring: `angular.json` includes `src/theme.scss` in the `styles` array.
+
+Implementation notes:
+
+- Uses Material `theme-type: color-scheme` which emits CSS `light-dark(...)` tokens.
+- `src/theme.scss` sets `color-scheme` to match `prefers-color-scheme` so the browser resolves `light-dark(...)` correctly.
+- Visual consistency in dark mode relies on Material system tokens like `--mat-sys-surface` / `--mat-sys-on-surface`.
+
 ### PWA / Installable App
 
 The production build is configured as a Progressive Web App (PWA):

--- a/src/app/shared/player-card/player-card.component.scss
+++ b/src/app/shared/player-card/player-card.component.scss
@@ -11,6 +11,20 @@
   }
 }
 
+mat-card {
+  background-color: var(--mat-sys-surface-container-high);
+  color: var(--mat-sys-on-surface);
+}
+
+table.mat-mdc-table {
+  background-color: var(--mat-sys-surface);
+  color: var(--mat-sys-on-surface);
+}
+
+.mat-mdc-cell {
+  color: var(--mat-sys-on-surface);
+}
+
 .card-title-icon {
   width: 30px;
   height: 30px;
@@ -32,7 +46,8 @@ mat-card-title {
 }
 
 .mat-cell-label {
-  background-color: #eeeeee;
+  background-color: var(--mat-sys-surface-container-high);
+  color: var(--mat-sys-on-surface);
   font-weight: bold;
 }
 
@@ -79,16 +94,16 @@ mat-card-title {
   }
 
   &::-webkit-scrollbar-track {
-    background: #f1f1f1;
+    background: var(--mat-sys-surface-container);
     border-radius: 4px;
   }
 
   &::-webkit-scrollbar-thumb {
-    background: #888;
+    background: var(--mat-sys-outline);
     border-radius: 4px;
 
     &:hover {
-      background: #555;
+      background: var(--mat-sys-on-surface-variant);
     }
   }
 }
@@ -101,16 +116,16 @@ mat-card-title {
   }
 
   &::-webkit-scrollbar-track {
-    background: #f1f1f1;
+    background: var(--mat-sys-surface-container);
     border-radius: 4px;
   }
 
   &::-webkit-scrollbar-thumb {
-    background: #888;
+    background: var(--mat-sys-outline);
     border-radius: 4px;
 
     &:hover {
-      background: #555;
+      background: var(--mat-sys-on-surface-variant);
     }
   }
 }
@@ -184,8 +199,9 @@ mat-card-title {
     align-items: center;
     width: 100%;
     padding: 12px 16px;
-    background-color: var(--mdc-theme-surface, #fff);
-    border: 1px solid var(--mdc-theme-outline, #ccc);
+    background-color: var(--mat-sys-surface-container);
+    border: 1px solid var(--mat-sys-outline-variant);
+    color: var(--mat-sys-on-surface);
     border-radius: 4px;
     cursor: pointer;
     font-size: 14px;
@@ -195,7 +211,7 @@ mat-card-title {
     z-index: 1;
 
     &:hover {
-      background-color: var(--mdc-theme-surface-variant, #f5f5f5);
+      background-color: var(--mat-sys-surface-container-high);
     }
 
     span {
@@ -231,7 +247,8 @@ mat-card-title {
     transform: translateX(-50%);
     width: 95vw;
     max-width: 95vw;
-    background: white;
+    background: var(--mat-sys-surface-container-high);
+    color: var(--mat-sys-on-surface);
     border-top-left-radius: 16px;
     border-top-right-radius: 16px;
     box-shadow: 0 -2px 10px rgba(0, 0, 0, 0.2);
@@ -272,7 +289,8 @@ mat-card-title {
 
   th {
     font-weight: bold;
-    background-color: #f5f5f5;
+    background-color: var(--mat-sys-surface-container);
+    color: var(--mat-sys-on-surface);
     text-align: center;
     position: sticky;
     top: 0;
@@ -287,7 +305,8 @@ mat-card-title {
   th:first-child,
   td:first-child {
     font-weight: bold;
-    background-color: #eeeeee;
+    background-color: var(--mat-sys-surface-container-high);
+    color: var(--mat-sys-on-surface);
   }
 }
 

--- a/src/app/shared/settings-panel/min-games-slider/min-games-slider.component.scss
+++ b/src/app/shared/settings-panel/min-games-slider/min-games-slider.component.scss
@@ -11,7 +11,7 @@
   display: flex;
   justify-content: space-between;
   span {
-    color: #1a1b1f;
+    color: var(--mat-sys-on-surface-variant);
     font-size: 0.875rem;
     letter-spacing: 0.016rem;
   }

--- a/src/app/shared/settings-panel/settings-panel.component.scss
+++ b/src/app/shared/settings-panel/settings-panel.component.scss
@@ -10,8 +10,9 @@
   align-items: center;
   width: 100%;
   padding: 12px 16px;
-  background-color: var(--mdc-theme-surface, #fff);
-  border: 1px solid var(--mdc-theme-outline, #ccc);
+  background-color: var(--mat-sys-surface-container);
+  border: 1px solid var(--mat-sys-outline-variant);
+  color: var(--mat-sys-on-surface);
   border-radius: 4px;
   cursor: pointer;
   font-size: 14px;
@@ -20,7 +21,7 @@
   transition: background-color 0.2s;
 
   &:hover {
-    background-color: var(--mdc-theme-surface-variant, #f5f5f5);
+    background-color: var(--mat-sys-surface-container-high);
   }
 
   span {

--- a/src/app/shared/stats-table/stats-table.component.scss
+++ b/src/app/shared/stats-table/stats-table.component.scss
@@ -50,7 +50,7 @@
 .search-container {
   position: sticky;
   top: 0;
-  background: white;
+  background: var(--mat-sys-surface);
   z-index: 2;
   padding-bottom: 8px;
 }
@@ -68,12 +68,26 @@
 }
 
 .mat-mdc-table {
+  background: var(--mat-sys-surface);
+  color: var(--mat-sys-on-surface);
+}
+
+.mat-mdc-table {
   .mat-mdc-header-row {
     position: sticky;
     top: 0;
     z-index: 1;
-    background: white;
+    background: var(--mat-sys-surface-container);
+    color: var(--mat-sys-on-surface);
   }
+}
+
+.mat-mdc-header-cell {
+  color: var(--mat-sys-on-surface);
+}
+
+.mat-mdc-cell {
+  color: var(--mat-sys-on-surface);
 }
 
 .no-results {
@@ -90,6 +104,7 @@
 
 .mat-mdc-row:hover {
   background-color: var(--mat-sys-primary-container);
+  color: var(--mat-sys-on-primary-container);
   cursor: pointer;
 }
 
@@ -100,6 +115,7 @@
 
 .mat-mdc-row.a11y-active {
   background-color: var(--mat-sys-primary-container);
+  color: var(--mat-sys-on-primary-container);
 }
 
 

--- a/src/app/shared/top-controls/top-controls.component.scss
+++ b/src/app/shared/top-controls/top-controls.component.scss
@@ -11,8 +11,9 @@
 	align-items: center;
 	width: 100%;
 	padding: 10px 16px;
-	background-color: var(--mdc-theme-surface, #fff);
-	border: 1px solid var(--mdc-theme-outline, #ccc);
+	background-color: var(--mat-sys-surface-container);
+	border: 1px solid var(--mat-sys-outline-variant);
+	color: var(--mat-sys-on-surface);
 	border-radius: 4px;
 	cursor: pointer;
 	font-size: 14px;
@@ -21,7 +22,7 @@
 	transition: background-color 0.2s;
 
 	&:hover {
-		background-color: var(--mdc-theme-surface-variant, #f5f5f5);
+		background-color: var(--mat-sys-surface-container-high);
 	}
 
 	span {

--- a/src/index.html
+++ b/src/index.html
@@ -9,7 +9,9 @@
   <link rel="icon" href="icons/favicon-32.png" type="image/png" sizes="32x32">
   <link rel="icon" href="icons/favicon-16.png" type="image/png" sizes="16x16">
   <link rel="manifest" href="manifest.webmanifest">
-  <meta name="theme-color" content="#1976d2">
+  <meta name="color-scheme" content="light dark">
+  <meta name="theme-color" media="(prefers-color-scheme: light)" content="#1976d2">
+  <meta name="theme-color" media="(prefers-color-scheme: dark)" content="#0b1f3a">
 
   <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-capable" content="yes">

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -21,6 +21,226 @@ body {
 body {
   margin: 0;
   font-family: Roboto, "Helvetica Neue", sans-serif;
+  background-color: var(--mat-sys-surface);
+  color: var(--mat-sys-on-surface);
+}
+
+// Material: ensure overlays/dialogs/tabs/toggles follow theme tokens.
+// Some MDC-based components can look incorrect in dark mode if defaults bleed through.
+
+.cdk-overlay-container {
+  color: var(--mat-sys-on-surface);
+}
+
+// Backdrop: keep a consistent, not-too-heavy overlay.
+.cdk-overlay-backdrop {
+  background: rgb(0 0 0 / 0.4) !important;
+}
+
+@media (prefers-color-scheme: dark) {
+  .cdk-overlay-backdrop {
+    background: rgb(0 0 0 / 0.55) !important;
+  }
+}
+
+// Dialog surfaces (player card + help dialog) should not default to white.
+.mat-mdc-dialog-container .mdc-dialog__surface {
+  background-color: var(--mat-sys-surface-container-high) !important;
+  color: var(--mat-sys-on-surface) !important;
+}
+
+// Cards are used in dialogs (player card) and should not default to white.
+.mat-mdc-card {
+  background-color: var(--mat-sys-surface-container-high);
+  color: var(--mat-sys-on-surface);
+}
+
+// Dropdown/menu/autocomplete panels (rendered in cdk overlay).
+.mat-mdc-select-panel,
+.mat-mdc-menu-panel,
+.mat-mdc-autocomplete-panel,
+.mat-datepicker-content {
+  background-color: var(--mat-sys-surface-container-high) !important;
+  color: var(--mat-sys-on-surface) !important;
+}
+
+.mat-mdc-option,
+.mat-mdc-menu-item,
+.mat-mdc-autocomplete-panel .mat-mdc-option {
+  color: var(--mat-sys-on-surface) !important;
+}
+
+.mat-mdc-option:hover:not(.mdc-list-item--disabled),
+.mat-mdc-menu-item:hover:not(.mat-mdc-menu-item-disabled) {
+  background-color: var(--mat-sys-surface-container-highest) !important;
+}
+
+.mat-mdc-option.mdc-list-item--selected:not(.mdc-list-item--disabled) {
+  background-color: var(--mat-sys-primary-container) !important;
+  color: var(--mat-sys-on-primary-container) !important;
+}
+
+// Form fields (selects + search): prevent light containers in dark mode.
+.mat-mdc-form-field .mat-mdc-text-field-wrapper {
+  background-color: var(--mat-sys-surface-container-high) !important;
+  color: var(--mat-sys-on-surface) !important;
+}
+
+.mat-mdc-form-field .mdc-floating-label {
+  color: var(--mat-sys-on-surface-variant) !important;
+}
+
+.mat-mdc-form-field .mat-mdc-input-element,
+.mat-mdc-form-field .mat-mdc-select-min-line,
+.mat-mdc-form-field .mat-mdc-select-value-text {
+  color: var(--mat-sys-on-surface) !important;
+}
+
+.mat-mdc-form-field .mat-mdc-select-arrow {
+  color: var(--mat-sys-on-surface-variant) !important;
+}
+
+// Tabs: avoid black-on-black by explicitly mapping to system tokens.
+.mat-mdc-tab-header {
+  background-color: var(--mat-sys-surface-container);
+  border-bottom: 1px solid var(--mat-sys-outline-variant);
+}
+
+.mat-mdc-tab .mdc-tab__text-label,
+.mat-mdc-tab-header .mdc-tab__text-label {
+  color: var(--mat-sys-on-surface-variant) !important;
+}
+
+.mat-mdc-tab.mdc-tab--active .mdc-tab__text-label,
+.mat-mdc-tab-header .mdc-tab--active .mdc-tab__text-label {
+  color: var(--mat-sys-on-surface) !important;
+}
+
+// Button toggles (report type): make inactive readable and active high-contrast.
+.mat-button-toggle-group {
+  background-color: var(--mat-sys-surface-container) !important;
+  border: 1px solid var(--mat-sys-outline-variant) !important;
+}
+
+.mat-button-toggle {
+  color: var(--mat-sys-on-surface) !important;
+}
+
+.mat-button-toggle-checked {
+  background-color: var(--mat-sys-primary-container) !important;
+  color: var(--mat-sys-on-primary-container) !important;
+}
+
+// The checkmark shown on selected toggles should match the selected text color.
+// Material uses a pseudo-checkbox with its own internal styles; use high specificity.
+.mat-button-toggle-group .mat-button-toggle .mat-pseudo-checkbox {
+  color: currentColor !important;
+  border-color: currentColor !important;
+}
+
+.mat-button-toggle-group .mat-button-toggle-checked .mat-pseudo-checkbox {
+  color: currentColor !important;
+  border-color: currentColor !important;
+  opacity: 1 !important;
+}
+
+// Checkmark stroke is typically drawn using borders on a pseudo-element.
+.mat-button-toggle-group .mat-button-toggle-checked .mat-pseudo-checkbox::after {
+  border-color: currentColor !important;
+  opacity: 1 !important;
+}
+
+// Some variants use an additional "checked" class.
+.mat-button-toggle-group .mat-button-toggle-checked .mat-pseudo-checkbox.mat-pseudo-checkbox-checked {
+  color: currentColor !important;
+  border-color: currentColor !important;
+  opacity: 1 !important;
+}
+
+// Material's "minimal" pseudo-checkbox uses a CSS variable for the checkmark.
+// Override it for checked toggles so it stays readable (matches selected text).
+.mat-button-toggle-group .mat-button-toggle-checked .mat-pseudo-checkbox-minimal {
+  --mat-pseudo-checkbox-minimal-selected-checkmark-color: currentColor;
+}
+
+.mat-button-toggle-group .mat-button-toggle-checked .mat-pseudo-checkbox-minimal.mat-pseudo-checkbox-checked::after {
+  color: currentColor !important;
+}
+
+// If the selected indicator is rendered as an icon instead of a pseudo-checkbox.
+.mat-button-toggle-group .mat-button-toggle-checked mat-icon,
+.mat-button-toggle-group .mat-button-toggle-checked .mat-icon {
+  color: currentColor !important;
+  opacity: 1 !important;
+}
+
+.mat-button-toggle-button {
+  color: inherit !important;
+}
+
+.mat-button-toggle-label-content {
+  color: inherit !important;
+}
+
+@media (prefers-color-scheme: dark) {
+  // Slides toggles (points per game): ensure readable + modern dark styling.
+  .mat-mdc-slide-toggle .mdc-switch__track {
+    background-color: var(--mat-sys-surface-container-high) !important;
+  }
+
+  .mat-mdc-slide-toggle .mdc-switch__handle {
+    background-color: var(--mat-sys-on-surface-variant) !important;
+  }
+
+  .mat-mdc-slide-toggle.mat-mdc-slide-toggle-checked .mdc-switch__track {
+    background-color: var(--mat-sys-primary) !important;
+  }
+
+  .mat-mdc-slide-toggle.mat-mdc-slide-toggle-checked .mdc-switch__handle {
+    background-color: var(--mat-sys-on-primary) !important;
+  }
+
+  .mat-mdc-slide-toggle .mdc-form-field > label {
+    color: var(--mat-sys-on-surface) !important;
+  }
+}
+
+// Help dialog: ensure title/body text uses on-surface (defaults can be too dark).
+.help-dialog {
+  .mdc-dialog__title,
+  .mdc-dialog__content,
+  .mat-mdc-dialog-title,
+  .mat-mdc-dialog-content {
+    color: var(--mat-sys-on-surface) !important;
+  }
+
+  // Dialog action (e.g. "Sulje") should use a readable accent in dark mode.
+  .mat-mdc-dialog-actions .mat-mdc-button,
+  .mat-mdc-dialog-actions .mat-mdc-unelevated-button,
+  .mat-mdc-dialog-actions .mat-mdc-outlined-button,
+  .mat-mdc-dialog-actions a {
+    color: var(--mat-sys-primary) !important;
+  }
+}
+
+// Player card graphs: checkbox labels and boxes need contrast in dark mode.
+.player-card-dialog {
+  .mat-mdc-checkbox .mdc-form-field > label {
+    color: var(--mat-sys-on-surface) !important;
+  }
+
+  .mat-mdc-checkbox .mdc-checkbox__background {
+    border-color: var(--mat-sys-outline) !important;
+  }
+
+  .mat-mdc-checkbox.mat-mdc-checkbox-checked .mdc-checkbox__background {
+    background-color: var(--mat-sys-primary) !important;
+    border-color: var(--mat-sys-primary) !important;
+  }
+
+  .mat-mdc-checkbox.mat-mdc-checkbox-checked .mdc-checkbox__checkmark-path {
+    stroke: var(--mat-sys-on-primary) !important;
+  }
 }
 
 .sr-only {
@@ -42,9 +262,9 @@ body {
   z-index: 10000;
   padding: 8px 12px;
   border-radius: 6px;
-  background: #fff;
-  color: #000;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+  background: var(--mat-sys-surface);
+  color: var(--mat-sys-on-surface);
+  box-shadow: var(--mat-sys-level2);
   transform: translateY(-200%);
   transition: transform 120ms ease-in-out;
 }

--- a/src/theme.scss
+++ b/src/theme.scss
@@ -1,0 +1,62 @@
+@use "@angular/material" as mat;
+
+// Material theme setup
+// Auto dark mode (no manual toggle): use `theme-type: color-scheme`, which emits CSS `light-dark()`
+// values and lets the browser pick the correct value based on the user's preferred color scheme.
+//
+// We keep colors aligned with the previous prebuilt theme choice (azure-blue).
+
+$primary: mat.$azure-palette;
+$tertiary: mat.$blue-palette;
+
+$theme: mat.define-theme(
+  (
+    color: (
+      theme-type: color-scheme,
+      primary: $primary,
+      tertiary: $tertiary,
+    ),
+    typography: (
+      plain-family: (Roboto, sans-serif),
+      brand-family: (Roboto, sans-serif),
+    ),
+    density: (
+      scale: 0,
+    ),
+  )
+);
+
+@include mat.core();
+
+:root {
+  // Ensure the browser's *used* color-scheme matches the user's preference.
+  // This matters because the generated theme tokens rely on CSS `light-dark()`.
+  color-scheme: light;
+
+  // System-level variables (e.g. --mat-sys-*)
+  @include mat.theme(
+    (
+      color: (
+        theme-type: color-scheme,
+        primary: $primary,
+        tertiary: $tertiary,
+      ),
+      typography: (
+        plain-family: (Roboto, sans-serif),
+        brand-family: (Roboto, sans-serif),
+      ),
+      density: (
+        scale: 0,
+      ),
+    )
+  );
+
+  // Component token variables (e.g. --mat-*)
+  @include mat.all-component-themes($theme);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    color-scheme: dark;
+  }
+}


### PR DESCRIPTION
Use Angular Material color-scheme theming to follow prefers-color-scheme automatically (no manual toggle).

- Replace prebuilt theme with src/theme.scss
- Use Material system tokens in global + component styles to fix dark-mode surfaces (overlays, dialogs, tabs, toggles, form fields)
- Document the theming approach and add a short README mention