### PR TITLE
chore(coverage): new coverage% requirements and make needed tests

### DIFF
--- a/docs/project-requirements.md
+++ b/docs/project-requirements.md
@@ -69,13 +69,13 @@ npm run test:coverage
 
 - **Scope**: Application implementation under `src/` (test files excluded)
 - **Coverage gate (enforced by tooling)**:
-  - >= 95% statements
-  - >= 95% lines
-  - >= 95% functions
-  - >= 85% branches
+  - >= 98% statements
+  - >= 98% lines
+  - >= 98% functions
+  - >= 96% branches
 - **Long-term target**:
   - 100% statements, lines, and functions
-  - >= 90% branches
+  - >= 96% branches
 - **Action on Failure**: Add/update tests or refactor/simplify code until targets are met
 - **Prefer**: Remove unused/dead code rather than writing tests solely to “cover” it
 - **Contribution rule (required)**: every new/changed code path must be covered by tests (aim 100% coverage for the code you touched, including error/edge cases)
@@ -101,10 +101,10 @@ Coverage is enforced by tooling (Karma coverage check) and must meet the gate.
 
 | Metric     | Enforced Coverage Gate | Long-term Target |
 | ---------- | ---------------------- | ---------------- |
-| Statements | >= 95%                 | 100%             |
-| Lines      | >= 95%                 | 100%             |
-| Functions  | >= 95%                 | 100%             |
-| Branches   | >= 85%                 | >= 90%           |
+| Statements | >= 98%                 | 100%             |
+| Lines      | >= 98%                 | 100%             |
+| Functions  | >= 98%                 | 100%             |
+| Branches   | >= 96%                 | >= 96%           |
 
 #### Coverage Enforcement
 
@@ -431,7 +431,7 @@ Before marking work complete, verify:
 - [ ] Build succeeds (`npm run build`)
 - [ ] App serves without errors (`npm start`)
 - [ ] New features have tests
-- [ ] Test coverage meets gate (>=95% statements/lines/functions, >=85% branches)
+- [ ] Test coverage meets gate (>=98% statements/lines/functions, >=96% branches)
 - [ ] No TypeScript errors
 - [ ] Code follows project structure
 - [ ] Documentation updated

--- a/docs/project-testing.md
+++ b/docs/project-testing.md
@@ -9,7 +9,7 @@ This project has comprehensive test coverage for all UI behaviors, services, and
 - **Total Test Files / Tests**: Run `npm test` to see the current count and status
 - **Test Framework**: Jasmine + Karma
 - **E2E Framework**: Playwright
-- **Coverage**: Enforced gate is >=95% statements/lines/functions and >=85% branches; long-term target is 100% statements/lines/functions and >=90% branches
+- **Coverage**: Enforced gate is >=98% statements/lines/functions and >=96% branches; long-term target is 100% statements/lines/functions and >=96% branches
 Note: avoid hard-coding a “current test count” in docs; it becomes stale quickly.
 
 ## Contribution Requirement: 100% Tested Changes

--- a/karma.conf.cjs
+++ b/karma.conf.cjs
@@ -33,10 +33,10 @@ module.exports = function (config) {
       check: {
         emitWarning: false,
         global: {
-          statements: 95,
-          lines: 95,
-          functions: 95,
-          branches: 85,
+          statements: 98,
+          lines: 98,
+          functions: 98,
+          branches: 96,
           excludes: [
             '**/*.spec.ts',
             '**/*.test.ts',

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -511,4 +511,54 @@ describe('AppComponent', () => {
       expect(snackBar.open.calls.count()).toBe(2);
     }));
   });
+
+  describe('activateUpdateAndReload', () => {
+    it('should delegate to PwaUpdateService.activateAndReload', () => {
+      const fixture = TestBed.createComponent(AppComponent);
+      const app = fixture.componentInstance;
+
+      app.activateUpdateAndReload();
+
+      expect(pwaUpdateService.activateAndReload).toHaveBeenCalled();
+    });
+  });
+
+  describe('help keydown guards', () => {
+    it('should not open help dialog when modifier keys are pressed', () => {
+      const fixture = TestBed.createComponent(AppComponent);
+      const app = fixture.componentInstance;
+
+      app.onDocumentKeydown({
+        key: '?',
+        altKey: true,
+        ctrlKey: false,
+        metaKey: false,
+        shiftKey: false,
+        preventDefault: jasmine.createSpy('preventDefault'),
+        target: document.body,
+      } as any);
+
+      expect(dialog.open).not.toHaveBeenCalled();
+    });
+
+    it('should not open help dialog when target is contentEditable', () => {
+      const fixture = TestBed.createComponent(AppComponent);
+      const app = fixture.componentInstance;
+
+      const editable = document.createElement('div');
+      editable.contentEditable = 'true';
+
+      app.onDocumentKeydown({
+        key: '?',
+        altKey: false,
+        ctrlKey: false,
+        metaKey: false,
+        shiftKey: false,
+        preventDefault: jasmine.createSpy('preventDefault'),
+        target: editable,
+      } as any);
+
+      expect(dialog.open).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/src/app/services/tests/api.service.spec.ts
+++ b/src/app/services/tests/api.service.spec.ts
@@ -106,6 +106,23 @@ describe('ApiService', () => {
       req.flush(mockSeasons);
     });
 
+    it('should treat teamId "1" as default (no query param, no team cache suffix)', (done) => {
+      const mockSeasons: Season[] = [{ season: 2024, text: '2024-25' }];
+
+      service.getSeasons('regular', '1').subscribe((seasons) => {
+        expect(seasons).toEqual(mockSeasons);
+        const cachedData = cacheService.get<Season[]>('seasons-regular');
+        expect(cachedData).toEqual(mockSeasons);
+        done();
+      });
+
+      const req = httpMock.expectOne((r) => {
+        return r.url === `${API_URL}/seasons/regular` && !r.params.has('teamId');
+      });
+      expect(req.request.method).toBe('GET');
+      req.flush(mockSeasons);
+    });
+
     it('should handle API errors gracefully', (done) => {
       const consoleErrorSpy = spyOn(console, 'error');
 

--- a/src/app/services/tests/pwa-update.service.spec.ts
+++ b/src/app/services/tests/pwa-update.service.spec.ts
@@ -1,5 +1,6 @@
-import { TestBed } from '@angular/core/testing';
 import { DOCUMENT } from '@angular/common';
+import { PLATFORM_ID } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
 import { SwUpdate } from '@angular/service-worker';
 import { Subject } from 'rxjs';
 import { PwaUpdateService } from '../pwa-update.service';
@@ -13,44 +14,57 @@ class SwUpdateMock {
 }
 
 describe('PwaUpdateService', () => {
-  let service: PwaUpdateService;
-  let swUpdate: SwUpdateMock;
-  let fakeDocument: any;
-  let listeners: Record<string, Array<() => void>>;
+  class FakeDocument extends EventTarget {
+    visibilityState: DocumentVisibilityState = 'visible';
+    defaultView = {
+      location: {
+        reload: jasmine.createSpy('reload'),
+      },
+    } as any;
+  }
 
-  beforeEach(() => {
-    listeners = {};
-    fakeDocument = {
-      visibilityState: 'visible',
-      addEventListener: (type: string, handler: () => void) => {
-        listeners[type] = listeners[type] ?? [];
-        listeners[type].push(handler);
-      },
-      removeEventListener: (type: string, handler: () => void) => {
-        listeners[type] = (listeners[type] ?? []).filter((h) => h !== handler);
-      },
-      defaultView: {
-        location: {
-          reload: jasmine.createSpy('reload'),
-        },
-      },
-    };
+  it('should no-op on non-browser platforms', () => {
+    TestBed.configureTestingModule({
+      providers: [
+        PwaUpdateService,
+        { provide: PLATFORM_ID, useValue: 'server' },
+      ],
+    });
+
+    expect(() => TestBed.inject(PwaUpdateService)).not.toThrow();
+  });
+
+  it('should no-op when SwUpdate is not provided', () => {
+    TestBed.configureTestingModule({
+      providers: [
+        PwaUpdateService,
+        { provide: PLATFORM_ID, useValue: 'browser' },
+      ],
+    });
+
+    const service = TestBed.inject(PwaUpdateService);
+
+    let latest: boolean | undefined;
+    service.updateAvailable$.subscribe((v) => (latest = v));
+    expect(latest).toBe(false);
+  });
+
+  it('should flip updateAvailable$ to true on VERSION_READY', (done) => {
+    const doc = new FakeDocument();
 
     TestBed.configureTestingModule({
       providers: [
         PwaUpdateService,
+        { provide: PLATFORM_ID, useValue: 'browser' },
         { provide: SwUpdate, useClass: SwUpdateMock },
-        { provide: DOCUMENT, useValue: fakeDocument },
+        { provide: DOCUMENT, useValue: doc },
       ],
     });
 
-    service = TestBed.inject(PwaUpdateService);
-    swUpdate = TestBed.inject(SwUpdate) as unknown as SwUpdateMock;
-  });
+    const service = TestBed.inject(PwaUpdateService);
+    const swUpdate = TestBed.inject(SwUpdate) as unknown as SwUpdateMock;
 
-  it('should flip updateAvailable$ to true on VERSION_READY', (done) => {
     const values: boolean[] = [];
-
     const sub = service.updateAvailable$.subscribe((v) => {
       values.push(v);
       if (values.includes(true)) {
@@ -64,18 +78,69 @@ describe('PwaUpdateService', () => {
     swUpdate.versionUpdates.next({ type: 'VERSION_READY' });
   });
 
+  it('should check for updates when app becomes visible', () => {
+    const doc = new FakeDocument();
+    doc.visibilityState = 'hidden';
+
+    TestBed.configureTestingModule({
+      providers: [
+        PwaUpdateService,
+        { provide: PLATFORM_ID, useValue: 'browser' },
+        { provide: SwUpdate, useClass: SwUpdateMock },
+        { provide: DOCUMENT, useValue: doc },
+      ],
+    });
+
+    const swUpdate = TestBed.inject(SwUpdate) as unknown as SwUpdateMock;
+    TestBed.inject(PwaUpdateService);
+
+    doc.dispatchEvent(new Event('visibilitychange'));
+    expect(swUpdate.checkForUpdate).not.toHaveBeenCalled();
+
+    doc.visibilityState = 'visible';
+    doc.dispatchEvent(new Event('visibilitychange'));
+    expect(swUpdate.checkForUpdate).toHaveBeenCalled();
+  });
+
+  it('activateAndReload should early-return when SwUpdate is disabled', async () => {
+    const doc = new FakeDocument();
+    const swUpdateMock = new SwUpdateMock();
+    swUpdateMock.isEnabled = false;
+
+    TestBed.configureTestingModule({
+      providers: [
+        PwaUpdateService,
+        { provide: PLATFORM_ID, useValue: 'browser' },
+        { provide: SwUpdate, useValue: swUpdateMock },
+        { provide: DOCUMENT, useValue: doc },
+      ],
+    });
+
+    const service = TestBed.inject(PwaUpdateService);
+    await service.activateAndReload();
+
+    expect(swUpdateMock.activateUpdate).not.toHaveBeenCalled();
+    expect(doc.defaultView.location.reload).not.toHaveBeenCalled();
+  });
+
   it('should activate update and reload on activateAndReload()', async () => {
+    const doc = new FakeDocument();
+
+    TestBed.configureTestingModule({
+      providers: [
+        PwaUpdateService,
+        { provide: PLATFORM_ID, useValue: 'browser' },
+        { provide: SwUpdate, useClass: SwUpdateMock },
+        { provide: DOCUMENT, useValue: doc },
+      ],
+    });
+
+    const service = TestBed.inject(PwaUpdateService);
+    const swUpdate = TestBed.inject(SwUpdate) as unknown as SwUpdateMock;
+
     await service.activateAndReload();
 
     expect(swUpdate.activateUpdate).toHaveBeenCalled();
-    expect(fakeDocument.defaultView.location.reload).toHaveBeenCalled();
-  });
-
-  it('should check for updates when app becomes visible', () => {
-    const handler = listeners['visibilitychange']?.[0];
-    expect(handler).toBeDefined();
-
-    handler?.();
-    expect(swUpdate.checkForUpdate).toHaveBeenCalled();
+    expect(doc.defaultView.location.reload).toHaveBeenCalled();
   });
 });

--- a/src/app/shared/player-card/player-card-graphs/player-card-graphs.component.spec.ts
+++ b/src/app/shared/player-card/player-card-graphs/player-card-graphs.component.spec.ts
@@ -263,4 +263,89 @@ describe('PlayerCardGraphsComponent', () => {
       )
     ).toBe('rgba(0,0,0,0.8)');
   });
+
+  it('should use goalie stat keys when data is a goalie', () => {
+    const goalieSeasons: any[] = [
+      { season: 2024, score: 10, scoreAdjustedByGames: 0.2, games: 40, wins: 20, saves: 900, shutouts: 4 },
+      { season: 2023, score: 8, scoreAdjustedByGames: 0.18, games: 38, wins: 18, saves: 850, shutouts: 3 },
+    ];
+
+    const goalie: any = {
+      name: 'Goalie One',
+      score: 0,
+      scoreAdjustedByGames: 0,
+      games: 40,
+      wins: 20,
+      saves: 900,
+      shutouts: 4,
+      seasons: goalieSeasons,
+    };
+
+    const goalieFixture = TestBed.createComponent(PlayerCardGraphsComponent);
+    const goalieComponent = goalieFixture.componentInstance;
+
+    goalieComponent.data = goalie;
+    goalieFixture.detectChanges();
+
+    expect(goalieComponent.isGoalie).toBeTrue();
+    expect(goalieComponent.chartStatKeys).toContain('wins');
+    expect(goalieComponent.chartStatKeys).toContain('saves');
+    expect(goalieComponent.chartStatKeys).toContain('shutouts');
+
+    goalieComponent.onStatToggle('wins', { checked: true } as any);
+    goalieFixture.detectChanges();
+    expect(goalieComponent.lineChartData.datasets.length).toBeGreaterThan(0);
+  });
+
+  it('should set y-axis stepSize to 1 when maxValue is 0', () => {
+    const themedFixture = TestBed.createComponent(PlayerCardGraphsComponent);
+    const themed = themedFixture.componentInstance;
+    themed.data = mockPlayer;
+
+    (themed as any).chartYearsRange = [2024];
+    (themed as any).chartLabels = ['24-25'];
+    themed.chartSelections = { score: true } as any;
+
+    (themed as any).updateChartData([{ season: 2024, score: 0 } as any]);
+
+    const y: any = (themed.lineChartOptions.scales as any).y;
+    expect(y.ticks.stepSize).toBe(1);
+    expect(y.max).toBe(5);
+  });
+
+  it('resolveCssColorVar should fall back when document.body is missing', () => {
+    const themedFixture = TestBed.createComponent(PlayerCardGraphsComponent);
+    const themed = themedFixture.componentInstance;
+
+    (themed as any).document = { body: null };
+    expect((themed as any).resolveCssColorVar('--mat-sys-on-surface', '#1f1f1f')).toBe('#1f1f1f');
+  });
+
+  it('resolveCssColorVar should fall back when computed style is empty', () => {
+    const themedFixture = TestBed.createComponent(PlayerCardGraphsComponent);
+    const themed = themedFixture.componentInstance;
+
+    spyOn(window as any, 'getComputedStyle').and.returnValue({
+      color: '   ',
+      backgroundColor: '   ',
+    } as any);
+
+    expect((themed as any).resolveCssColorVar('--mat-sys-on-surface', '#1f1f1f')).toBe('#1f1f1f');
+  });
+
+  it('applyThemeToChartOptions should initialize missing plugins/scales', () => {
+    const themedFixture = TestBed.createComponent(PlayerCardGraphsComponent);
+    const themed = themedFixture.componentInstance;
+
+    themed.lineChartOptions = {
+      responsive: true,
+      maintainAspectRatio: false,
+    } as any;
+
+    spyOn<any>(themed, 'resolveCssColorVar').and.returnValue('rgb(1, 2, 3)');
+    (themed as any).applyThemeToChartOptions();
+
+    expect(themed.lineChartOptions.plugins).toBeTruthy();
+    expect(themed.lineChartOptions.scales).toBeTruthy();
+  });
 });

--- a/src/app/shared/player-card/player-card-graphs/player-card-graphs.component.ts
+++ b/src/app/shared/player-card/player-card-graphs/player-card-graphs.component.ts
@@ -24,29 +24,24 @@ export class PlayerCardGraphsComponent {
   // Track graph controls visibility on mobile
   graphControlsExpanded = false;
 
-  readonly chartStatKeys: string[] = this.isGoalie
-    ? ['score', 'scoreAdjustedByGames', 'games', 'wins', 'saves', 'shutouts']
-    : [
-        'score',
-        'scoreAdjustedByGames',
-        'games',
-        'goals',
-        'assists',
-        'points',
-        'shots',
-        'penalties',
-        'hits',
-        'blocks',
-      ];
+  get chartStatKeys(): string[] {
+    return this.isGoalie
+      ? ['score', 'scoreAdjustedByGames', 'games', 'wins', 'saves', 'shutouts']
+      : [
+          'score',
+          'scoreAdjustedByGames',
+          'games',
+          'goals',
+          'assists',
+          'points',
+          'shots',
+          'penalties',
+          'hits',
+          'blocks',
+        ];
+  }
 
-  chartSelections: Record<string, boolean> = this.chartStatKeys.reduce(
-    (acc, key) => ({
-      ...acc,
-      // Default: only score fields selected; others via toggle
-      [key]: key === 'score' || key === 'scoreAdjustedByGames',
-    }),
-    {} as Record<string, boolean>
-  );
+  chartSelections: Record<string, boolean> = {};
 
   chartLabels: string[] = [];
   chartYearsRange: number[] = [];
@@ -80,6 +75,17 @@ export class PlayerCardGraphsComponent {
 
   ngOnInit(): void {
     this.applyThemeToChartOptions();
+
+    if (Object.keys(this.chartSelections).length === 0) {
+      this.chartSelections = this.chartStatKeys.reduce(
+        (acc, key) => ({
+          ...acc,
+          // Default: only score fields selected; others via toggle
+          [key]: key === 'score' || key === 'scoreAdjustedByGames',
+        }),
+        {} as Record<string, boolean>
+      );
+    }
 
     if (this.hasSeasons) {
       this.setupChartData();

--- a/src/app/shared/player-card/player-card.component.spec.ts
+++ b/src/app/shared/player-card/player-card.component.spec.ts
@@ -652,6 +652,38 @@ describe('PlayerCardComponent', () => {
         expect(fallback.focus).toHaveBeenCalled();
       });
     });
+
+    it('should format season as short form on mobile', () => {
+      const short = (component as any).formatSeasonShort(2024);
+      expect(short).toBe('24-25');
+    });
+
+    it('should update graphsInputs with close button element when available', () => {
+      const btn = document.createElement('button');
+      component.closeButton = new ElementRef(btn);
+
+      (component as any).updateGraphsInputs();
+
+      expect((component as any).graphsInputs.closeButtonEl).toBe(btn);
+      expect(typeof (component as any).graphsInputs.requestFocusTabHeader).toBe('function');
+    });
+
+    it('should call checkScreenSize when window resize event fires', () => {
+      const checkSpy = spyOn<any>(component as any, 'checkScreenSize').and.callThrough();
+
+      window.dispatchEvent(new Event('resize'));
+
+      expect(checkSpy).toHaveBeenCalled();
+    });
+
+    it('graphsInputs.requestFocusTabHeader should invoke focusActiveTabHeader', () => {
+      const focusSpy = spyOn<any>(component as any, 'focusActiveTabHeader').and.callThrough();
+      (component as any).updateGraphsInputs();
+
+      (component as any).graphsInputs.requestFocusTabHeader();
+
+      expect(focusSpy).toHaveBeenCalled();
+    });
   });
 
   describe('without seasons data', () => {

--- a/src/app/shared/stats-table/stats-table.component.spec.ts
+++ b/src/app/shared/stats-table/stats-table.component.spec.ts
@@ -373,6 +373,18 @@ describe('StatsTableComponent', () => {
       expect(component.activeRowIndex).toBe(0);
       expect(focus0).toHaveBeenCalled();
     });
+
+    it('focusRow should no-op when the row element is missing', () => {
+      component.dataRows = {
+        toArray: () => [{ nativeElement: null }],
+        length: 1,
+      } as any;
+
+      component.activeRowIndex = 0;
+      (component as any).focusRow(0);
+
+      expect(component.activeRowIndex).toBe(0);
+    });
   });
 
   describe('accessibility labeling', () => {
@@ -533,6 +545,33 @@ describe('StatsTableComponent', () => {
       fixture.detectChanges();
 
       expect(component.sort.direction).toBe('desc');
+    });
+
+    it('should fall back to first non-position column when desired sort column is not displayed', () => {
+      component.data = mockPlayerData;
+      component.columns = playerColumns;
+      fixture.detectChanges();
+
+      component.displayedColumns = ['position', 'name', 'games'];
+      component.defaultSortColumn = 'nonexistent';
+
+      (component as any).applyDefaultSort();
+
+      expect(component.sort.active).toBe('name');
+      expect(component.sort.direction).toBe('desc');
+    });
+
+    it('should fall back to first column when only position column exists', () => {
+      component.data = mockPlayerData;
+      component.columns = playerColumns;
+      fixture.detectChanges();
+
+      component.displayedColumns = ['position'];
+      component.defaultSortColumn = 'nonexistent';
+
+      (component as any).applyDefaultSort();
+
+      expect(component.sort.active).toBe('position');
     });
   });
 

--- a/src/app/shared/top-controls/team-switcher/team-switcher.component.spec.ts
+++ b/src/app/shared/top-controls/team-switcher/team-switcher.component.spec.ts
@@ -124,4 +124,28 @@ describe('TeamSwitcherComponent', () => {
     expect(filterService.resetAll).toHaveBeenCalled();
     expect(router.navigate).toHaveBeenCalledWith(['/player-stats']);
   }));
+
+  it('should fall back to team.name when translation key is missing', () => {
+    spyOn(translate, 'instant').and.callFake((key: string) => key);
+
+    const label = (component as any).getTeamLabel({ id: '99', name: 'unknown-team' });
+    expect(label).toBe('unknown-team');
+  });
+
+  it('should no-op when teamId is falsy', fakeAsync(() => {
+    apiService.getTeams.and.returnValue(of(mockTeams));
+    component.ngOnInit();
+    tick();
+
+    const teamService = TestBed.inject(TeamService) as unknown as TeamServiceMock;
+    const setTeamSpy = spyOn(teamService, 'setTeamId').and.callThrough();
+
+    const event = { value: '' } as unknown as MatSelectChange;
+    component.changeTeam(event);
+    tick();
+
+    expect(setTeamSpy).not.toHaveBeenCalled();
+    expect(filterService.resetAll).not.toHaveBeenCalled();
+    expect(router.navigate).not.toHaveBeenCalled();
+  }));
 });


### PR DESCRIPTION
- Raise global Istanbul branches threshold to 96% and update docs\n- Consolidate PWA update service specs\n- Improve PlayerCardGraphs goalie handling and add targeted tests\n- Keep verify green (unit coverage + prod build)