### PR TITLE
Feature: Player Comparison Mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ node_modules/
 
 # Claude Code local configuration
 .claude/
+
+# Design plans (local only)
+docs/plans/

--- a/docs/project-requirements.md
+++ b/docs/project-requirements.md
@@ -435,6 +435,7 @@ Before marking work complete, verify:
 - [ ] Code follows project structure
 - [ ] Documentation updated
 - [ ] Commit message follows format
+- [ ] New user-facing features have E2E tests (Playwright)
 
 ---
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -2,6 +2,42 @@
 
 Planned improvements and future development ideas, roughly ordered by priority.
 
+## Application features
+
+### High priority
+
+#### Favorites / Watchlist
+
+Star/bookmark players, persisted in localStorage. Add a "Suosikit" filter toggle to quickly view only watched players. No API changes needed.
+
+### Medium priority
+
+#### Player Card Navigation (Prev/Next)
+
+Navigate to the next/previous player in the current table sort order from within the player card. No visible UI buttons — use keyboard arrows and swipe gestures (mobile/touchpad/mouse), similar to carousel grid interaction patterns.
+
+#### Highlight Career Bests in Player Card
+
+In the "Kausittain" (By Season) tab, bold the career-best value for each individual stat column. Only applies to players with more than one season of data. Show a tooltip on hover/keyboard focus: "Kauden paras {statName}" (personal best). Should be subtle — not draw too much visual attention.
+
+#### Search Focus Shortcut
+
+Press `/` to focus the search field (GitHub-style). Complements the existing `?` help shortcut.
+
+### Low priority
+
+#### URL-Persisted Filter State
+
+Encode stats table filter state (team, season, report type, per-game mode, etc.) in URL query parameters so users can share and bookmark specific views. Lower priority since player card deep linking already exists.
+
+#### Manual Dark/Light Mode Toggle
+
+Override the current auto-only system-preference-based theme. Persist choice in localStorage.
+
+#### Remember Sort Column
+
+Persist the user's last sort column and direction per table (players/goalies) in localStorage across sessions.
+
 ## E2E Testing
 
 ### Test data management
@@ -12,7 +48,3 @@ Planned improvements and future development ideas, roughly ordered by priority.
 
 - Visual regression testing (Playwright screenshot comparison)
 - Performance testing (Core Web Vitals)
-
-## Application features
-
-_(Add planned app features here as they come up.)_

--- a/e2e/page-objects/ComparisonBar.ts
+++ b/e2e/page-objects/ComparisonBar.ts
@@ -1,0 +1,59 @@
+import { Page, expect } from '@playwright/test';
+
+/**
+ * Page object for the comparison floating bar at the bottom of the screen.
+ * The bar appears when at least one player is selected for comparison.
+ */
+export class ComparisonBar {
+  constructor(private page: Page) {}
+
+  private get bar() {
+    return this.page.locator('[role="status"]');
+  }
+
+  /**
+   * Select a player for comparison by clicking their checkbox in the table row.
+   * Uses the aria-label attribute set on each mat-checkbox.
+   */
+  async selectPlayer(playerName: string): Promise<void> {
+    const row = this.page.locator('tr[mat-row]', { hasText: playerName });
+    await row.getByRole('checkbox').click();
+  }
+
+  /**
+   * Deselect a player by clicking their checkbox again.
+   */
+  async deselectPlayer(playerName: string): Promise<void> {
+    await this.selectPlayer(playerName);
+  }
+
+  /**
+   * Check if the floating bar is visible.
+   */
+  async isVisible(): Promise<boolean> {
+    return this.bar.isVisible();
+  }
+
+  /**
+   * Get the text content of the bar.
+   */
+  async getBarText(): Promise<string> {
+    return await this.bar.innerText();
+  }
+
+  /**
+   * Click the compare button ("Vertaile").
+   */
+  async clickCompare(): Promise<void> {
+    await this.page.getByRole('button', { name: 'Vertaile' }).click();
+    // Wait for dialog to open
+    await this.page.getByRole('dialog').waitFor({ state: 'visible' });
+  }
+
+  /**
+   * Click the clear button ("Tyhjennä").
+   */
+  async clickClear(): Promise<void> {
+    await this.page.getByRole('button', { name: 'Tyhjennä' }).click();
+  }
+}

--- a/e2e/page-objects/ComparisonDialog.ts
+++ b/e2e/page-objects/ComparisonDialog.ts
@@ -1,0 +1,103 @@
+import { Page, expect } from '@playwright/test';
+
+/**
+ * Page object for the comparison dialog.
+ *
+ * DOM structure (from comparison-dialog.component.html):
+ *   div.comparison-dialog
+ *     div.dialog-header > h2, button[aria-label="Sulje"]
+ *     div.dialog-ingress > p.ingress-names, p.ingress-team
+ *     mat-tab-group > mat-tab ("Tilastot"), mat-tab ("Graafit")
+ *
+ * Stats tab: div.stat-row-desktop (or .stat-row-mobile on mobile)
+ * Graphs tab: canvas (Chart.js radar chart)
+ */
+export class ComparisonDialog {
+  constructor(private page: Page) {}
+
+  private get dialog() {
+    return this.page.getByRole('dialog');
+  }
+
+  /**
+   * Check if the dialog is open.
+   */
+  async isOpen(): Promise<boolean> {
+    return this.dialog.isVisible();
+  }
+
+  /**
+   * Wait for the dialog to be visible.
+   */
+  async waitForOpen(): Promise<void> {
+    await this.dialog.waitFor({ state: 'visible' });
+  }
+
+  /**
+   * Get the dialog title (h2 text).
+   */
+  async getTitle(): Promise<string> {
+    return await this.dialog.locator('h2').innerText();
+  }
+
+  /**
+   * Get the ingress names text (p.ingress-names).
+   */
+  async getIngress(): Promise<string> {
+    return await this.dialog.locator('.ingress-names').innerText();
+  }
+
+  /**
+   * Get the team name text (p.ingress-team).
+   */
+  async getTeamName(): Promise<string> {
+    return await this.dialog.locator('.ingress-team').innerText();
+  }
+
+  /**
+   * Close the dialog via the X button.
+   * The button has aria-label="Sulje" which takes precedence as the accessible name.
+   */
+  async close(): Promise<void> {
+    const closeButton = this.dialog.getByRole('button', { name: 'Sulje' });
+    await closeButton.click();
+    await this.dialog.waitFor({ state: 'hidden' });
+  }
+
+  /**
+   * Close the dialog via Escape key.
+   */
+  async closeViaEscape(): Promise<void> {
+    await this.page.keyboard.press('Escape');
+    await this.dialog.waitFor({ state: 'hidden' });
+  }
+
+  /**
+   * Switch to a tab by name.
+   */
+  async switchToTab(tab: 'stats' | 'graphs'): Promise<void> {
+    const tabName = tab === 'stats' ? 'Tilastot' : 'Graafit';
+    await this.dialog.getByRole('tab', { name: tabName }).click();
+    // Allow tab content to render
+    await this.page.waitForTimeout(300);
+  }
+
+  /**
+   * Get the count of stat rows in the stats tab.
+   * Uses .stat-row-desktop or .stat-row-mobile depending on viewport.
+   */
+  async getStatRowCount(): Promise<number> {
+    const desktopRows = this.dialog.locator('.stat-row-desktop');
+    const mobileRows = this.dialog.locator('.stat-row-mobile');
+    const desktopCount = await desktopRows.count();
+    const mobileCount = await mobileRows.count();
+    return desktopCount + mobileCount;
+  }
+
+  /**
+   * Check if the radar chart canvas is visible.
+   */
+  async isRadarChartVisible(): Promise<boolean> {
+    return await this.dialog.locator('.comparison-radar canvas').isVisible();
+  }
+}

--- a/e2e/specs/filters.spec.ts
+++ b/e2e/specs/filters.spec.ts
@@ -20,12 +20,12 @@ test.describe('Filters', () => {
   });
 
   test.describe('Individual Filters', () => {
-    test('season selector changes data', async ({ page }) => {
+    test('season selector and start-from season filter data', async ({ page }) => {
       // Select "Kaikki kaudet" (all seasons)
       await selectSeason(page, 'Kaikki kaudet');
       const allSeasonsData = await getRowCount(page);
 
-      // Select a specific season
+      // Select a specific season — should have fewer rows
       const seasonSelector = page.getByRole('combobox', {
         name: 'Kausivalitsin',
       });
@@ -36,133 +36,94 @@ test.describe('Filters', () => {
       await waitForTableData(page);
 
       const singleSeasonData = await getRowCount(page);
-
-      // All seasons should have more or equal rows than single season
       expect(allSeasonsData).toBeGreaterThanOrEqual(singleSeasonData);
 
-      // Verify season selector shows selected season
       if (firstSeasonText) {
         await expect(seasonSelector).toContainText(firstSeasonText);
       }
-    });
 
-    test('start-from season filters data', async ({ page }) => {
-      // Get row count with all seasons
+      // Switch back to all seasons and test start-from filter
       await selectSeason(page, 'Kaikki kaudet');
       const allSeasonsCount = await getRowCount(page);
 
-      // Select start-from season (e.g., 2018-19)
       const startFromSelector = page.getByRole('combobox', {
         name: 'Alkaen kaudesta',
       });
       await startFromSelector.click();
-      const options = page.getByRole('option');
-      // Select a season that's not the oldest (e.g., 5th option)
-      await options.nth(5).click();
+      await page.getByRole('option').nth(5).click();
       await waitForTableData(page);
 
       const filteredCount = await getRowCount(page);
-
-      // Filtered should have fewer or equal rows
       expect(filteredCount).toBeLessThanOrEqual(allSeasonsCount);
     });
 
-    test('report type toggle changes data', async ({ page }) => {
-      // Get regular season data
+    test('report type toggle and stats per game change data', async ({ page }) => {
+      // Report type toggle
       await switchReportType(page, 'regular');
       const regularData = await getRowCount(page);
 
-      // Switch to playoffs
       await switchReportType(page, 'playoffs');
       const playoffsData = await getRowCount(page);
-
-      // Data should be different (playoffs typically has fewer rows)
       expect(playoffsData).not.toBe(regularData);
-    });
 
-    test('position filter reduces row count', async ({ page }) => {
-      // Get count with all positions
-      await selectPosition(page, 'all');
-      const allCount = await getRowCount(page);
+      // Switch back to regular for per-game test
+      await switchReportType(page, 'regular');
 
-      // Filter by forwards
-      await selectPosition(page, 'forwards');
-      const forwardsCount = await getRowCount(page);
-
-      // Forwards should be less than all
-      expect(forwardsCount).toBeLessThan(allCount);
-
-      // Filter by defense
-      await selectPosition(page, 'defense');
-      const defenseCount = await getRowCount(page);
-
-      // Defense should be less than all
-      expect(defenseCount).toBeLessThan(allCount);
-
-      // All should equal forwards + defense (approximately)
-      expect(allCount).toBeGreaterThanOrEqual(forwardsCount);
-      expect(allCount).toBeGreaterThanOrEqual(defenseCount);
-    });
-
-    test('stats per game toggle changes values', async ({ page }) => {
-      // Get goals value from first row (total stats)
+      // Stats per game toggle
       const goalsColumnClass = 'mat-column-goals';
       const totalGoals = await getColumnValues(page, goalsColumnClass);
       const firstTotalGoals = parseFloat(totalGoals[0] || '0');
 
-      // Enable stats per game
       await toggleStatsPerGame(page);
 
-      // Get goals value from first row (per game stats)
       const perGameGoals = await getColumnValues(page, goalsColumnClass);
       const firstPerGameGoals = parseFloat(perGameGoals[0] || '0');
 
-      // Per game should be less than total (for players with >1 game)
       expect(firstPerGameGoals).toBeLessThanOrEqual(firstTotalGoals);
-
-      // Per game should be a decimal value (not integer)
       expect(firstPerGameGoals).not.toBe(Math.floor(firstPerGameGoals));
     });
 
-    test('min games slider filters players', async ({ page }) => {
-      // Get count with min games = 0
+    test('position filter and min games slider reduce row count', async ({ page }) => {
+      // Position filter
+      await selectPosition(page, 'all');
+      const allCount = await getRowCount(page);
+
+      await selectPosition(page, 'forwards');
+      const forwardsCount = await getRowCount(page);
+      expect(forwardsCount).toBeLessThan(allCount);
+
+      await selectPosition(page, 'defense');
+      const defenseCount = await getRowCount(page);
+      expect(defenseCount).toBeLessThan(allCount);
+
+      // Reset to all positions for min games test
+      await selectPosition(page, 'all');
+
+      // Min games slider
       const initialCount = await getRowCount(page);
-
-      // Set min games to 20
       await setMinGames(page, 20);
-
-      // Get new count
       const filteredCount = await getRowCount(page);
-
-      // Filtered should have fewer rows
       expect(filteredCount).toBeLessThan(initialCount);
     });
   });
 
   test.describe('Filter Combinations', () => {
-    test('all seasons + stats per game + min games combination', async ({
-      page,
-    }) => {
-      // Apply combination of filters
+    test('all seasons + stats per game + min games combination', async ({ page }) => {
       await selectSeason(page, 'Kaikki kaudet');
       await toggleStatsPerGame(page);
       await setMinGames(page, 50);
 
-      // Verify table has data
       const count = await getRowCount(page);
       expect(count).toBeGreaterThan(0);
 
-      // Verify per game stats are shown
       const goalsColumnClass = 'mat-column-goals';
       const goals = await getColumnValues(page, goalsColumnClass);
       const firstGoals = parseFloat(goals[0] || '0');
-
-      // Should be decimal (per game)
       expect(firstGoals).not.toBe(Math.floor(firstGoals));
     });
 
-    test('single season + position filter combination', async ({ page }) => {
-      // Select a specific season
+    test('season + position + report type combinations', async ({ page }) => {
+      // Single season + position filter
       const seasonSelector = page.getByRole('combobox', {
         name: 'Kausivalitsin',
       });
@@ -170,86 +131,46 @@ test.describe('Filters', () => {
       await page.getByRole('option').nth(1).click();
       await waitForTableData(page);
 
-      // Filter by forwards
       await selectPosition(page, 'forwards');
-
-      // Verify table has data
-      const count = await getRowCount(page);
+      let count = await getRowCount(page);
       expect(count).toBeGreaterThan(0);
-    });
 
-    test('playoffs + min games + stats per game combination', async ({
-      page,
-    }) => {
-      // Apply combination
+      // Playoffs + min games + stats per game
+      await selectPosition(page, 'all');
       await switchReportType(page, 'playoffs');
       await setMinGames(page, 5);
       await toggleStatsPerGame(page);
 
-      // Verify table has data
-      const count = await getRowCount(page);
+      count = await getRowCount(page);
       expect(count).toBeGreaterThan(0);
 
-      // Verify per game stats
       const goalsColumnClass = 'mat-column-goals';
       const goals = await getColumnValues(page, goalsColumnClass);
       const firstGoals = parseFloat(goals[0] || '0');
-
-      // Should be decimal
       expect(firstGoals).not.toBe(Math.floor(firstGoals));
-    });
-
-    test('start from season + position filter combination', async ({
-      page,
-    }) => {
-      // Select all seasons first
-      await selectSeason(page, 'Kaikki kaudet');
-
-      // Set start-from season
-      const startFromSelector = page.getByRole('combobox', {
-        name: 'Alkaen kaudesta',
-      });
-      await startFromSelector.click();
-      await page.getByRole('option').nth(3).click();
-      await waitForTableData(page);
-
-      // Filter by defense
-      await selectPosition(page, 'defense');
-
-      // Verify table has data
-      const count = await getRowCount(page);
-      expect(count).toBeGreaterThan(0);
     });
   });
 
   test.describe('Filter Isolation', () => {
     test('player and goalie filters are independent', async ({ page }) => {
-      // On players tab, set filters
       await switchToPlayersTab(page);
       await toggleStatsPerGame(page);
       await setMinGames(page, 20);
 
-      // Verify player filters applied
       const playerStatsToggle = page.getByLabel('Tilastot per ottelu');
       await expect(playerStatsToggle).toBeChecked();
 
-      // Switch to goalies
       await switchToGoaliesTab(page);
       await waitForTableData(page);
 
-      // Verify goalie filters are independent (not affected by player filters)
       const goalieStatsToggle = page.getByLabel('Tilastot per ottelu');
       await expect(goalieStatsToggle).not.toBeChecked();
 
-      // Apply goalie filters
       await toggleStatsPerGame(page);
       await expect(goalieStatsToggle).toBeChecked();
 
-      // Switch back to players
       await switchToPlayersTab(page);
       await waitForTableData(page);
-
-      // Verify player filters still applied
       await expect(playerStatsToggle).toBeChecked();
     });
   });

--- a/e2e/specs/mobile.spec.ts
+++ b/e2e/specs/mobile.spec.ts
@@ -16,197 +16,104 @@ test.describe('Mobile', () => {
     await waitForTableData(page);
   });
 
-  test.describe('Basic Mobile Features', () => {
-    test('displays team name under title', async ({ page }) => {
-      // Verify team name is visible below title in mobile team summary
-      const teamName = page.locator('.mobile-team-name');
-      await expect(teamName).toBeVisible();
-      await expect(teamName).toHaveText(DEFAULT_TEAM);
-    });
+  test('displays team name and updates on team change', async ({ page }) => {
+    // Verify initial team name
+    const teamName = page.locator('.mobile-team-name');
+    await expect(teamName).toBeVisible();
+    await expect(teamName).toHaveText(DEFAULT_TEAM);
 
-    test('team name updates when team changes', async ({ page }) => {
-      // Open settings drawer
-      await settingsDrawer.open();
+    // Change team via drawer
+    await settingsDrawer.open();
+    const newTeam = 'Dallas Stars';
+    await settingsDrawer.selectTeam(newTeam);
+    await settingsDrawer.close();
 
-      // Change team
-      const newTeam = 'Dallas Stars';
-      await settingsDrawer.selectTeam(newTeam);
-
-      // Close drawer
-      await settingsDrawer.close();
-
-      // Wait for team change to complete
-      await waitForTeamChange(page, newTeam);
-
-      // Verify team name updated in mobile team summary
-      const teamName = page.locator('.mobile-team-name');
-      await expect(teamName).toHaveText(newTeam);
-    });
+    await waitForTeamChange(page, newTeam);
+    await expect(teamName).toHaveText(newTeam);
   });
 
-  test.describe('Settings Drawer - Basic Interactions', () => {
-    test('opens settings drawer via gear icon', async ({ page }) => {
-      // Verify drawer is closed initially
-      const isOpenBefore = await settingsDrawer.isOpen();
-      expect(isOpenBefore).toBe(false);
+  test('settings drawer opens via gear, closes via button and Escape', async ({ page }) => {
+    // Initially closed
+    expect(await settingsDrawer.isOpen()).toBe(false);
 
-      // Open drawer
-      await settingsDrawer.open();
+    // Open and verify controls visible
+    await settingsDrawer.open();
+    expect(await settingsDrawer.isOpen()).toBe(true);
+    await expect(page.getByRole('combobox', { name: 'Joukkue' })).toBeVisible();
 
-      // Verify drawer is now open
-      const isOpenAfter = await settingsDrawer.isOpen();
-      expect(isOpenAfter).toBe(true);
+    // Close via button
+    await settingsDrawer.close();
+    expect(await settingsDrawer.isOpen()).toBe(false);
 
-      // Verify settings controls are visible
-      const teamSelector = page.getByRole('combobox', { name: 'Joukkue' });
-      await expect(teamSelector).toBeVisible();
-    });
-
-    test('closes drawer via button', async () => {
-      // Open drawer first
-      await settingsDrawer.open();
-      const isOpenBefore = await settingsDrawer.isOpen();
-      expect(isOpenBefore).toBe(true);
-
-      // Close via button
-      await settingsDrawer.close();
-
-      // Verify drawer is closed
-      const isOpenAfter = await settingsDrawer.isOpen();
-      expect(isOpenAfter).toBe(false);
-    });
-
-    test('closes drawer via Escape key', async () => {
-      // Open drawer
-      await settingsDrawer.open();
-      const isOpenBefore = await settingsDrawer.isOpen();
-      expect(isOpenBefore).toBe(true);
-
-      // Close via Escape
-      await settingsDrawer.closeViaEscape();
-
-      // Verify drawer is closed (check class instead of visibility)
-      const isOpenAfter = await settingsDrawer.isOpen();
-      expect(isOpenAfter).toBe(false);
-    });
+    // Open again, close via Escape
+    await settingsDrawer.open();
+    expect(await settingsDrawer.isOpen()).toBe(true);
+    await settingsDrawer.closeViaEscape();
+    expect(await settingsDrawer.isOpen()).toBe(false);
   });
 
-  test.describe('Settings Drawer - Controls & State', () => {
-    test('changes filters via drawer controls', async ({ page }) => {
-      // Open drawer
-      await settingsDrawer.open();
+  test('drawer filter changes persist when reopening', async ({ page }) => {
+    // Set filters
+    await settingsDrawer.open();
+    await settingsDrawer.toggleStatsPerGame();
+    await settingsDrawer.setMinGames(30);
+    await settingsDrawer.close();
 
-      // Change filters
-      await settingsDrawer.toggleStatsPerGame();
-      await settingsDrawer.setMinGames(20);
+    await page.waitForTimeout(500);
 
-      // Close drawer
-      await settingsDrawer.close();
+    // Reopen and verify filters persisted
+    await settingsDrawer.open();
+    const statsToggle = page.getByLabel('Tilastot per ottelu');
+    await expect(statsToggle).toBeChecked();
 
-      // Verify filters were applied (check stats per game toggle is checked)
-      await page.waitForTimeout(500);
-      await settingsDrawer.open();
-
-      const statsToggle = page.getByLabel('Tilastot per ottelu');
-      await expect(statsToggle).toBeChecked();
-
-      await settingsDrawer.close();
-    });
-
-    test('preserves filter state when reopening drawer', async ({ page }) => {
-      // Open drawer and set filters
-      await settingsDrawer.open();
-      await settingsDrawer.toggleStatsPerGame();
-      await settingsDrawer.setMinGames(30);
-      await settingsDrawer.close();
-
-      // Wait for drawer to fully close
-      await page.waitForTimeout(500);
-
-      // Reopen drawer
-      await settingsDrawer.open();
-
-      // Verify filters are still set
-      const statsToggle = page.getByLabel('Tilastot per ottelu');
-      await expect(statsToggle).toBeChecked();
-
-      const minGamesSlider = page.locator('#min-games-slider input[type="range"]');
-      const sliderValue = await minGamesSlider.inputValue();
-      expect(parseInt(sliderValue)).toBeGreaterThanOrEqual(30);
-    });
-
-    test('shows last updated timestamp in drawer', async ({ page }) => {
-      // Open drawer
-      await settingsDrawer.open();
-
-      // Verify last updated text is visible in the drawer
-      const drawer = page.locator('mat-sidenav[position="start"]');
-      const lastUpdated = drawer.locator('.settings-drawer-last-modified');
-      await expect(lastUpdated).toBeVisible();
-      await expect(lastUpdated).toContainText(/Päivitetty/i);
-    });
+    const minGamesSlider = page.locator('#min-games-slider input[type="range"]');
+    const sliderValue = await minGamesSlider.inputValue();
+    expect(parseInt(sliderValue)).toBeGreaterThanOrEqual(30);
   });
 
-  test.describe('Mobile Player Card', () => {
-    test('player card shows graphs on mobile', async ({ page }) => {
-      // Ensure "Kaikki kaudet" is selected for line graphs
-      await settingsDrawer.open();
-      await settingsDrawer.selectSeason('Kaikki kaudet');
-      await settingsDrawer.close();
+  test('shows last updated timestamp in drawer', async ({ page }) => {
+    await settingsDrawer.open();
 
-      // Open player card
-      const playerCard = new PlayerCardDialog(page);
-      await playerCard.open('Jamie Benn');
+    const drawer = page.locator('mat-sidenav[position="start"]');
+    const lastUpdated = drawer.locator('.settings-drawer-last-modified');
+    await expect(lastUpdated).toBeVisible();
+    await expect(lastUpdated).toContainText(/Päivitetty/i);
+  });
 
-      // Switch to graphs tab
-      await playerCard.switchToTab('graphs');
+  test('player card graphs and accordion work on mobile', async ({ page }) => {
+    // Select all seasons for line graphs
+    await settingsDrawer.open();
+    await settingsDrawer.selectSeason('Kaikki kaudet');
+    await settingsDrawer.close();
 
-      // Verify graphs are visible
-      await playerCard.verifyTabContent('graphs');
+    // Open player card and go to graphs tab
+    const playerCard = new PlayerCardDialog(page);
+    await playerCard.open('Jamie Benn');
+    await playerCard.switchToTab('graphs');
+    await playerCard.verifyTabContent('graphs');
 
-      // Verify line graphs are visible
-      const hasLineGraphs = await playerCard.hasLineGraphs();
-      expect(hasLineGraphs).toBe(true);
-    });
+    const hasLineGraphs = await playerCard.hasLineGraphs();
+    expect(hasLineGraphs).toBe(true);
 
-    test('graph accordion toggles series on mobile', async ({ page }) => {
-      // Ensure "Kaikki kaudet" is selected for line graphs
-      await settingsDrawer.open();
-      await settingsDrawer.selectSeason('Kaikki kaudet');
-      await settingsDrawer.close();
+    // Test accordion toggle
+    const accordionButton = page.locator('button.graphs-controls-toggle');
+    await accordionButton.click();
+    await expect(accordionButton).toHaveAttribute('aria-expanded', 'true');
 
-      // Open player card
-      const playerCard = new PlayerCardDialog(page);
-      await playerCard.open('Jamie Benn');
+    const controlsList = page.locator('.graphs-controls.visible');
+    await expect(controlsList).toBeVisible();
 
-      // Switch to graphs tab
-      await playerCard.switchToTab('graphs');
+    // Toggle series off and back on
+    const checkbox = controlsList.getByRole('checkbox', { name: 'Pisteet' });
+    await expect(checkbox).toBeVisible();
+    await checkbox.click();
+    await page.waitForTimeout(300);
+    await checkbox.click();
+    await page.waitForTimeout(300);
 
-      // Open the graph controls accordion
-      const accordionButton = page.locator('button.graphs-controls-toggle');
-      await accordionButton.click();
-
-      // Verify accordion expanded
-      await expect(accordionButton).toHaveAttribute('aria-expanded', 'true');
-
-      // Verify checkboxes are visible in the accordion
-      const controlsList = page.locator('.graphs-controls.visible');
-      await expect(controlsList).toBeVisible();
-
-      // Toggle a series off (e.g., "Pisteet" / Points)
-      const checkbox = controlsList.getByRole('checkbox', { name: 'Pisteet' });
-      await expect(checkbox).toBeVisible();
-      await checkbox.click();
-      await page.waitForTimeout(300);
-
-      // Toggle it back on
-      await checkbox.click();
-      await page.waitForTimeout(300);
-
-      // Close accordion by clicking the overlay backdrop
-      const overlay = page.locator('.graphs-controls-overlay.visible');
-      await overlay.click();
-      await expect(accordionButton).toHaveAttribute('aria-expanded', 'false');
-    });
+    // Close accordion via overlay
+    const overlay = page.locator('.graphs-controls-overlay.visible');
+    await overlay.click();
+    await expect(accordionButton).toHaveAttribute('aria-expanded', 'false');
   });
 });

--- a/e2e/specs/player-card.spec.ts
+++ b/e2e/specs/player-card.spec.ts
@@ -10,39 +10,27 @@ test.describe('Player Card', () => {
     await page.goto('/');
     playerCard = new PlayerCardDialog(page);
     statsTable = new StatsTable(page);
-
-    // Wait for table data
     await statsTable.verifyDataLoaded();
   });
 
-  test('opens when clicking a player row', async ({ page }) => {
-    await playerCard.open('Jamie Benn');
-
-    // Verify dialog is visible
+  test('opens on row click, closes via X button and Escape key', async ({ page }) => {
     const dialog = page.getByRole('dialog');
+
+    // Open and close via X button
+    await playerCard.open('Jamie Benn');
     await expect(dialog).toBeVisible();
-  });
-
-  test('closes via X button', async ({ page }) => {
-    await playerCard.open('Jamie Benn');
     await playerCard.close();
-
-    // Verify dialog is hidden
-    const dialog = page.getByRole('dialog');
     await expect(dialog).not.toBeVisible();
-  });
 
-  test('closes via Escape key', async ({ page }) => {
+    // Open and close via Escape
     await playerCard.open('Jamie Benn');
+    await expect(dialog).toBeVisible();
     await playerCard.closeViaEscape();
-
-    // Verify dialog is hidden
-    const dialog = page.getByRole('dialog');
     await expect(dialog).not.toBeVisible();
   });
 
-  test('switches between tabs when all seasons selected', async ({ page }) => {
-    // Ensure "Kaikki kaudet" is selected
+  test('tabs: all seasons shows 3 tabs, single season shows 2 tabs without by-season', async ({ page }) => {
+    // All seasons: 3 tabs with full navigation
     const seasonSelector = page.getByRole('combobox', {
       name: 'Kausivalitsin',
     });
@@ -50,67 +38,35 @@ test.describe('Player Card', () => {
     await page.getByRole('option', { name: 'Kaikki kaudet' }).click();
 
     await playerCard.open('Jamie Benn');
-
-    // Verify all 3 tabs available
     const tabs = await playerCard.getAvailableTabs();
     expect(tabs.length).toBe(3);
 
-    // Switch to by-season tab
     await playerCard.switchToTab('by-season');
     await playerCard.verifyTabContent('by-season');
-
-    // Switch to graphs tab
     await playerCard.switchToTab('graphs');
     await playerCard.verifyTabContent('graphs');
-
-    // Switch back to stats
     await playerCard.switchToTab('stats');
     await playerCard.verifyTabContent('stats');
-  });
+    await playerCard.close();
 
-  test('shows only 2 tabs when single season selected', async ({ page }) => {
-    // Select a specific season
-    const seasonSelector = page.getByRole('combobox', {
-      name: 'Kausivalitsin',
-    });
+    // Single season: 2 tabs, no by-season, no line graphs
     await seasonSelector.click();
-    const options = page.getByRole('option');
-    await options.nth(1).click(); // Select first non-"all" season
+    await page.getByRole('option').nth(1).click();
 
     await playerCard.open('Jamie Benn');
+    const singleTabs = await playerCard.getAvailableTabs();
+    expect(singleTabs.length).toBe(2);
+    expect(singleTabs).not.toContain('Kausittain');
 
-    // Verify only 2 tabs available (stats and graphs, no by-season)
-    const tabs = await playerCard.getAvailableTabs();
-    expect(tabs.length).toBe(2);
-    expect(tabs).not.toContain('Kausittain');
-
-    // Verify graphs tab only has radar chart
     await playerCard.switchToTab('graphs');
     const hasLineGraphs = await playerCard.hasLineGraphs();
     expect(hasLineGraphs).toBe(false);
   });
 
-  test('toggles graph series on desktop', async ({ page }) => {
-    // Set desktop viewport
+  test('graph series toggle and chart type switching', async ({ page }) => {
     await page.setViewportSize({ width: 1280, height: 720 });
 
-    await playerCard.open('Jamie Benn');
-    await playerCard.switchToTab('graphs');
-
-    // Toggle a series off
-    await playerCard.toggleGraphSeries('Pisteet');
-    await page.waitForTimeout(500); // Wait for animation
-
-    // Toggle it back on
-    await playerCard.toggleGraphSeries('Pisteet');
-    await page.waitForTimeout(500);
-
-    // Verify graph still visible
-    await playerCard.verifyTabContent('graphs');
-  });
-
-  test('switches between line and radar charts', async ({ page }) => {
-    // Ensure "Kaikki kaudet" is selected for line graphs
+    // Ensure all seasons for line graphs
     const seasonSelector = page.getByRole('combobox', {
       name: 'Kausivalitsin',
     });
@@ -120,19 +76,22 @@ test.describe('Player Card', () => {
     await playerCard.open('Jamie Benn');
     await playerCard.switchToTab('graphs');
 
-    // Verify line graphs are visible
+    // Toggle series off and back on
+    await playerCard.toggleGraphSeries('Pisteet');
+    await page.waitForTimeout(500);
+    await playerCard.toggleGraphSeries('Pisteet');
+    await page.waitForTimeout(500);
+    await playerCard.verifyTabContent('graphs');
+
+    // Switch between chart types
     let hasLineGraphs = await playerCard.hasLineGraphs();
     expect(hasLineGraphs).toBe(true);
 
-    // Switch to radar chart
     await playerCard.switchChartType('radar');
-    await page.waitForTimeout(500); // Wait for chart to render
-
-    // Switch back to line chart
+    await page.waitForTimeout(500);
     await playerCard.switchChartType('line');
     await page.waitForTimeout(500);
 
-    // Verify line graphs are back
     hasLineGraphs = await playerCard.hasLineGraphs();
     expect(hasLineGraphs).toBe(true);
   });
@@ -141,23 +100,17 @@ test.describe('Player Card', () => {
     page,
     browserName,
   }) => {
-    // Clipboard permissions only supported on Chromium
     test.skip(
       browserName !== 'chromium',
       'Clipboard API permissions not supported'
     );
 
     await playerCard.open('Jamie Benn');
-
-    // Grant clipboard permissions (Chromium only)
     await page
       .context()
       .grantPermissions(['clipboard-read', 'clipboard-write']);
-
-    // Click copy link button
     await playerCard.copyPlayerLink();
 
-    // Verify clipboard contains the player URL
     const clipboardText = await page.evaluate(() =>
       navigator.clipboard.readText()
     );
@@ -165,7 +118,6 @@ test.describe('Player Card', () => {
   });
 
   test('compare toggle state persists across tabs', async ({ page }) => {
-    // Ensure "Kaikki kaudet" is selected so all 3 tabs are available
     const seasonSelector = page.getByRole('combobox', {
       name: 'Kausivalitsin',
     });
@@ -174,56 +126,35 @@ test.describe('Player Card', () => {
 
     await playerCard.open('Jamie Benn');
 
-    // Find the compare toggle (mat-slide-toggle inside .position-filter-switch)
     const compareToggle = page
       .getByRole('dialog')
       .locator('mat-slide-toggle button[role="switch"]');
 
-    // Toggle should be unchecked initially
     await expect(compareToggle).toHaveAttribute('aria-checked', 'false');
-
-    // Enable the compare toggle
     await compareToggle.dispatchEvent('click');
     await expect(compareToggle).toHaveAttribute('aria-checked', 'true');
 
-    // Switch to by-season tab and back
+    // Verify persistence across tab switches
     await playerCard.switchToTab('by-season');
     await playerCard.switchToTab('stats');
-
-    // Verify toggle state persisted
     await expect(compareToggle).toHaveAttribute('aria-checked', 'true');
 
-    // Switch to graphs tab and back
     await playerCard.switchToTab('graphs');
     await playerCard.switchToTab('stats');
-
-    // Verify toggle state still persisted
     await expect(compareToggle).toHaveAttribute('aria-checked', 'true');
   });
 
-  test('opens player card via direct URL', async ({ page }) => {
-    // Navigate directly to player card URL using slug-based routing
+  test('opens player card via direct URL and with tab query param', async ({ page }) => {
+    // Direct URL opens dialog with correct player
     await page.goto('/player/colorado/jamie-benn');
-
-    // Wait for dialog to open
     const dialog = page.getByRole('dialog');
     await expect(dialog).toBeVisible({ timeout: 10000 });
-
-    // Verify player name in dialog
     await expect(dialog.getByText('Jamie Benn')).toBeVisible();
-  });
+    await playerCard.close();
 
-  test('opens player card with specific tab via query param', async ({
-    page,
-  }) => {
-    // Navigate directly to player card with graphs tab
+    // Direct URL with tab query param opens correct tab
     await page.goto('/player/colorado/jamie-benn?tab=graphs');
-
-    // Wait for dialog to open
-    const dialog = page.getByRole('dialog');
     await expect(dialog).toBeVisible({ timeout: 10000 });
-
-    // Verify graphs tab is active
     await playerCard.verifyTabContent('graphs');
   });
 });

--- a/e2e/specs/player-comparison.spec.ts
+++ b/e2e/specs/player-comparison.spec.ts
@@ -17,162 +17,110 @@ test.describe('Player Comparison', () => {
   });
 
   test.describe('Selection and Floating Bar', () => {
-    test('selecting one player shows floating bar with prompt', async () => {
+    test('selection progression: one player shows prompt, two shows compare button and names', async ({ page }) => {
+      // Select one player — bar visible with prompt
       await comparisonBar.selectPlayer('Jamie Benn');
       expect(await comparisonBar.isVisible()).toBeTruthy();
-      const text = await comparisonBar.getBarText();
+      let text = await comparisonBar.getBarText();
       expect(text).toContain('valitse toinen vertailuun');
-    });
 
-    test('selecting two players shows compare button', async ({ page }) => {
-      await comparisonBar.selectPlayer('Jamie Benn');
+      // Select second player — compare button visible, both names shown
       await comparisonBar.selectPlayer('Vincent Trocheck');
       await expect(page.getByRole('button', { name: 'Vertaile' })).toBeVisible();
+      text = await comparisonBar.getBarText();
+      expect(text).toContain('Jamie Benn');
+      expect(text).toContain('Vincent Trocheck');
     });
 
-    test('clear button removes selection and hides bar', async () => {
-      await comparisonBar.selectPlayer('Jamie Benn');
-      expect(await comparisonBar.isVisible()).toBeTruthy();
-      await comparisonBar.clickClear();
-      expect(await comparisonBar.isVisible()).toBeFalsy();
-    });
-
-    test('deselecting a player hides bar when none remain', async () => {
-      await comparisonBar.selectPlayer('Jamie Benn');
-      expect(await comparisonBar.isVisible()).toBeTruthy();
-      await comparisonBar.deselectPlayer('Jamie Benn');
-      expect(await comparisonBar.isVisible()).toBeFalsy();
-    });
-
-    test('deselecting one of two players keeps bar visible with prompt', async () => {
+    test('deselecting players updates bar state correctly', async () => {
+      // Select two, deselect one — bar stays with prompt
       await comparisonBar.selectPlayer('Jamie Benn');
       await comparisonBar.selectPlayer('Vincent Trocheck');
       await comparisonBar.deselectPlayer('Vincent Trocheck');
       expect(await comparisonBar.isVisible()).toBeTruthy();
       const text = await comparisonBar.getBarText();
       expect(text).toContain('valitse toinen vertailuun');
+
+      // Deselect last — bar hides
+      await comparisonBar.deselectPlayer('Jamie Benn');
+      expect(await comparisonBar.isVisible()).toBeFalsy();
     });
 
-    test('remaining checkboxes are disabled when two are selected', async ({ page }) => {
+    test('clear button hides bar and checkboxes disabled at max selection', async ({ page }) => {
+      // Select two players
       await comparisonBar.selectPlayer('Jamie Benn');
       await comparisonBar.selectPlayer('Vincent Trocheck');
-      // A third player's checkbox should be disabled
+
+      // Third player's checkbox should be disabled
       const thirdRow = page.locator('tr[mat-row]', { hasText: 'Reilly Smith' });
       await expect(thirdRow.getByRole('checkbox')).toBeDisabled();
-    });
 
-    test('bar text shows both names when two are selected', async () => {
-      await comparisonBar.selectPlayer('Jamie Benn');
-      await comparisonBar.selectPlayer('Vincent Trocheck');
-      const text = await comparisonBar.getBarText();
-      expect(text).toContain('Jamie Benn');
-      expect(text).toContain('Vincent Trocheck');
+      // Clear removes selection and hides bar
+      await comparisonBar.clickClear();
+      expect(await comparisonBar.isVisible()).toBeFalsy();
     });
   });
 
-  test.describe('Dialog - Opening and Closing', () => {
-    test('compare button opens comparison dialog', async () => {
+  test.describe('Dialog', () => {
+    test('opens via compare button, closes via X and Escape', async () => {
       await comparisonBar.selectPlayer('Jamie Benn');
       await comparisonBar.selectPlayer('Vincent Trocheck');
-      await comparisonBar.clickCompare();
-      expect(await comparisonDialog.isOpen()).toBeTruthy();
-    });
 
-    test('dialog closes via X button', async () => {
-      await comparisonBar.selectPlayer('Jamie Benn');
-      await comparisonBar.selectPlayer('Vincent Trocheck');
+      // Open and close via X
       await comparisonBar.clickCompare();
       expect(await comparisonDialog.isOpen()).toBeTruthy();
       await comparisonDialog.close();
       expect(await comparisonDialog.isOpen()).toBeFalsy();
-    });
 
-    test('dialog closes via Escape key', async () => {
-      await comparisonBar.selectPlayer('Jamie Benn');
-      await comparisonBar.selectPlayer('Vincent Trocheck');
+      // Open and close via Escape
       await comparisonBar.clickCompare();
       expect(await comparisonDialog.isOpen()).toBeTruthy();
       await comparisonDialog.closeViaEscape();
       expect(await comparisonDialog.isOpen()).toBeFalsy();
     });
-  });
 
-  test.describe('Dialog - Content', () => {
-    test('shows correct title for same-position forwards', async () => {
+    test('same-position forwards: correct title, ingress names, and team', async () => {
       await comparisonBar.selectPlayer('Jamie Benn');
       await comparisonBar.selectPlayer('Vincent Trocheck');
       await comparisonBar.clickCompare();
+
       const title = await comparisonDialog.getTitle();
       expect(title).toBe('Hyökkääjävertailu');
-    });
 
-    test('shows correct title for mixed positions (forward vs defense)', async () => {
-      await comparisonBar.selectPlayer('Jamie Benn'); // F
-      await comparisonBar.selectPlayer('Oliver Ekman-Larsson'); // D
-      await comparisonBar.clickCompare();
-      const title = await comparisonDialog.getTitle();
-      expect(title).toBe('Pelaajavertailu');
-    });
-
-    test('shows player names in ingress', async () => {
-      await comparisonBar.selectPlayer('Jamie Benn');
-      await comparisonBar.selectPlayer('Vincent Trocheck');
-      await comparisonBar.clickCompare();
       const ingress = await comparisonDialog.getIngress();
       expect(ingress).toContain('Benn');
       expect(ingress).toContain('Trocheck');
-    });
 
-    test('shows team name', async () => {
-      await comparisonBar.selectPlayer('Jamie Benn');
-      await comparisonBar.selectPlayer('Vincent Trocheck');
-      await comparisonBar.clickCompare();
       const team = await comparisonDialog.getTeamName();
       expect(team).toContain('Colorado Avalanche');
     });
 
-    test('ingress shows position abbreviations for mixed positions', async () => {
-      await comparisonBar.selectPlayer('Jamie Benn'); // F
-      await comparisonBar.selectPlayer('Oliver Ekman-Larsson'); // D
+    test('mixed positions: correct title and position abbreviations in ingress', async () => {
+      await comparisonBar.selectPlayer('Jamie Benn');
+      await comparisonBar.selectPlayer('Oliver Ekman-Larsson');
       await comparisonBar.clickCompare();
+
+      const title = await comparisonDialog.getTitle();
+      expect(title).toBe('Pelaajavertailu');
+
       const ingress = await comparisonDialog.getIngress();
-      // Finnish: H = hyökkääjä (forward), P = puolustaja (defense)
       expect(ingress).toMatch(/[HP]/);
     });
-  });
 
-  test.describe('Dialog - Stats Tab', () => {
-    test('stats tab shows stat rows with values', async () => {
+    test('stats tab shows correct row count with numeric values', async ({ page }) => {
       await comparisonBar.selectPlayer('Jamie Benn');
       await comparisonBar.selectPlayer('Vincent Trocheck');
       await comparisonBar.clickCompare();
+
       const rowCount = await comparisonDialog.getStatRowCount();
-      // PLAYER_STAT_COLUMNS has 13 columns for players
       expect(rowCount).toBe(13);
-    });
 
-    test('stat rows contain numeric values', async ({ page }) => {
-      await comparisonBar.selectPlayer('Jamie Benn');
-      await comparisonBar.selectPlayer('Vincent Trocheck');
-      await comparisonBar.clickCompare();
-      // Check that at least one value-a span contains a number
       const dialog = page.getByRole('dialog');
-      const values = dialog.locator('.value-a');
-      const firstValue = await values.first().innerText();
+      const firstValue = await dialog.locator('.value-a').first().innerText();
       expect(firstValue).toBeTruthy();
     });
-  });
 
-  test.describe('Dialog - Graphs Tab', () => {
-    test('graphs tab shows radar chart', async () => {
-      await comparisonBar.selectPlayer('Jamie Benn');
-      await comparisonBar.selectPlayer('Vincent Trocheck');
-      await comparisonBar.clickCompare();
-      await comparisonDialog.switchToTab('graphs');
-      expect(await comparisonDialog.isRadarChartVisible()).toBeTruthy();
-    });
-
-    test('can switch between stats and graphs tabs', async () => {
+    test('graphs tab shows radar chart and tab switching works', async () => {
       await comparisonBar.selectPlayer('Jamie Benn');
       await comparisonBar.selectPlayer('Vincent Trocheck');
       await comparisonBar.clickCompare();
@@ -181,11 +129,11 @@ test.describe('Player Comparison', () => {
       const statRows = await comparisonDialog.getStatRowCount();
       expect(statRows).toBeGreaterThan(0);
 
-      // Switch to graphs tab
+      // Switch to graphs tab — radar chart visible
       await comparisonDialog.switchToTab('graphs');
       expect(await comparisonDialog.isRadarChartVisible()).toBeTruthy();
 
-      // Switch back to stats tab
+      // Switch back to stats tab — rows still there
       await comparisonDialog.switchToTab('stats');
       const rowsAfter = await comparisonDialog.getStatRowCount();
       expect(rowsAfter).toBeGreaterThan(0);

--- a/e2e/specs/player-comparison.spec.ts
+++ b/e2e/specs/player-comparison.spec.ts
@@ -1,0 +1,194 @@
+import { test, expect } from '../fixtures/test-fixture';
+import { ComparisonBar } from '../page-objects/ComparisonBar';
+import { ComparisonDialog } from '../page-objects/ComparisonDialog';
+import { StatsTable } from '../page-objects/StatsTable';
+
+test.describe('Player Comparison', () => {
+  let comparisonBar: ComparisonBar;
+  let comparisonDialog: ComparisonDialog;
+  let statsTable: StatsTable;
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    comparisonBar = new ComparisonBar(page);
+    comparisonDialog = new ComparisonDialog(page);
+    statsTable = new StatsTable(page);
+    await statsTable.verifyDataLoaded();
+  });
+
+  test.describe('Selection and Floating Bar', () => {
+    test('selecting one player shows floating bar with prompt', async () => {
+      await comparisonBar.selectPlayer('Jamie Benn');
+      expect(await comparisonBar.isVisible()).toBeTruthy();
+      const text = await comparisonBar.getBarText();
+      expect(text).toContain('valitse toinen vertailuun');
+    });
+
+    test('selecting two players shows compare button', async ({ page }) => {
+      await comparisonBar.selectPlayer('Jamie Benn');
+      await comparisonBar.selectPlayer('Vincent Trocheck');
+      await expect(page.getByRole('button', { name: 'Vertaile' })).toBeVisible();
+    });
+
+    test('clear button removes selection and hides bar', async () => {
+      await comparisonBar.selectPlayer('Jamie Benn');
+      expect(await comparisonBar.isVisible()).toBeTruthy();
+      await comparisonBar.clickClear();
+      expect(await comparisonBar.isVisible()).toBeFalsy();
+    });
+
+    test('deselecting a player hides bar when none remain', async () => {
+      await comparisonBar.selectPlayer('Jamie Benn');
+      expect(await comparisonBar.isVisible()).toBeTruthy();
+      await comparisonBar.deselectPlayer('Jamie Benn');
+      expect(await comparisonBar.isVisible()).toBeFalsy();
+    });
+
+    test('deselecting one of two players keeps bar visible with prompt', async () => {
+      await comparisonBar.selectPlayer('Jamie Benn');
+      await comparisonBar.selectPlayer('Vincent Trocheck');
+      await comparisonBar.deselectPlayer('Vincent Trocheck');
+      expect(await comparisonBar.isVisible()).toBeTruthy();
+      const text = await comparisonBar.getBarText();
+      expect(text).toContain('valitse toinen vertailuun');
+    });
+
+    test('remaining checkboxes are disabled when two are selected', async ({ page }) => {
+      await comparisonBar.selectPlayer('Jamie Benn');
+      await comparisonBar.selectPlayer('Vincent Trocheck');
+      // A third player's checkbox should be disabled
+      const thirdRow = page.locator('tr[mat-row]', { hasText: 'Reilly Smith' });
+      await expect(thirdRow.getByRole('checkbox')).toBeDisabled();
+    });
+
+    test('bar text shows both names when two are selected', async () => {
+      await comparisonBar.selectPlayer('Jamie Benn');
+      await comparisonBar.selectPlayer('Vincent Trocheck');
+      const text = await comparisonBar.getBarText();
+      expect(text).toContain('Jamie Benn');
+      expect(text).toContain('Vincent Trocheck');
+    });
+  });
+
+  test.describe('Dialog - Opening and Closing', () => {
+    test('compare button opens comparison dialog', async () => {
+      await comparisonBar.selectPlayer('Jamie Benn');
+      await comparisonBar.selectPlayer('Vincent Trocheck');
+      await comparisonBar.clickCompare();
+      expect(await comparisonDialog.isOpen()).toBeTruthy();
+    });
+
+    test('dialog closes via X button', async () => {
+      await comparisonBar.selectPlayer('Jamie Benn');
+      await comparisonBar.selectPlayer('Vincent Trocheck');
+      await comparisonBar.clickCompare();
+      expect(await comparisonDialog.isOpen()).toBeTruthy();
+      await comparisonDialog.close();
+      expect(await comparisonDialog.isOpen()).toBeFalsy();
+    });
+
+    test('dialog closes via Escape key', async () => {
+      await comparisonBar.selectPlayer('Jamie Benn');
+      await comparisonBar.selectPlayer('Vincent Trocheck');
+      await comparisonBar.clickCompare();
+      expect(await comparisonDialog.isOpen()).toBeTruthy();
+      await comparisonDialog.closeViaEscape();
+      expect(await comparisonDialog.isOpen()).toBeFalsy();
+    });
+  });
+
+  test.describe('Dialog - Content', () => {
+    test('shows correct title for same-position forwards', async () => {
+      await comparisonBar.selectPlayer('Jamie Benn');
+      await comparisonBar.selectPlayer('Vincent Trocheck');
+      await comparisonBar.clickCompare();
+      const title = await comparisonDialog.getTitle();
+      expect(title).toBe('Hyökkääjävertailu');
+    });
+
+    test('shows correct title for mixed positions (forward vs defense)', async () => {
+      await comparisonBar.selectPlayer('Jamie Benn'); // F
+      await comparisonBar.selectPlayer('Oliver Ekman-Larsson'); // D
+      await comparisonBar.clickCompare();
+      const title = await comparisonDialog.getTitle();
+      expect(title).toBe('Pelaajavertailu');
+    });
+
+    test('shows player names in ingress', async () => {
+      await comparisonBar.selectPlayer('Jamie Benn');
+      await comparisonBar.selectPlayer('Vincent Trocheck');
+      await comparisonBar.clickCompare();
+      const ingress = await comparisonDialog.getIngress();
+      expect(ingress).toContain('Benn');
+      expect(ingress).toContain('Trocheck');
+    });
+
+    test('shows team name', async () => {
+      await comparisonBar.selectPlayer('Jamie Benn');
+      await comparisonBar.selectPlayer('Vincent Trocheck');
+      await comparisonBar.clickCompare();
+      const team = await comparisonDialog.getTeamName();
+      expect(team).toContain('Colorado Avalanche');
+    });
+
+    test('ingress shows position abbreviations for mixed positions', async () => {
+      await comparisonBar.selectPlayer('Jamie Benn'); // F
+      await comparisonBar.selectPlayer('Oliver Ekman-Larsson'); // D
+      await comparisonBar.clickCompare();
+      const ingress = await comparisonDialog.getIngress();
+      // Finnish: H = hyökkääjä (forward), P = puolustaja (defense)
+      expect(ingress).toMatch(/[HP]/);
+    });
+  });
+
+  test.describe('Dialog - Stats Tab', () => {
+    test('stats tab shows stat rows with values', async () => {
+      await comparisonBar.selectPlayer('Jamie Benn');
+      await comparisonBar.selectPlayer('Vincent Trocheck');
+      await comparisonBar.clickCompare();
+      const rowCount = await comparisonDialog.getStatRowCount();
+      // PLAYER_STAT_COLUMNS has 13 columns for players
+      expect(rowCount).toBe(13);
+    });
+
+    test('stat rows contain numeric values', async ({ page }) => {
+      await comparisonBar.selectPlayer('Jamie Benn');
+      await comparisonBar.selectPlayer('Vincent Trocheck');
+      await comparisonBar.clickCompare();
+      // Check that at least one value-a span contains a number
+      const dialog = page.getByRole('dialog');
+      const values = dialog.locator('.value-a');
+      const firstValue = await values.first().innerText();
+      expect(firstValue).toBeTruthy();
+    });
+  });
+
+  test.describe('Dialog - Graphs Tab', () => {
+    test('graphs tab shows radar chart', async () => {
+      await comparisonBar.selectPlayer('Jamie Benn');
+      await comparisonBar.selectPlayer('Vincent Trocheck');
+      await comparisonBar.clickCompare();
+      await comparisonDialog.switchToTab('graphs');
+      expect(await comparisonDialog.isRadarChartVisible()).toBeTruthy();
+    });
+
+    test('can switch between stats and graphs tabs', async () => {
+      await comparisonBar.selectPlayer('Jamie Benn');
+      await comparisonBar.selectPlayer('Vincent Trocheck');
+      await comparisonBar.clickCompare();
+
+      // Start on stats tab
+      const statRows = await comparisonDialog.getStatRowCount();
+      expect(statRows).toBeGreaterThan(0);
+
+      // Switch to graphs tab
+      await comparisonDialog.switchToTab('graphs');
+      expect(await comparisonDialog.isRadarChartVisible()).toBeTruthy();
+
+      // Switch back to stats tab
+      await comparisonDialog.switchToTab('stats');
+      const rowsAfter = await comparisonDialog.getStatRowCount();
+      expect(rowsAfter).toBeGreaterThan(0);
+    });
+  });
+});

--- a/e2e/specs/smoke.spec.ts
+++ b/e2e/specs/smoke.spec.ts
@@ -6,22 +6,17 @@ test.describe('Smoke Tests', () => {
     await page.goto('/');
   });
 
-  test('page loads with correct title and heading', async ({ page }) => {
-    // Check page title
+  test('page loads with correct title, heading, nav tabs, and controls', async ({ page }) => {
+    // Title and heading
     await expect(page).toHaveTitle(/FFHL tilastopalvelu/);
-
-    // Check heading
     await expect(
       page.getByRole('heading', { name: /FFHL tilastopalvelu/ })
     ).toBeVisible();
-
-    // Check default team is selected
     await expect(
       page.getByRole('combobox', { name: 'Joukkue' })
     ).toContainText(DEFAULT_TEAM);
-  });
 
-  test('navigation tabs are visible', async ({ page }) => {
+    // Navigation tabs
     await expect(page.getByRole('tablist')).toBeVisible();
     await expect(
       page.getByRole('tab', { name: TAB_LABELS.PLAYERS })
@@ -29,31 +24,20 @@ test.describe('Smoke Tests', () => {
     await expect(
       page.getByRole('tab', { name: TAB_LABELS.GOALIES })
     ).toBeVisible();
-  });
 
-  test('top controls are visible', async ({ page }) => {
-    // Team selector
-    await expect(page.getByRole('combobox', { name: 'Joukkue' })).toBeVisible();
-
-    // Season selector
+    // Top controls
     await expect(
       page.getByRole('combobox', { name: 'Kausivalitsin' })
     ).toBeVisible();
-
-    // Report type selector
     await expect(
       page.getByRole('combobox', { name: 'Stats report type' })
     ).toBeVisible();
   });
 
   test('table renders with data', async ({ page }) => {
-    // Search input visible
     await expect(page.getByLabel('Pelaajahaku')).toBeVisible();
-
-    // Table visible
     await expect(page.getByRole('table')).toBeVisible();
 
-    // At least one data row
     const rows = page.locator('tr[mat-row]');
     await rows.first().waitFor({ state: 'visible', timeout: 10000 });
     const count = await rows.count();
@@ -64,11 +48,9 @@ test.describe('Smoke Tests', () => {
     const playerTab = page.getByRole('tab', { name: TAB_LABELS.PLAYERS });
     const goalieTab = page.getByRole('tab', { name: TAB_LABELS.GOALIES });
 
-    // Switch to goalies
     await goalieTab.click();
     await expect(page).toHaveURL(/.*\/goalie-stats$/);
 
-    // Switch back to players
     await playerTab.click();
     await expect(page).toHaveURL(/.*\/player-stats$/);
   });

--- a/e2e/specs/team-switching.spec.ts
+++ b/e2e/specs/team-switching.spec.ts
@@ -10,59 +10,32 @@ test.describe('Team Switching', () => {
   });
 
   test('changes team and updates data', async ({ page }) => {
-    // Verify initial team selected
     const teamSelector = page.getByRole('combobox', { name: 'Joukkue' });
     await expect(teamSelector).toContainText(DEFAULT_TEAM);
 
-    // Get initial table data
     const initialData = await getFirstRowText(page);
 
-    // Switch to different team
     const newTeam = 'Tampa Bay Lightning';
     await selectTeam(page, newTeam);
 
-    // Verify team selector updated
     await expect(teamSelector).toContainText(newTeam);
-
-    // Verify data changed
     const newData = await getFirstRowText(page);
     expect(newData).not.toBe(initialData);
   });
 
-  test('resets filters when team changes', async ({ page }) => {
+  test('resets filters on team change and does not restore when switching back', async ({ page }) => {
     // Enable stats per game toggle
     await toggleStatsPerGame(page);
-
-    // Verify toggle is checked
     const statsPerGameToggle = page.getByLabel('Tilastot per ottelu');
     await expect(statsPerGameToggle).toBeChecked();
 
-    // Switch team
+    // Switch team — toggle should reset
     const newTeam = 'Tampa Bay Lightning';
     await selectTeam(page, newTeam);
-
-    // Verify toggle is unchecked (reset)
     await expect(statsPerGameToggle).not.toBeChecked();
-  });
 
-  test('does not restore filters when switching back to original team', async ({
-    page,
-  }) => {
-    // Enable stats per game toggle
-    await toggleStatsPerGame(page);
-
-    // Verify toggle is checked
-    const statsPerGameToggle = page.getByLabel('Tilastot per ottelu');
-    await expect(statsPerGameToggle).toBeChecked();
-
-    // Switch to different team
-    const newTeam = 'Tampa Bay Lightning';
-    await selectTeam(page, newTeam);
-
-    // Switch back to original team
+    // Switch back to original team — toggle should still be unchecked (not restored)
     await selectTeam(page, DEFAULT_TEAM);
-
-    // Verify toggle is still unchecked (not restored)
     await expect(statsPerGameToggle).not.toBeChecked();
   });
 });

--- a/public/i18n/fi.json
+++ b/public/i18n/fi.json
@@ -203,6 +203,17 @@
     "switchToLine": "Vaihda kausikohtaisiin käyriin",
     "radarInfo": "Joukkueen sisäinen vertailuarvo 0-100 välillä"
   },
+  "comparison": {
+    "selectedOne": "{{name}} valittu — valitse toinen vertailuun",
+    "compare": "Vertaile",
+    "clear": "Tyhjennä",
+    "playerTitle": "Pelaajavertailu",
+    "forwardTitle": "Hyökkääjävertailu",
+    "defenseTitle": "Puolustajavertailu",
+    "goalieTitle": "Maalivahtivertailu",
+    "statsTab": "Tilastot",
+    "graphsTab": "Graafit"
+  },
   "controlPanel": {
     "filters": "Asetukset",
     "graphControls": "Näytettävät tilastot"

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -121,4 +121,5 @@
     }
   </div>
 </main>
+<app-comparison-bar />
 <app-footer />

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -21,6 +21,7 @@ import { FooterComponent } from "@base/footer/footer.component";
 import { NavigationComponent } from "./base/navigation/navigation.component";
 import { TopControlsComponent } from "@shared/top-controls/top-controls.component";
 import { SettingsPanelComponent } from "@shared/settings-panel/settings-panel.component";
+import { ComparisonBarComponent } from "@shared/comparison-bar/comparison-bar.component";
 import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 import {
   BehaviorSubject,
@@ -61,6 +62,7 @@ import { PwaUpdateService } from "@services/pwa-update.service";
     NavigationComponent,
     TopControlsComponent,
     SettingsPanelComponent,
+    ComparisonBarComponent,
   ],
   templateUrl: "./app.component.html",
   styleUrl: "./app.component.scss",

--- a/src/app/services/comparison.service.ts
+++ b/src/app/services/comparison.service.ts
@@ -1,0 +1,50 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+import { map } from 'rxjs/operators';
+import { Player, Goalie } from './api.service';
+
+export type OrderedComparison = {
+  playerA: Player | Goalie;
+  playerB: Player | Goalie;
+};
+
+@Injectable({ providedIn: 'root' })
+export class ComparisonService {
+  private selectedPlayers = new BehaviorSubject<(Player | Goalie)[]>([]);
+
+  readonly selection$ = this.selectedPlayers.asObservable();
+
+  readonly canSelectMore$ = this.selection$.pipe(
+    map((selection) => selection.length < 2),
+  );
+
+  readonly orderedSelection$ = this.selection$.pipe(
+    map((selection): OrderedComparison | null => {
+      if (selection.length < 2) {
+        return null;
+      }
+      const [a, b] = selection;
+      return a.score >= b.score
+        ? { playerA: a, playerB: b }
+        : { playerA: b, playerB: a };
+    }),
+  );
+
+  toggle(player: Player | Goalie): void {
+    const current = this.selectedPlayers.value;
+    const index = current.findIndex((p) => p.name === player.name);
+    if (index >= 0) {
+      this.selectedPlayers.next(current.filter((_, i) => i !== index));
+    } else if (current.length < 2) {
+      this.selectedPlayers.next([...current, player]);
+    }
+  }
+
+  isSelected(player: Player | Goalie): boolean {
+    return this.selectedPlayers.value.some((p) => p.name === player.name);
+  }
+
+  clear(): void {
+    this.selectedPlayers.next([]);
+  }
+}

--- a/src/app/services/comparison.service.ts
+++ b/src/app/services/comparison.service.ts
@@ -1,7 +1,11 @@
-import { Injectable } from '@angular/core';
+import { DestroyRef, inject, Injectable } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { BehaviorSubject } from 'rxjs';
-import { map } from 'rxjs/operators';
+import { distinctUntilChanged, map, skip } from 'rxjs/operators';
 import { Player, Goalie } from './api.service';
+import { TeamService } from './team.service';
+import { FilterService } from './filter.service';
+import { SettingsService } from './settings.service';
 
 export type OrderedComparison = {
   playerA: Player | Goalie;
@@ -10,6 +14,11 @@ export type OrderedComparison = {
 
 @Injectable({ providedIn: 'root' })
 export class ComparisonService {
+  private readonly destroyRef = inject(DestroyRef);
+  private readonly teamService = inject(TeamService);
+  private readonly filterService = inject(FilterService);
+  private readonly settingsService = inject(SettingsService);
+
   private selectedPlayers = new BehaviorSubject<(Player | Goalie)[]>([]);
 
   readonly selection$ = this.selectedPlayers.asObservable();
@@ -29,6 +38,38 @@ export class ComparisonService {
         : { playerA: b, playerB: a };
     }),
   );
+
+  constructor() {
+    // Clear on team change
+    this.teamService.selectedTeamId$
+      .pipe(skip(1), takeUntilDestroyed(this.destroyRef))
+      .subscribe(() => this.clear());
+
+    // Clear on report type or season change (player filters)
+    this.filterService.playerFilters$
+      .pipe(
+        map((f) => `${f.reportType}-${f.season ?? ''}`),
+        distinctUntilChanged(),
+        skip(1),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe(() => this.clear());
+
+    // Clear on report type or season change (goalie filters)
+    this.filterService.goalieFilters$
+      .pipe(
+        map((f) => `${f.reportType}-${f.season ?? ''}`),
+        distinctUntilChanged(),
+        skip(1),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe(() => this.clear());
+
+    // Clear on start-from-season change
+    this.settingsService.startFromSeason$
+      .pipe(skip(1), takeUntilDestroyed(this.destroyRef))
+      .subscribe(() => this.clear());
+  }
 
   toggle(player: Player | Goalie): void {
     const current = this.selectedPlayers.value;

--- a/src/app/services/tests/comparison.service.spec.ts
+++ b/src/app/services/tests/comparison.service.spec.ts
@@ -1,0 +1,175 @@
+import { TestBed } from '@angular/core/testing';
+import { ComparisonService } from '../comparison.service';
+import { Player } from '../api.service';
+import { first } from 'rxjs';
+
+const mockPlayerA: Player = {
+  name: 'Mikko Rantanen',
+  position: 'F',
+  score: 94.31,
+  scoreAdjustedByGames: 93.1,
+  games: 427,
+  goals: 193,
+  assists: 254,
+  points: 447,
+  plusMinus: 0,
+  penalties: 256,
+  shots: 1182,
+  ppp: 165,
+  shp: 0,
+  hits: 276,
+  blocks: 41,
+};
+
+const mockPlayerB: Player = {
+  name: 'Aaron Ekblad',
+  position: 'D',
+  score: 100,
+  scoreAdjustedByGames: 67.22,
+  games: 540,
+  goals: 100,
+  assists: 188,
+  points: 288,
+  plusMinus: 40,
+  penalties: 355,
+  shots: 1413,
+  ppp: 94,
+  shp: 6,
+  hits: 582,
+  blocks: 574,
+};
+
+const mockPlayerC: Player = {
+  name: 'Jason Zucker',
+  position: 'F',
+  score: 71.58,
+  scoreAdjustedByGames: 58.64,
+  games: 448,
+  goals: 132,
+  assists: 110,
+  points: 242,
+  plusMinus: 26,
+  penalties: 169,
+  shots: 1038,
+  ppp: 41,
+  shp: 5,
+  hits: 496,
+  blocks: 0,
+};
+
+describe('ComparisonService', () => {
+  let service: ComparisonService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(ComparisonService);
+  });
+
+  describe('initial state', () => {
+    it('should start with empty selection', (done) => {
+      service.selection$.pipe(first()).subscribe((selection) => {
+        expect(selection).toEqual([]);
+        done();
+      });
+    });
+
+    it('should report canSelectMore as true', (done) => {
+      service.canSelectMore$.pipe(first()).subscribe((canSelect) => {
+        expect(canSelect).toBeTrue();
+        done();
+      });
+    });
+  });
+
+  describe('toggle', () => {
+    it('should add a player to selection', (done) => {
+      service.toggle(mockPlayerA);
+      service.selection$.pipe(first()).subscribe((selection) => {
+        expect(selection.length).toBe(1);
+        expect(selection[0].name).toBe('Mikko Rantanen');
+        done();
+      });
+    });
+
+    it('should remove a player that is already selected', (done) => {
+      service.toggle(mockPlayerA);
+      service.toggle(mockPlayerA);
+      service.selection$.pipe(first()).subscribe((selection) => {
+        expect(selection).toEqual([]);
+        done();
+      });
+    });
+
+    it('should allow selecting two players', (done) => {
+      service.toggle(mockPlayerA);
+      service.toggle(mockPlayerB);
+      service.selection$.pipe(first()).subscribe((selection) => {
+        expect(selection.length).toBe(2);
+        done();
+      });
+    });
+
+    it('should not allow selecting more than two players', (done) => {
+      service.toggle(mockPlayerA);
+      service.toggle(mockPlayerB);
+      service.toggle(mockPlayerC);
+      service.selection$.pipe(first()).subscribe((selection) => {
+        expect(selection.length).toBe(2);
+        done();
+      });
+    });
+
+    it('should report canSelectMore as false when two are selected', (done) => {
+      service.toggle(mockPlayerA);
+      service.toggle(mockPlayerB);
+      service.canSelectMore$.pipe(first()).subscribe((canSelect) => {
+        expect(canSelect).toBeFalse();
+        done();
+      });
+    });
+  });
+
+  describe('isSelected', () => {
+    it('should return true for a selected player', () => {
+      service.toggle(mockPlayerA);
+      expect(service.isSelected(mockPlayerA)).toBeTrue();
+    });
+
+    it('should return false for an unselected player', () => {
+      expect(service.isSelected(mockPlayerA)).toBeFalse();
+    });
+  });
+
+  describe('clear', () => {
+    it('should remove all selections', (done) => {
+      service.toggle(mockPlayerA);
+      service.toggle(mockPlayerB);
+      service.clear();
+      service.selection$.pipe(first()).subscribe((selection) => {
+        expect(selection).toEqual([]);
+        done();
+      });
+    });
+  });
+
+  describe('orderedSelection', () => {
+    it('should return player with higher FR as playerA', (done) => {
+      service.toggle(mockPlayerA); // FR 94.31
+      service.toggle(mockPlayerB); // FR 100
+      service.orderedSelection$.pipe(first()).subscribe((ordered) => {
+        expect(ordered).not.toBeNull();
+        expect(ordered!.playerA.name).toBe('Aaron Ekblad');
+        expect(ordered!.playerB.name).toBe('Mikko Rantanen');
+        done();
+      });
+    });
+
+    it('should return null when fewer than 2 selected', (done) => {
+      service.toggle(mockPlayerA);
+      service.orderedSelection$.pipe(first()).subscribe((ordered) => {
+        expect(ordered).toBeNull();
+        done();
+      });
+    });
+  });
+});

--- a/src/app/services/tests/comparison.service.spec.ts
+++ b/src/app/services/tests/comparison.service.spec.ts
@@ -174,6 +174,17 @@ describe('ComparisonService', () => {
         done();
       });
     });
+
+    it('should keep order when first selected has higher score', (done) => {
+      service.toggle(mockPlayerB); // FR 100 (higher)
+      service.toggle(mockPlayerA); // FR 94.31
+      service.orderedSelection$.pipe(first()).subscribe((ordered) => {
+        expect(ordered).not.toBeNull();
+        expect(ordered!.playerA.name).toBe('Aaron Ekblad');
+        expect(ordered!.playerB.name).toBe('Mikko Rantanen');
+        done();
+      });
+    });
   });
 
   describe('clearOnDataChange', () => {

--- a/src/app/services/tests/comparison.service.spec.ts
+++ b/src/app/services/tests/comparison.service.spec.ts
@@ -2,6 +2,9 @@ import { TestBed } from '@angular/core/testing';
 import { ComparisonService } from '../comparison.service';
 import { Player } from '../api.service';
 import { first } from 'rxjs';
+import { TeamService } from '../team.service';
+import { FilterService } from '../filter.service';
+import { SettingsService } from '../settings.service';
 
 const mockPlayerA: Player = {
   name: 'Mikko Rantanen',
@@ -168,6 +171,99 @@ describe('ComparisonService', () => {
       service.toggle(mockPlayerA);
       service.orderedSelection$.pipe(first()).subscribe((ordered) => {
         expect(ordered).toBeNull();
+        done();
+      });
+    });
+  });
+
+  describe('clearOnDataChange', () => {
+    let teamService: TeamService;
+    let filterService: FilterService;
+    let settingsService: SettingsService;
+
+    beforeEach(() => {
+      teamService = TestBed.inject(TeamService);
+      filterService = TestBed.inject(FilterService);
+      settingsService = TestBed.inject(SettingsService);
+    });
+
+    it('should clear selection when team changes', (done) => {
+      service.toggle(mockPlayerA);
+      teamService.setTeamId('99');
+      service.selection$.pipe(first()).subscribe((s) => {
+        expect(s).toEqual([]);
+        done();
+      });
+    });
+
+    it('should clear selection when player report type changes', (done) => {
+      service.toggle(mockPlayerA);
+      filterService.updatePlayerFilters({ reportType: 'playoffs' });
+      service.selection$.pipe(first()).subscribe((s) => {
+        expect(s).toEqual([]);
+        done();
+      });
+    });
+
+    it('should clear selection when goalie report type changes', (done) => {
+      service.toggle(mockPlayerA);
+      filterService.updateGoalieFilters({ reportType: 'playoffs' });
+      service.selection$.pipe(first()).subscribe((s) => {
+        expect(s).toEqual([]);
+        done();
+      });
+    });
+
+    it('should clear selection when player season changes', (done) => {
+      service.toggle(mockPlayerA);
+      filterService.updatePlayerFilters({ season: 2024 });
+      service.selection$.pipe(first()).subscribe((s) => {
+        expect(s).toEqual([]);
+        done();
+      });
+    });
+
+    it('should clear selection when goalie season changes', (done) => {
+      service.toggle(mockPlayerA);
+      filterService.updateGoalieFilters({ season: 2024 });
+      service.selection$.pipe(first()).subscribe((s) => {
+        expect(s).toEqual([]);
+        done();
+      });
+    });
+
+    it('should clear selection when startFromSeason changes', (done) => {
+      service.toggle(mockPlayerA);
+      settingsService.setStartFromSeason(2020);
+      service.selection$.pipe(first()).subscribe((s) => {
+        expect(s).toEqual([]);
+        done();
+      });
+    });
+
+    it('should not clear selection when minGames changes', (done) => {
+      service.toggle(mockPlayerA);
+      filterService.updatePlayerFilters({ minGames: 10 });
+      service.selection$.pipe(first()).subscribe((s) => {
+        expect(s.length).toBe(1);
+        done();
+      });
+    });
+
+    it('should not clear selection when statsPerGame changes', (done) => {
+      service.toggle(mockPlayerA);
+      filterService.updatePlayerFilters({ statsPerGame: true });
+      service.selection$.pipe(first()).subscribe((s) => {
+        expect(s.length).toBe(1);
+        done();
+      });
+    });
+
+    it('should not clear selection when positionFilter changes', (done) => {
+      service.toggle(mockPlayerA);
+      filterService.updatePlayerFilters({ positionFilter: 'F' });
+      service.selection$.pipe(first()).subscribe((s) => {
+        expect(s.length).toBe(1);
         done();
       });
     });

--- a/src/app/shared/comparison-bar/comparison-bar.component.html
+++ b/src/app/shared/comparison-bar/comparison-bar.component.html
@@ -6,7 +6,7 @@
         {{ 'comparison.compare' | translate }}
       </button>
     }
-    <button mat-button (click)="onClear()">
+    <button mat-stroked-button (click)="onClear()">
       {{ 'comparison.clear' | translate }}
     </button>
   </div>

--- a/src/app/shared/comparison-bar/comparison-bar.component.html
+++ b/src/app/shared/comparison-bar/comparison-bar.component.html
@@ -1,0 +1,13 @@
+@if (visible$ | async) {
+  <div class="comparison-bar" role="status" aria-live="polite">
+    <span class="bar-text">{{ barText$ | async }}</span>
+    @if (showCompareButton$ | async) {
+      <button mat-raised-button color="primary" (click)="onCompare()">
+        {{ 'comparison.compare' | translate }}
+      </button>
+    }
+    <button mat-button (click)="onClear()">
+      {{ 'comparison.clear' | translate }}
+    </button>
+  </div>
+}

--- a/src/app/shared/comparison-bar/comparison-bar.component.scss
+++ b/src/app/shared/comparison-bar/comparison-bar.component.scss
@@ -1,0 +1,35 @@
+:host {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: 100;
+  display: flex;
+  justify-content: center;
+  pointer-events: none;
+}
+
+.comparison-bar {
+  pointer-events: auto;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 24px;
+  background: var(--mat-sys-surface-container-high);
+  border-top: 1px solid var(--mat-sys-outline-variant);
+  box-shadow: 0 -2px 8px rgba(0, 0, 0, 0.15);
+  border-radius: 12px 12px 0 0;
+
+  @media (max-width: 768px) {
+    width: 100%;
+    justify-content: center;
+    padding: 10px 16px;
+    gap: 8px;
+    border-radius: 0;
+  }
+}
+
+.bar-text {
+  font-size: 14px;
+  color: var(--mat-sys-on-surface);
+}

--- a/src/app/shared/comparison-bar/comparison-bar.component.scss
+++ b/src/app/shared/comparison-bar/comparison-bar.component.scss
@@ -33,3 +33,11 @@
   font-size: 14px;
   color: var(--mat-sys-on-surface);
 }
+
+// Clear button: neutral color (white in dark mode, dark in light mode)
+:host ::ng-deep .mat-mdc-outlined-button:not(:disabled) {
+  --mdc-outlined-button-label-text-color: var(--mat-sys-on-surface);
+  --mdc-outlined-button-outline-color: var(--mat-sys-outline);
+  color: var(--mat-sys-on-surface) !important;
+  border-color: var(--mat-sys-outline) !important;
+}

--- a/src/app/shared/comparison-bar/comparison-bar.component.spec.ts
+++ b/src/app/shared/comparison-bar/comparison-bar.component.spec.ts
@@ -1,4 +1,5 @@
 import { TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { MatDialog } from '@angular/material/dialog';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { ComparisonBarComponent } from './comparison-bar.component';
 import { ComparisonService } from '@services/comparison.service';
@@ -143,6 +144,41 @@ describe('ComparisonBarComponent', () => {
 
     compareButton!.click();
     expect(fixture.componentInstance.onCompare).toHaveBeenCalled();
+  }));
+
+  it('should open comparison dialog when onCompare is called with two players', fakeAsync(() => {
+    comparisonService.toggle(mockPlayerA);
+    comparisonService.toggle(mockPlayerB);
+
+    const fixture = TestBed.createComponent(ComparisonBarComponent);
+    fixture.detectChanges();
+    tick();
+    fixture.detectChanges();
+
+    const dialog = TestBed.inject(MatDialog);
+    spyOn(dialog, 'open');
+
+    fixture.componentInstance.onCompare();
+    tick();
+
+    expect(dialog.open).toHaveBeenCalled();
+  }));
+
+  it('should not open dialog when onCompare is called with fewer than two players', fakeAsync(() => {
+    comparisonService.toggle(mockPlayerA);
+
+    const fixture = TestBed.createComponent(ComparisonBarComponent);
+    fixture.detectChanges();
+    tick();
+    fixture.detectChanges();
+
+    const dialog = TestBed.inject(MatDialog);
+    spyOn(dialog, 'open');
+
+    fixture.componentInstance.onCompare();
+    tick();
+
+    expect(dialog.open).not.toHaveBeenCalled();
   }));
 
   it('should show both player names when two players are selected', fakeAsync(() => {

--- a/src/app/shared/comparison-bar/comparison-bar.component.spec.ts
+++ b/src/app/shared/comparison-bar/comparison-bar.component.spec.ts
@@ -1,0 +1,162 @@
+import { TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { TranslateModule, TranslateService } from '@ngx-translate/core';
+import { ComparisonBarComponent } from './comparison-bar.component';
+import { ComparisonService } from '@services/comparison.service';
+import { Player } from '@services/api.service';
+
+const mockPlayerA: Player = {
+  name: 'Mikko Rantanen', position: 'F', score: 94.31, scoreAdjustedByGames: 93.1,
+  games: 427, goals: 193, assists: 254, points: 447, plusMinus: 0,
+  penalties: 256, shots: 1182, ppp: 165, shp: 0, hits: 276, blocks: 41,
+};
+
+const mockPlayerB: Player = {
+  name: 'Aaron Ekblad', position: 'D', score: 100, scoreAdjustedByGames: 67.22,
+  games: 540, goals: 100, assists: 188, points: 288, plusMinus: 40,
+  penalties: 355, shots: 1413, ppp: 94, shp: 6, hits: 582, blocks: 574,
+};
+
+describe('ComparisonBarComponent', () => {
+  let comparisonService: ComparisonService;
+  let translateService: TranslateService;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ComparisonBarComponent, TranslateModule.forRoot()],
+    }).compileComponents();
+
+    comparisonService = TestBed.inject(ComparisonService);
+    translateService = TestBed.inject(TranslateService);
+
+    translateService.setTranslation('fi', {
+      comparison: {
+        selectedOne: '{{name}} valittu \u2014 valitse toinen vertailuun',
+        compare: 'Vertaile',
+        clear: 'Tyhjenn\u00e4',
+      },
+    });
+    translateService.use('fi');
+
+    // Ensure clean state
+    comparisonService.clear();
+  });
+
+  it('should not be visible when no players are selected', fakeAsync(() => {
+    const fixture = TestBed.createComponent(ComparisonBarComponent);
+    fixture.detectChanges();
+    tick();
+
+    const el: HTMLElement = fixture.nativeElement;
+    const bar = el.querySelector('.comparison-bar');
+    expect(bar).toBeNull();
+  }));
+
+  it('should be visible when one player is selected', fakeAsync(() => {
+    comparisonService.toggle(mockPlayerA);
+
+    const fixture = TestBed.createComponent(ComparisonBarComponent);
+    fixture.detectChanges();
+    tick();
+    fixture.detectChanges();
+
+    const el: HTMLElement = fixture.nativeElement;
+    const bar = el.querySelector('.comparison-bar');
+    expect(bar).toBeTruthy();
+  }));
+
+  it('should show prompt text when one player is selected', fakeAsync(() => {
+    comparisonService.toggle(mockPlayerA);
+
+    const fixture = TestBed.createComponent(ComparisonBarComponent);
+    fixture.detectChanges();
+    tick();
+    fixture.detectChanges();
+
+    const el: HTMLElement = fixture.nativeElement;
+    const barText = el.querySelector('.bar-text')?.textContent?.trim() ?? '';
+    expect(barText).toContain('Mikko Rantanen');
+    expect(barText).toContain('valitse toinen vertailuun');
+  }));
+
+  it('should show compare button when two players are selected', fakeAsync(() => {
+    comparisonService.toggle(mockPlayerA);
+    comparisonService.toggle(mockPlayerB);
+
+    const fixture = TestBed.createComponent(ComparisonBarComponent);
+    fixture.detectChanges();
+    tick();
+    fixture.detectChanges();
+
+    const el: HTMLElement = fixture.nativeElement;
+    const buttons = Array.from(el.querySelectorAll('button'));
+    const compareButton = buttons.find((b) => b.textContent?.trim() === 'Vertaile');
+    expect(compareButton).toBeTruthy();
+  }));
+
+  it('should not show compare button when only one player is selected', fakeAsync(() => {
+    comparisonService.toggle(mockPlayerA);
+
+    const fixture = TestBed.createComponent(ComparisonBarComponent);
+    fixture.detectChanges();
+    tick();
+    fixture.detectChanges();
+
+    const el: HTMLElement = fixture.nativeElement;
+    const buttons = Array.from(el.querySelectorAll('button'));
+    const compareButton = buttons.find((b) => b.textContent?.trim() === 'Vertaile');
+    expect(compareButton).toBeFalsy();
+  }));
+
+  it('should call comparisonService.clear() when clear button is clicked', fakeAsync(() => {
+    comparisonService.toggle(mockPlayerA);
+    spyOn(comparisonService, 'clear').and.callThrough();
+
+    const fixture = TestBed.createComponent(ComparisonBarComponent);
+    fixture.detectChanges();
+    tick();
+    fixture.detectChanges();
+
+    const el: HTMLElement = fixture.nativeElement;
+    const buttons = Array.from(el.querySelectorAll('button'));
+    const clearButton = buttons.find((b) => b.textContent?.trim() === 'Tyhjenn\u00e4');
+    expect(clearButton).toBeTruthy();
+
+    clearButton!.click();
+    expect(comparisonService.clear).toHaveBeenCalled();
+  }));
+
+  it('should call onCompare when compare button is clicked', fakeAsync(() => {
+    comparisonService.toggle(mockPlayerA);
+    comparisonService.toggle(mockPlayerB);
+
+    const fixture = TestBed.createComponent(ComparisonBarComponent);
+    fixture.detectChanges();
+    tick();
+    fixture.detectChanges();
+
+    spyOn(fixture.componentInstance, 'onCompare');
+
+    const el: HTMLElement = fixture.nativeElement;
+    const buttons = Array.from(el.querySelectorAll('button'));
+    const compareButton = buttons.find((b) => b.textContent?.trim() === 'Vertaile');
+    expect(compareButton).toBeTruthy();
+
+    compareButton!.click();
+    expect(fixture.componentInstance.onCompare).toHaveBeenCalled();
+  }));
+
+  it('should show both player names when two players are selected', fakeAsync(() => {
+    comparisonService.toggle(mockPlayerA);
+    comparisonService.toggle(mockPlayerB);
+
+    const fixture = TestBed.createComponent(ComparisonBarComponent);
+    fixture.detectChanges();
+    tick();
+    fixture.detectChanges();
+
+    const el: HTMLElement = fixture.nativeElement;
+    const barText = el.querySelector('.bar-text')?.textContent?.trim() ?? '';
+    expect(barText).toContain('Mikko Rantanen');
+    expect(barText).toContain('Aaron Ekblad');
+  }));
+});

--- a/src/app/shared/comparison-bar/comparison-bar.component.ts
+++ b/src/app/shared/comparison-bar/comparison-bar.component.ts
@@ -1,10 +1,12 @@
 import { Component, inject } from '@angular/core';
 import { AsyncPipe } from '@angular/common';
 import { MatButtonModule } from '@angular/material/button';
+import { MatDialog } from '@angular/material/dialog';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { Observable } from 'rxjs';
 import { map, first } from 'rxjs/operators';
 import { ComparisonService } from '@services/comparison.service';
+import { ComparisonDialogComponent, ComparisonDialogData } from '@shared/comparison-dialog/comparison-dialog.component';
 
 @Component({
   selector: 'app-comparison-bar',
@@ -15,6 +17,7 @@ import { ComparisonService } from '@services/comparison.service';
 export class ComparisonBarComponent {
   private comparisonService = inject(ComparisonService);
   private translateService = inject(TranslateService);
+  private dialog = inject(MatDialog);
 
   readonly selection$ = this.comparisonService.selection$;
 
@@ -45,9 +48,13 @@ export class ComparisonBarComponent {
   onCompare(): void {
     this.comparisonService.orderedSelection$.pipe(first()).subscribe((ordered) => {
       if (ordered) {
-        // ComparisonDialogComponent will be created in Task 6
-        // For now, just log to verify wiring works
-        console.log('Compare:', ordered.playerA.name, 'vs', ordered.playerB.name);
+        const dialogData: ComparisonDialogData = ordered;
+        this.dialog.open(ComparisonDialogComponent, {
+          data: dialogData,
+          maxWidth: '95vw',
+          width: 'auto',
+          panelClass: 'comparison-dialog-panel',
+        });
       }
     });
   }

--- a/src/app/shared/comparison-bar/comparison-bar.component.ts
+++ b/src/app/shared/comparison-bar/comparison-bar.component.ts
@@ -1,0 +1,54 @@
+import { Component, inject } from '@angular/core';
+import { AsyncPipe } from '@angular/common';
+import { MatButtonModule } from '@angular/material/button';
+import { TranslateModule, TranslateService } from '@ngx-translate/core';
+import { Observable } from 'rxjs';
+import { map, first } from 'rxjs/operators';
+import { ComparisonService } from '@services/comparison.service';
+
+@Component({
+  selector: 'app-comparison-bar',
+  imports: [AsyncPipe, MatButtonModule, TranslateModule],
+  templateUrl: './comparison-bar.component.html',
+  styleUrl: './comparison-bar.component.scss',
+})
+export class ComparisonBarComponent {
+  private comparisonService = inject(ComparisonService);
+  private translateService = inject(TranslateService);
+
+  readonly selection$ = this.comparisonService.selection$;
+
+  readonly visible$: Observable<boolean> = this.selection$.pipe(
+    map((s) => s.length > 0)
+  );
+
+  readonly showCompareButton$: Observable<boolean> = this.selection$.pipe(
+    map((s) => s.length === 2)
+  );
+
+  readonly barText$: Observable<string> = this.selection$.pipe(
+    map((selection) => {
+      if (selection.length === 1) {
+        return this.translateService.instant('comparison.selectedOne', { name: selection[0].name });
+      }
+      if (selection.length === 2) {
+        return `${selection[0].name}, ${selection[1].name}`;
+      }
+      return '';
+    })
+  );
+
+  onClear(): void {
+    this.comparisonService.clear();
+  }
+
+  onCompare(): void {
+    this.comparisonService.orderedSelection$.pipe(first()).subscribe((ordered) => {
+      if (ordered) {
+        // ComparisonDialogComponent will be created in Task 6
+        // For now, just log to verify wiring works
+        console.log('Compare:', ordered.playerA.name, 'vs', ordered.playerB.name);
+      }
+    });
+  }
+}

--- a/src/app/shared/comparison-dialog/comparison-dialog.component.html
+++ b/src/app/shared/comparison-dialog/comparison-dialog.component.html
@@ -1,0 +1,35 @@
+<div class="comparison-dialog"
+     [attr.aria-label]="'Vertailu: ' + data.playerA.name + ' vs ' + data.playerB.name">
+  <div class="dialog-header">
+    <h2>{{ title }}</h2>
+    <button mat-icon-button (click)="dialogRef.close()" #closeButton aria-label="Sulje">X</button>
+  </div>
+  @if (isMobile$ | async; as isMobile) {
+    <div class="dialog-ingress">
+      <p class="ingress-names"><strong>{{ getIngressText(true) }}</strong></p>
+      @if (teamName) {
+        <p class="ingress-team">{{ teamName }}</p>
+      }
+    </div>
+  } @else {
+    <div class="dialog-ingress">
+      <p class="ingress-names"><strong>{{ getIngressText(false) }}</strong></p>
+      @if (teamName) {
+        <p class="ingress-team">{{ teamName }}</p>
+      }
+    </div>
+  }
+  <mat-tab-group>
+    <mat-tab [label]="'comparison.statsTab' | translate">
+      <app-comparison-stats
+        [playerA]="data.playerA"
+        [playerB]="data.playerB"
+        [isMobile]="(isMobile$ | async) ?? false" />
+    </mat-tab>
+    <mat-tab [label]="'comparison.graphsTab' | translate">
+      <app-comparison-radar
+        [playerA]="data.playerA"
+        [playerB]="data.playerB" />
+    </mat-tab>
+  </mat-tab-group>
+</div>

--- a/src/app/shared/comparison-dialog/comparison-dialog.component.html
+++ b/src/app/shared/comparison-dialog/comparison-dialog.component.html
@@ -24,7 +24,7 @@
       <app-comparison-stats
         [playerA]="data.playerA"
         [playerB]="data.playerB"
-        [isMobile]="(isMobile$ | async) ?? false" />
+        [isMobile]="(isNarrow$ | async) ?? false" />
     </mat-tab>
     <mat-tab [label]="'comparison.graphsTab' | translate">
       <app-comparison-radar

--- a/src/app/shared/comparison-dialog/comparison-dialog.component.scss
+++ b/src/app/shared/comparison-dialog/comparison-dialog.component.scss
@@ -1,0 +1,76 @@
+.comparison-dialog {
+  min-width: 600px;
+  max-width: 960px;
+  width: 100%;
+  padding: 8px 0 0 0;
+  background-color: var(--mat-sys-surface-container-high);
+  color: var(--mat-sys-on-surface);
+}
+
+.dialog-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 16px;
+
+  h2 {
+    margin: 0;
+    font-size: 24px;
+    font-weight: bold;
+  }
+
+  button {
+    flex-shrink: 0;
+  }
+}
+
+.dialog-ingress {
+  text-align: center;
+  padding: 8px 16px 0;
+
+  .ingress-names {
+    margin: 0;
+    font-size: 1rem;
+  }
+
+  .ingress-team {
+    margin: 4px 0 0;
+    font-size: 0.875rem;
+    color: var(--mat-sys-on-surface-variant);
+  }
+}
+
+mat-tab-group {
+  width: 100%;
+}
+
+// Tablet landscape and medium screens
+@media (max-width: 960px) {
+  .comparison-dialog {
+    max-width: 90vw;
+  }
+}
+
+// Tablet portrait and small screens
+@media (max-width: 768px) {
+  .comparison-dialog {
+    min-width: 100%;
+    max-width: 100%;
+  }
+
+  .dialog-header h2 {
+    font-size: 20px;
+  }
+}
+
+// Small mobile
+@media (max-width: 480px) {
+  .comparison-dialog {
+    min-width: 100%;
+    padding: 4px 0 0 0;
+  }
+
+  .dialog-header h2 {
+    font-size: 18px;
+  }
+}

--- a/src/app/shared/comparison-dialog/comparison-dialog.component.scss
+++ b/src/app/shared/comparison-dialog/comparison-dialog.component.scss
@@ -8,18 +8,22 @@
 }
 
 .dialog-header {
-  display: flex;
+  display: grid;
+  grid-template-columns: 48px 1fr 48px;
   align-items: center;
-  justify-content: space-between;
   padding: 0 16px;
 
   h2 {
+    grid-column: 2;
     margin: 0;
     font-size: 24px;
     font-weight: bold;
+    text-align: center;
   }
 
   button {
+    grid-column: 3;
+    justify-self: end;
     flex-shrink: 0;
   }
 }
@@ -34,7 +38,7 @@
   }
 
   .ingress-team {
-    margin: 4px 0 0;
+    margin: 4px 0 4px;
     font-size: 0.875rem;
     color: var(--mat-sys-on-surface-variant);
   }

--- a/src/app/shared/comparison-dialog/comparison-dialog.component.spec.ts
+++ b/src/app/shared/comparison-dialog/comparison-dialog.component.spec.ts
@@ -258,6 +258,16 @@ describe('ComparisonDialogComponent', () => {
     });
   });
 
+  describe('isNarrow$', () => {
+    it('should emit from BreakpointObserver', (done) => {
+      setup({ playerA: mockForwardA, playerB: mockForwardB });
+      component.isNarrow$.subscribe((isNarrow) => {
+        expect(typeof isNarrow).toBe('boolean');
+        done();
+      });
+    });
+  });
+
   describe('isMixedPosition', () => {
     it('should return true for forward vs defense', () => {
       setup({ playerA: mockForwardA, playerB: mockDefenseA });

--- a/src/app/shared/comparison-dialog/comparison-dialog.component.spec.ts
+++ b/src/app/shared/comparison-dialog/comparison-dialog.component.spec.ts
@@ -186,6 +186,35 @@ describe('ComparisonDialogComponent', () => {
       fixture.detectChanges();
       expect(component.teamName).toBe('Colorado');
     }));
+
+    it('should set empty team name when team is not found', fakeAsync(() => {
+      dialogRefSpy = jasmine.createSpyObj('MatDialogRef', ['close']);
+
+      TestBed.resetTestingModule();
+      TestBed.configureTestingModule({
+        imports: [
+          ComparisonDialogComponent,
+          NoopAnimationsModule,
+          TranslateModule.forRoot(),
+        ],
+        providers: [
+          { provide: MAT_DIALOG_DATA, useValue: { playerA: mockForwardA, playerB: mockForwardB } },
+          { provide: MatDialogRef, useValue: dialogRefSpy },
+          {
+            provide: ApiService,
+            useValue: { getTeams: () => of([{ id: '999', name: 'other', presentName: 'Other' }]) },
+          },
+          { provide: TeamService, useValue: { selectedTeamId: '1' } },
+        ],
+      });
+
+      const localFixture = TestBed.createComponent(ComparisonDialogComponent);
+      localFixture.detectChanges();
+      tick();
+
+      expect(localFixture.componentInstance.teamName).toBe('');
+      localFixture.destroy();
+    }));
   });
 
   describe('dialog actions', () => {

--- a/src/app/shared/comparison-dialog/comparison-dialog.component.spec.ts
+++ b/src/app/shared/comparison-dialog/comparison-dialog.component.spec.ts
@@ -1,0 +1,248 @@
+import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { TranslateModule, TranslateService } from '@ngx-translate/core';
+import { of } from 'rxjs';
+import { ComparisonDialogComponent, ComparisonDialogData } from './comparison-dialog.component';
+import type { Player, Goalie } from '@services/api.service';
+import { ApiService } from '@services/api.service';
+import { TeamService } from '@services/team.service';
+
+const mockForwardA: Player = {
+  name: 'Mikko Rantanen', position: 'F', score: 100, scoreAdjustedByGames: 93.1,
+  games: 427, goals: 193, assists: 254, points: 447, plusMinus: 10,
+  penalties: 256, shots: 1182, ppp: 165, shp: 0, hits: 276, blocks: 41,
+  scores: { goals: 80, assists: 75, points: 85, plusMinus: 50, penalties: 60, shots: 70, ppp: 90, shp: 10, hits: 40, blocks: 20 },
+};
+
+const mockForwardB: Player = {
+  name: 'Aleksander Barkov', position: 'F', score: 94.31, scoreAdjustedByGames: 67.22,
+  games: 540, goals: 100, assists: 188, points: 288, plusMinus: 40,
+  penalties: 355, shots: 1413, ppp: 94, shp: 6, hits: 582, blocks: 574,
+  scores: { goals: 60, assists: 70, points: 65, plusMinus: 70, penalties: 55, shots: 80, ppp: 50, shp: 30, hits: 85, blocks: 90 },
+};
+
+const mockDefenseA: Player = {
+  name: 'Aaron Ekblad', position: 'D', score: 100, scoreAdjustedByGames: 67.22,
+  games: 540, goals: 100, assists: 188, points: 288, plusMinus: 40,
+  penalties: 355, shots: 1413, ppp: 94, shp: 6, hits: 582, blocks: 574,
+  scores: { goals: 60, assists: 70, points: 65, plusMinus: 70, penalties: 55, shots: 80, ppp: 50, shp: 30, hits: 85, blocks: 90 },
+};
+
+const mockDefenseB: Player = {
+  name: 'Miro Heiskanen', position: 'D', score: 88, scoreAdjustedByGames: 77,
+  games: 400, goals: 80, assists: 200, points: 280, plusMinus: 30,
+  penalties: 100, shots: 900, ppp: 120, shp: 2, hits: 300, blocks: 400,
+  scores: { goals: 50, assists: 80, points: 70, plusMinus: 55, penalties: 30, shots: 60, ppp: 70, shp: 15, hits: 55, blocks: 75 },
+};
+
+const mockGoalieA: Goalie = {
+  name: 'Juuse Saros', score: 100, scoreAdjustedByGames: 90,
+  games: 200, wins: 120, saves: 5000, shutouts: 15,
+  goals: 0, assists: 2, points: 2, penalties: 4, ppp: 0, shp: 0,
+  scores: { wins: 85, saves: 90, shutouts: 70 },
+};
+
+const mockGoalieB: Goalie = {
+  name: 'Andrei Vasilevskiy', score: 95, scoreAdjustedByGames: 85,
+  games: 250, wins: 150, saves: 6000, shutouts: 20,
+  goals: 0, assists: 5, points: 5, penalties: 6, ppp: 0, shp: 0,
+  scores: { wins: 90, saves: 80, shutouts: 75 },
+};
+
+describe('ComparisonDialogComponent', () => {
+  let fixture: ComponentFixture<ComparisonDialogComponent>;
+  let component: ComparisonDialogComponent;
+  let dialogRefSpy: jasmine.SpyObj<MatDialogRef<ComparisonDialogComponent>>;
+  let translateService: TranslateService;
+
+  function setup(data: ComparisonDialogData): void {
+    dialogRefSpy = jasmine.createSpyObj('MatDialogRef', ['close']);
+
+    TestBed.configureTestingModule({
+      imports: [
+        ComparisonDialogComponent,
+        NoopAnimationsModule,
+        TranslateModule.forRoot(),
+      ],
+      providers: [
+        { provide: MAT_DIALOG_DATA, useValue: data },
+        { provide: MatDialogRef, useValue: dialogRefSpy },
+        {
+          provide: ApiService,
+          useValue: { getTeams: () => of([{ id: '1', name: 'colorado', presentName: 'Colorado' }]) },
+        },
+        { provide: TeamService, useValue: { selectedTeamId: '1' } },
+      ],
+    });
+
+    translateService = TestBed.inject(TranslateService);
+    translateService.setTranslation('fi', {
+      comparison: {
+        playerTitle: 'Pelaajavertailu',
+        forwardTitle: 'Hyokkaajavertailu',
+        defenseTitle: 'Puolustajavertailu',
+        goalieTitle: 'Maalivahtivertailu',
+        statsTab: 'Tilastot',
+        graphsTab: 'Graafit',
+      },
+      tableColumn: {
+        score: 'FR',
+        scoreAdjustedByGames: 'FR/O',
+        games: 'Ottelut',
+        goals: 'Maalit',
+        assists: 'Syotot',
+        points: 'Pisteet',
+        plusMinus: 'Plusmiinus',
+        penalties: 'Jaahyt',
+        shots: 'Laukaukset',
+        ppp: 'YV-pisteet',
+        shp: 'AV-pisteet',
+        hits: 'Taklaukset',
+        blocks: 'Blokit',
+        wins: 'Voitot',
+        saves: 'Torjunnat',
+        shutouts: 'Nollat',
+        gaa: 'GAA',
+        savePercent: 'Torjunta%',
+      },
+    });
+    translateService.use('fi');
+
+    fixture = TestBed.createComponent(ComparisonDialogComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  }
+
+  afterEach(() => {
+    fixture?.destroy();
+  });
+
+  describe('title', () => {
+    it('should show forward title when both players are forwards', () => {
+      setup({ playerA: mockForwardA, playerB: mockForwardB });
+      expect(component.title).toBe('Hyokkaajavertailu');
+    });
+
+    it('should show defense title when both players are defensemen', () => {
+      setup({ playerA: mockDefenseA, playerB: mockDefenseB });
+      expect(component.title).toBe('Puolustajavertailu');
+    });
+
+    it('should show player title for mixed positions', () => {
+      setup({ playerA: mockForwardA, playerB: mockDefenseA });
+      expect(component.title).toBe('Pelaajavertailu');
+    });
+
+    it('should show goalie title for goalies', () => {
+      setup({ playerA: mockGoalieA, playerB: mockGoalieB });
+      expect(component.title).toBe('Maalivahtivertailu');
+    });
+  });
+
+  describe('ingress', () => {
+    it('should show full names on desktop', () => {
+      setup({ playerA: mockForwardA, playerB: mockForwardB });
+      const text = component.getIngressText(false);
+      expect(text).toBe('Mikko Rantanen <-> Aleksander Barkov');
+    });
+
+    it('should show surnames only on mobile', () => {
+      setup({ playerA: mockForwardA, playerB: mockForwardB });
+      const text = component.getIngressText(true);
+      expect(text).toBe('Rantanen <-> Barkov');
+    });
+
+    it('should show positions for mixed comparison on desktop', () => {
+      setup({ playerA: mockForwardA, playerB: mockDefenseA });
+      const text = component.getIngressText(false);
+      expect(text).toBe('H Mikko Rantanen <-> Aaron Ekblad P');
+    });
+
+    it('should show positions for mixed comparison on mobile', () => {
+      setup({ playerA: mockForwardA, playerB: mockDefenseA });
+      const text = component.getIngressText(true);
+      expect(text).toBe('H Rantanen <-> Ekblad P');
+    });
+
+    it('should not show positions when both are forwards', () => {
+      setup({ playerA: mockForwardA, playerB: mockForwardB });
+      const text = component.getIngressText(false);
+      expect(text).not.toContain(' H ');
+      expect(text).not.toContain(' P ');
+    });
+
+    it('should not show positions for goalies', () => {
+      setup({ playerA: mockGoalieA, playerB: mockGoalieB });
+      const text = component.getIngressText(false);
+      expect(text).toBe('Juuse Saros <-> Andrei Vasilevskiy');
+    });
+  });
+
+  describe('team name', () => {
+    it('should display team name from TeamService', fakeAsync(() => {
+      setup({ playerA: mockForwardA, playerB: mockForwardB });
+      tick();
+      fixture.detectChanges();
+      expect(component.teamName).toBe('Colorado');
+    }));
+  });
+
+  describe('dialog actions', () => {
+    it('should close dialog when close button is clicked', () => {
+      setup({ playerA: mockForwardA, playerB: mockForwardB });
+      const el: HTMLElement = fixture.nativeElement;
+      const closeButton = el.querySelector('button[aria-label="Sulje"]') as HTMLButtonElement;
+      expect(closeButton).toBeTruthy();
+      closeButton.click();
+      expect(dialogRefSpy.close).toHaveBeenCalled();
+    });
+  });
+
+  describe('tabs', () => {
+    it('should render two tabs', () => {
+      setup({ playerA: mockForwardA, playerB: mockForwardB });
+      const el: HTMLElement = fixture.nativeElement;
+      const tabs = el.querySelectorAll('.mdc-tab');
+      expect(tabs.length).toBe(2);
+    });
+
+    it('should show Tilastot and Graafit tab labels', () => {
+      setup({ playerA: mockForwardA, playerB: mockForwardB });
+      const el: HTMLElement = fixture.nativeElement;
+      const tabLabels = Array.from(el.querySelectorAll('.mdc-tab__text-label'));
+      const labels = tabLabels.map((t) => t.textContent?.trim());
+      expect(labels).toContain('Tilastot');
+      expect(labels).toContain('Graafit');
+    });
+  });
+
+  describe('isGoalie', () => {
+    it('should return true for goalies', () => {
+      setup({ playerA: mockGoalieA, playerB: mockGoalieB });
+      expect(component.isGoalie).toBeTrue();
+    });
+
+    it('should return false for players', () => {
+      setup({ playerA: mockForwardA, playerB: mockForwardB });
+      expect(component.isGoalie).toBeFalse();
+    });
+  });
+
+  describe('isMixedPosition', () => {
+    it('should return true for forward vs defense', () => {
+      setup({ playerA: mockForwardA, playerB: mockDefenseA });
+      expect(component.isMixedPosition).toBeTrue();
+    });
+
+    it('should return false for same positions', () => {
+      setup({ playerA: mockForwardA, playerB: mockForwardB });
+      expect(component.isMixedPosition).toBeFalse();
+    });
+
+    it('should return false for goalies', () => {
+      setup({ playerA: mockGoalieA, playerB: mockGoalieB });
+      expect(component.isMixedPosition).toBeFalse();
+    });
+  });
+});

--- a/src/app/shared/comparison-dialog/comparison-dialog.component.ts
+++ b/src/app/shared/comparison-dialog/comparison-dialog.component.ts
@@ -1,0 +1,93 @@
+import { Component, inject } from '@angular/core';
+import { AsyncPipe } from '@angular/common';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatTabsModule } from '@angular/material/tabs';
+import { TranslateModule, TranslateService } from '@ngx-translate/core';
+import { take } from 'rxjs';
+import type { Player, Goalie } from '@services/api.service';
+import { ApiService } from '@services/api.service';
+import { TeamService } from '@services/team.service';
+import { ViewportService } from '@services/viewport.service';
+import { ComparisonStatsComponent } from './comparison-stats/comparison-stats.component';
+import { ComparisonRadarComponent } from './comparison-radar/comparison-radar.component';
+
+export type ComparisonDialogData = {
+  playerA: Player | Goalie;
+  playerB: Player | Goalie;
+};
+
+@Component({
+  selector: 'app-comparison-dialog',
+  imports: [
+    AsyncPipe,
+    MatButtonModule,
+    MatIconModule,
+    MatTabsModule,
+    TranslateModule,
+    ComparisonStatsComponent,
+    ComparisonRadarComponent,
+  ],
+  templateUrl: './comparison-dialog.component.html',
+  styleUrl: './comparison-dialog.component.scss',
+})
+export class ComparisonDialogComponent {
+  readonly data = inject<ComparisonDialogData>(MAT_DIALOG_DATA);
+  readonly dialogRef = inject(MatDialogRef<ComparisonDialogComponent>);
+  readonly isMobile$ = inject(ViewportService).isMobile$;
+  private translateService = inject(TranslateService);
+  private apiService = inject(ApiService);
+  private teamService = inject(TeamService);
+
+  teamName = '';
+
+  constructor() {
+    this.apiService.getTeams().pipe(take(1)).subscribe((teams) => {
+      const team = teams.find((t) => t.id === this.teamService.selectedTeamId);
+      this.teamName = team?.presentName ?? '';
+    });
+  }
+
+  get isGoalie(): boolean {
+    return 'wins' in this.data.playerA;
+  }
+
+  get isMixedPosition(): boolean {
+    if (this.isGoalie) return false;
+    const posA = (this.data.playerA as Player).position;
+    const posB = (this.data.playerB as Player).position;
+    return posA !== posB;
+  }
+
+  get title(): string {
+    if (this.isGoalie) return this.translateService.instant('comparison.goalieTitle');
+    const posA = (this.data.playerA as Player).position;
+    const posB = (this.data.playerB as Player).position;
+    if (posA === 'F' && posB === 'F') return this.translateService.instant('comparison.forwardTitle');
+    if (posA === 'D' && posB === 'D') return this.translateService.instant('comparison.defenseTitle');
+    return this.translateService.instant('comparison.playerTitle');
+  }
+
+  getIngressText(isMobile: boolean): string {
+    const nameA = isMobile ? this.getSurname(this.data.playerA.name) : this.data.playerA.name;
+    const nameB = isMobile ? this.getSurname(this.data.playerB.name) : this.data.playerB.name;
+
+    if (this.isMixedPosition) {
+      const posA = this.getPositionAbbreviation((this.data.playerA as Player).position);
+      const posB = this.getPositionAbbreviation((this.data.playerB as Player).position);
+      return `${posA} ${nameA} <-> ${nameB} ${posB}`;
+    }
+
+    return `${nameA} <-> ${nameB}`;
+  }
+
+  private getSurname(fullName: string): string {
+    const parts = fullName.split(' ');
+    return parts[parts.length - 1];
+  }
+
+  private getPositionAbbreviation(position: string | undefined): string {
+    return position === 'D' ? 'P' : 'H';
+  }
+}

--- a/src/app/shared/comparison-dialog/comparison-dialog.component.ts
+++ b/src/app/shared/comparison-dialog/comparison-dialog.component.ts
@@ -1,11 +1,12 @@
 import { Component, inject } from '@angular/core';
 import { AsyncPipe } from '@angular/common';
+import { BreakpointObserver } from '@angular/cdk/layout';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { MatTabsModule } from '@angular/material/tabs';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
-import { take } from 'rxjs';
+import { map, take } from 'rxjs';
 import type { Player, Goalie } from '@services/api.service';
 import { ApiService } from '@services/api.service';
 import { TeamService } from '@services/team.service';
@@ -36,6 +37,9 @@ export class ComparisonDialogComponent {
   readonly data = inject<ComparisonDialogData>(MAT_DIALOG_DATA);
   readonly dialogRef = inject(MatDialogRef<ComparisonDialogComponent>);
   readonly isMobile$ = inject(ViewportService).isMobile$;
+  readonly isNarrow$ = inject(BreakpointObserver)
+    .observe('(max-width: 480px)')
+    .pipe(map((result) => result.matches));
   private translateService = inject(TranslateService);
   private apiService = inject(ApiService);
   private teamService = inject(TeamService);

--- a/src/app/shared/comparison-dialog/comparison-radar/comparison-radar.component.html
+++ b/src/app/shared/comparison-dialog/comparison-radar/comparison-radar.component.html
@@ -1,0 +1,13 @@
+<div class="comparison-radar">
+  <div class="chart-container">
+    <canvas
+      baseChart
+      [type]="'radar'"
+      [data]="radarChartData"
+      [options]="radarChartOptions"
+    ></canvas>
+  </div>
+  <p class="chart-info">
+    {{ 'graphs.radarInfo' | translate }}
+  </p>
+</div>

--- a/src/app/shared/comparison-dialog/comparison-radar/comparison-radar.component.scss
+++ b/src/app/shared/comparison-dialog/comparison-radar/comparison-radar.component.scss
@@ -1,0 +1,43 @@
+.comparison-radar {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 16px 0;
+}
+
+.chart-container {
+  position: relative;
+  width: 100%;
+  height: 420px;
+  margin: 0;
+  padding: 0 8px;
+  box-sizing: border-box;
+  overflow-x: hidden;
+
+  canvas {
+    display: block;
+    max-width: 100%;
+  }
+}
+
+.chart-info {
+  text-align: center;
+  font-size: 0.875rem;
+  color: var(--mat-sys-on-surface-variant);
+  margin: 0;
+  padding: 0 16px;
+  font-style: italic;
+}
+
+@media (max-width: 768px) {
+  .chart-container {
+    height: 330px;
+    padding: 0;
+  }
+}
+
+@media (max-width: 480px) {
+  .chart-container {
+    height: 280px;
+  }
+}

--- a/src/app/shared/comparison-dialog/comparison-radar/comparison-radar.component.spec.ts
+++ b/src/app/shared/comparison-dialog/comparison-radar/comparison-radar.component.spec.ts
@@ -53,6 +53,12 @@ const mockPlayerNoScores: Player = {
   penalties: 2, shots: 20, ppp: 0, shp: 0, hits: 5, blocks: 5,
 };
 
+const mockGoalieNoScores: Goalie = {
+  name: 'No Scores Goalie', score: 50, scoreAdjustedByGames: 50,
+  games: 10, wins: 5, saves: 200, shutouts: 1,
+  goals: 0, assists: 0, points: 0, penalties: 0, ppp: 0, shp: 0,
+};
+
 describe('ComparisonRadarComponent', () => {
   let fixture: ComponentFixture<ComparisonRadarComponent>;
   let component: ComparisonRadarComponent;
@@ -212,6 +218,31 @@ describe('ComparisonRadarComponent', () => {
       const plugins = component.radarChartOptions?.plugins as Record<string, unknown>;
       const legend = plugins['legend'] as { position: string };
       expect(legend.position).toBe('bottom');
+    });
+  });
+
+  describe('goalie radar (no scores)', () => {
+    it('should not build datasets when goalies have no scores', () => {
+      createComponent(mockGoalieNoScores, mockGoalieNoScores);
+      expect(component.radarChartData.datasets.length).toBe(0);
+    });
+  });
+
+  describe('tooltip callback', () => {
+    it('should format tooltip label as "name: value/100"', () => {
+      createComponent(mockPlayerA, mockPlayerB);
+      const plugins = component.radarChartOptions?.plugins as Record<string, any>;
+      const labelFn = plugins['tooltip'].callbacks.label;
+      const result = labelFn({ dataset: { label: 'Mikko Rantanen' }, parsed: { r: 80 } });
+      expect(result).toBe('Mikko Rantanen: 80/100');
+    });
+
+    it('should handle missing dataset label gracefully', () => {
+      createComponent(mockPlayerA, mockPlayerB);
+      const plugins = component.radarChartOptions?.plugins as Record<string, any>;
+      const labelFn = plugins['tooltip'].callbacks.label;
+      const result = labelFn({ dataset: {}, parsed: { r: 50 } });
+      expect(result).toBe(': 50/100');
     });
   });
 

--- a/src/app/shared/comparison-dialog/comparison-radar/comparison-radar.component.spec.ts
+++ b/src/app/shared/comparison-dialog/comparison-radar/comparison-radar.component.spec.ts
@@ -1,0 +1,229 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { TranslateModule, TranslateService } from '@ngx-translate/core';
+import { ComparisonRadarComponent } from './comparison-radar.component';
+import type { Player, Goalie } from '@services/api.service';
+
+const mockPlayerA: Player = {
+  name: 'Mikko Rantanen', position: 'F', score: 100, scoreAdjustedByGames: 93.1,
+  games: 427, goals: 193, assists: 254, points: 447, plusMinus: 10,
+  penalties: 256, shots: 1182, ppp: 165, shp: 5, hits: 276, blocks: 41,
+  scores: { goals: 80, assists: 75, points: 85, plusMinus: 50, penalties: 60, shots: 70, ppp: 90, shp: 10, hits: 40, blocks: 20 },
+};
+
+const mockPlayerB: Player = {
+  name: 'Aaron Ekblad', position: 'D', score: 94.31, scoreAdjustedByGames: 67.22,
+  games: 540, goals: 100, assists: 188, points: 288, plusMinus: 40,
+  penalties: 355, shots: 1413, ppp: 94, shp: 6, hits: 582, blocks: 574,
+  scores: { goals: 60, assists: 70, points: 65, plusMinus: 70, penalties: 55, shots: 80, ppp: 50, shp: 30, hits: 85, blocks: 90 },
+};
+
+const mockGoalieCombinedA: Goalie = {
+  name: 'Juuse Saros', score: 100, scoreAdjustedByGames: 90,
+  games: 200, wins: 120, saves: 5000, shutouts: 15,
+  goals: 0, assists: 2, points: 2, penalties: 4, ppp: 0, shp: 0,
+  scores: { wins: 85, saves: 90, shutouts: 70 },
+};
+
+const mockGoalieCombinedB: Goalie = {
+  name: 'Andrei Vasilevskiy', score: 95, scoreAdjustedByGames: 85,
+  games: 250, wins: 150, saves: 6000, shutouts: 20,
+  goals: 0, assists: 5, points: 5, penalties: 6, ppp: 0, shp: 0,
+  scores: { wins: 90, saves: 80, shutouts: 75 },
+};
+
+const mockGoalieSeasonA: Goalie = {
+  name: 'Juuse Saros', score: 100, scoreAdjustedByGames: 90,
+  games: 60, wins: 35, saves: 1800, shutouts: 5,
+  goals: 0, assists: 1, points: 1, penalties: 2, ppp: 0, shp: 0,
+  gaa: '2.10', savePercent: '0.925',
+  scores: { wins: 85, saves: 90, shutouts: 70, gaa: 80, savePercent: 75 },
+};
+
+const mockGoalieSeasonB: Goalie = {
+  name: 'Andrei Vasilevskiy', score: 95, scoreAdjustedByGames: 85,
+  games: 55, wins: 30, saves: 1600, shutouts: 3,
+  goals: 0, assists: 2, points: 2, penalties: 4, ppp: 0, shp: 0,
+  gaa: '2.50', savePercent: '0.910',
+  scores: { wins: 90, saves: 80, shutouts: 75, gaa: 60, savePercent: 65 },
+};
+
+const mockPlayerNoScores: Player = {
+  name: 'No Scores Player', position: 'F', score: 50, scoreAdjustedByGames: 50,
+  games: 10, goals: 5, assists: 5, points: 10, plusMinus: 0,
+  penalties: 2, shots: 20, ppp: 0, shp: 0, hits: 5, blocks: 5,
+};
+
+describe('ComparisonRadarComponent', () => {
+  let fixture: ComponentFixture<ComparisonRadarComponent>;
+  let component: ComparisonRadarComponent;
+  let translateService: TranslateService;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ComparisonRadarComponent, TranslateModule.forRoot()],
+    }).compileComponents();
+
+    translateService = TestBed.inject(TranslateService);
+    translateService.setTranslation('fi', {
+      tableColumn: {
+        goals: 'Maalit',
+        assists: 'Syotot',
+        points: 'Pisteet',
+        plusMinus: 'Plusmiinus',
+        penalties: 'Jaahyt',
+        shots: 'Laukaukset',
+        ppp: 'YV-pisteet',
+        shp: 'AV-pisteet',
+        hits: 'Taklaukset',
+        blocks: 'Blokit',
+        wins: 'Voitot',
+        saves: 'Torjunnat',
+        shutouts: 'Nollat',
+        gaa: 'GAA',
+        savePercent: 'Torjunta%',
+      },
+      graphs: {
+        radarInfo: 'Joukkueen sisainen vertailuarvo 0-100 valilla',
+      },
+    });
+    translateService.use('fi');
+  });
+
+  function createComponent(playerA: Player | Goalie, playerB: Player | Goalie): void {
+    fixture = TestBed.createComponent(ComparisonRadarComponent);
+    component = fixture.componentInstance;
+    component.playerA = playerA;
+    component.playerB = playerB;
+    fixture.detectChanges();
+  }
+
+  afterEach(() => {
+    fixture?.destroy();
+  });
+
+  describe('player radar', () => {
+    it('should build chart data with two datasets', () => {
+      createComponent(mockPlayerA, mockPlayerB);
+      expect(component.radarChartData.datasets.length).toBe(2);
+    });
+
+    it('should have 10 labels for player stats', () => {
+      createComponent(mockPlayerA, mockPlayerB);
+      expect(component.radarChartData.labels!.length).toBe(10);
+    });
+
+    it('should use translated labels', () => {
+      createComponent(mockPlayerA, mockPlayerB);
+      const labels = component.radarChartData.labels as string[];
+      expect(labels).toContain('Maalit');
+      expect(labels).toContain('Syotot');
+      expect(labels).toContain('Pisteet');
+    });
+
+    it('should use blue color for Player A', () => {
+      createComponent(mockPlayerA, mockPlayerB);
+      const datasetA = component.radarChartData.datasets[0];
+      expect(datasetA.backgroundColor).toBe('rgba(25, 118, 210, 0.3)');
+      expect(datasetA.borderColor).toBe('#1976d2');
+    });
+
+    it('should use orange color for Player B', () => {
+      createComponent(mockPlayerA, mockPlayerB);
+      const datasetB = component.radarChartData.datasets[1];
+      expect(datasetB.backgroundColor).toBe('rgba(255, 152, 0, 0.3)');
+      expect(datasetB.borderColor).toBe('#ff9800');
+    });
+
+    it('should use player names as dataset labels', () => {
+      createComponent(mockPlayerA, mockPlayerB);
+      expect(component.radarChartData.datasets[0].label).toBe('Mikko Rantanen');
+      expect(component.radarChartData.datasets[1].label).toBe('Aaron Ekblad');
+    });
+
+    it('should populate correct score values for Player A', () => {
+      createComponent(mockPlayerA, mockPlayerB);
+      const dataA = component.radarChartData.datasets[0].data;
+      // Order: goals, assists, points, plusMinus, penalties, shots, ppp, shp, hits, blocks
+      expect(dataA).toEqual([80, 75, 85, 50, 60, 70, 90, 10, 40, 20]);
+    });
+
+    it('should populate correct score values for Player B', () => {
+      createComponent(mockPlayerA, mockPlayerB);
+      const dataB = component.radarChartData.datasets[1].data;
+      expect(dataB).toEqual([60, 70, 65, 70, 55, 80, 50, 30, 85, 90]);
+    });
+
+    it('should not build datasets when players have no scores', () => {
+      createComponent(mockPlayerNoScores, mockPlayerNoScores);
+      expect(component.radarChartData.datasets.length).toBe(0);
+    });
+  });
+
+  describe('goalie radar (combined)', () => {
+    it('should build chart data with two datasets for goalies', () => {
+      createComponent(mockGoalieCombinedA, mockGoalieCombinedB);
+      expect(component.radarChartData.datasets.length).toBe(2);
+    });
+
+    it('should have 3 labels for combined goalie stats', () => {
+      createComponent(mockGoalieCombinedA, mockGoalieCombinedB);
+      expect(component.radarChartData.labels!.length).toBe(3);
+    });
+
+    it('should use correct stat keys for combined goalies', () => {
+      createComponent(mockGoalieCombinedA, mockGoalieCombinedB);
+      const labels = component.radarChartData.labels as string[];
+      expect(labels).toEqual(['Voitot', 'Torjunnat', 'Nollat']);
+    });
+  });
+
+  describe('goalie radar (season)', () => {
+    it('should have 5 labels for season goalie stats', () => {
+      createComponent(mockGoalieSeasonA, mockGoalieSeasonB);
+      expect(component.radarChartData.labels!.length).toBe(5);
+    });
+
+    it('should include gaa and savePercent labels for season goalies', () => {
+      createComponent(mockGoalieSeasonA, mockGoalieSeasonB);
+      const labels = component.radarChartData.labels as string[];
+      expect(labels).toContain('GAA');
+      expect(labels).toContain('Torjunta%');
+    });
+  });
+
+  describe('chart options', () => {
+    it('should set radar scale min to 0 and max to 100', () => {
+      createComponent(mockPlayerA, mockPlayerB);
+      const scales = component.radarChartOptions?.scales as Record<string, unknown>;
+      const r = scales['r'] as { min: number; max: number };
+      expect(r.min).toBe(0);
+      expect(r.max).toBe(100);
+    });
+
+    it('should set tick step size to 20', () => {
+      createComponent(mockPlayerA, mockPlayerB);
+      const scales = component.radarChartOptions?.scales as Record<string, unknown>;
+      const r = scales['r'] as { ticks: { stepSize: number } };
+      expect(r.ticks.stepSize).toBe(20);
+    });
+
+    it('should show legend at bottom', () => {
+      createComponent(mockPlayerA, mockPlayerB);
+      const plugins = component.radarChartOptions?.plugins as Record<string, unknown>;
+      const legend = plugins['legend'] as { position: string };
+      expect(legend.position).toBe('bottom');
+    });
+  });
+
+  describe('isGoalie', () => {
+    it('should return true for goalies', () => {
+      createComponent(mockGoalieCombinedA, mockGoalieCombinedB);
+      expect(component.isGoalie).toBeTrue();
+    });
+
+    it('should return false for players', () => {
+      createComponent(mockPlayerA, mockPlayerB);
+      expect(component.isGoalie).toBeFalse();
+    });
+  });
+});

--- a/src/app/shared/comparison-dialog/comparison-radar/comparison-radar.component.ts
+++ b/src/app/shared/comparison-dialog/comparison-radar/comparison-radar.component.ts
@@ -1,0 +1,241 @@
+import { DOCUMENT } from '@angular/common';
+import { Component, Input, OnInit, inject } from '@angular/core';
+import { BaseChartDirective, provideCharts, withDefaultRegisterables } from 'ng2-charts';
+import type { ChartConfiguration, ChartData } from 'chart.js';
+import { TranslateModule, TranslateService } from '@ngx-translate/core';
+import type { Player, Goalie, PlayerScores } from '@services/api.service';
+
+@Component({
+  selector: 'app-comparison-radar',
+  imports: [BaseChartDirective, TranslateModule],
+  templateUrl: './comparison-radar.component.html',
+  styleUrl: './comparison-radar.component.scss',
+  providers: [provideCharts(withDefaultRegisterables())],
+})
+export class ComparisonRadarComponent implements OnInit {
+  private document = inject(DOCUMENT);
+  private translateService = inject(TranslateService);
+
+  @Input({ required: true }) playerA!: Player | Goalie;
+  @Input({ required: true }) playerB!: Player | Goalie;
+
+  radarChartData: ChartData<'radar'> = { labels: [], datasets: [] };
+  radarChartOptions: ChartConfiguration<'radar'>['options'] = {};
+
+  get isGoalie(): boolean {
+    return 'wins' in this.playerA;
+  }
+
+  ngOnInit(): void {
+    this.buildRadarChartOptions();
+    this.buildRadarChartData();
+  }
+
+  private buildRadarChartOptions(): void {
+    const textColor = this.resolveCssColorVar('--mat-sys-on-surface', '#1f1f1f');
+    const gridColor = this.resolveCssColorVar('--mat-sys-outline-variant', 'rgba(0,0,0,0.2)');
+    const tooltipBg = this.resolveCssColorVar(
+      '--mat-sys-surface-container-high',
+      'rgba(0,0,0,0.8)',
+      'backgroundColor',
+    );
+
+    this.radarChartOptions = {
+      responsive: true,
+      maintainAspectRatio: false,
+      scales: {
+        r: {
+          min: 0,
+          max: 100,
+          ticks: {
+            stepSize: 20,
+            color: textColor,
+            callback: (value) => `${value}`,
+            backdropColor: 'transparent',
+            font: { size: 11 },
+          },
+          grid: {
+            color: gridColor,
+          },
+          angleLines: {
+            color: gridColor,
+          },
+          pointLabels: {
+            color: textColor,
+            font: { size: 12 },
+          },
+        },
+      },
+      plugins: {
+        legend: {
+          position: 'bottom',
+          labels: {
+            color: textColor,
+          },
+        },
+        tooltip: {
+          callbacks: {
+            label: (context: any) => {
+              const label = context.dataset.label || '';
+              const value = context.parsed.r;
+              return `${label}: ${value}/100`;
+            },
+          },
+          titleColor: textColor,
+          bodyColor: textColor,
+          footerColor: textColor,
+          backgroundColor: tooltipBg,
+          borderColor: gridColor,
+          borderWidth: 1,
+        } as any,
+      },
+    };
+  }
+
+  private buildRadarChartData(): void {
+    if (this.isGoalie) {
+      this.buildGoalieRadarData();
+    } else {
+      this.buildPlayerRadarData();
+    }
+  }
+
+  private buildPlayerRadarData(): void {
+    const playerA = this.playerA as Player;
+    const playerB = this.playerB as Player;
+
+    const scoresA = playerA.scores;
+    const scoresB = playerB.scores;
+
+    if (!scoresA || !scoresB) return;
+
+    const statKeys: (keyof PlayerScores)[] = [
+      'goals', 'assists', 'points', 'plusMinus', 'penalties',
+      'shots', 'ppp', 'shp', 'hits', 'blocks',
+    ];
+
+    const labels = statKeys.map((key) =>
+      this.translateService.instant(`tableColumn.${key}`),
+    );
+
+    const dataA = statKeys.map((key) => scoresA[key]);
+    const dataB = statKeys.map((key) => scoresB[key]);
+
+    this.radarChartData = {
+      labels,
+      datasets: [
+        {
+          label: playerA.name,
+          data: dataA,
+          fill: true,
+          backgroundColor: 'rgba(25, 118, 210, 0.3)',
+          borderColor: '#1976d2',
+          pointBackgroundColor: '#1976d2',
+          pointBorderColor: '#fff',
+          pointHoverBackgroundColor: '#fff',
+          pointHoverBorderColor: '#1976d2',
+          pointRadius: 4,
+          pointHoverRadius: 6,
+        },
+        {
+          label: playerB.name,
+          data: dataB,
+          fill: true,
+          backgroundColor: 'rgba(255, 152, 0, 0.3)',
+          borderColor: '#ff9800',
+          pointBackgroundColor: '#ff9800',
+          pointBorderColor: '#fff',
+          pointHoverBackgroundColor: '#fff',
+          pointHoverBorderColor: '#ff9800',
+          pointRadius: 4,
+          pointHoverRadius: 6,
+        },
+      ],
+    };
+  }
+
+  private buildGoalieRadarData(): void {
+    const goalieA = this.playerA as Goalie;
+    const goalieB = this.playerB as Goalie;
+
+    if (!goalieA.scores || !goalieB.scores) return;
+
+    // Check if season-specific stats are available
+    const hasExtendedStats = 'gaa' in goalieA.scores;
+
+    const statKeys = hasExtendedStats
+      ? ['wins', 'saves', 'shutouts', 'gaa', 'savePercent']
+      : ['wins', 'saves', 'shutouts'];
+
+    const labels = statKeys.map((key) =>
+      this.translateService.instant(`tableColumn.${key}`),
+    );
+
+    const dataA = statKeys.map((key) => (goalieA.scores as Record<string, number>)[key]);
+    const dataB = statKeys.map((key) => (goalieB.scores as Record<string, number>)[key]);
+
+    this.radarChartData = {
+      labels,
+      datasets: [
+        {
+          label: goalieA.name,
+          data: dataA,
+          fill: true,
+          backgroundColor: 'rgba(25, 118, 210, 0.3)',
+          borderColor: '#1976d2',
+          pointBackgroundColor: '#1976d2',
+          pointBorderColor: '#fff',
+          pointHoverBackgroundColor: '#fff',
+          pointHoverBorderColor: '#1976d2',
+          pointRadius: 4,
+          pointHoverRadius: 6,
+        },
+        {
+          label: goalieB.name,
+          data: dataB,
+          fill: true,
+          backgroundColor: 'rgba(255, 152, 0, 0.3)',
+          borderColor: '#ff9800',
+          pointBackgroundColor: '#ff9800',
+          pointBorderColor: '#fff',
+          pointHoverBackgroundColor: '#fff',
+          pointHoverBorderColor: '#ff9800',
+          pointRadius: 4,
+          pointHoverRadius: 6,
+        },
+      ],
+    };
+  }
+
+  private resolveCssColorVar(
+    name: string,
+    fallback: string,
+    cssProperty: 'color' | 'backgroundColor' = 'color',
+  ): string {
+    try {
+      const body = this.document.body;
+      if (!body) return fallback;
+
+      const probe = this.document.createElement('span');
+      probe.setAttribute('aria-hidden', 'true');
+      probe.style.position = 'absolute';
+      probe.style.width = '0';
+      probe.style.height = '0';
+      probe.style.overflow = 'hidden';
+
+      if (cssProperty === 'backgroundColor') {
+        probe.style.backgroundColor = `var(${name})`;
+      } else {
+        probe.style.color = `var(${name})`;
+      }
+
+      body.appendChild(probe);
+      const computed = getComputedStyle(probe)[cssProperty];
+      probe.remove();
+
+      return computed?.trim() ? computed.trim() : fallback;
+    } catch {
+      return fallback;
+    }
+  }
+}

--- a/src/app/shared/comparison-dialog/comparison-stats/comparison-stats.component.html
+++ b/src/app/shared/comparison-dialog/comparison-stats/comparison-stats.component.html
@@ -1,0 +1,19 @@
+<div class="comparison-stats" [class.mobile]="isMobile">
+  @for (row of statRows; track row.key) {
+    @if (isMobile) {
+      <div class="stat-row-mobile">
+        <div class="stat-label">{{ row.label }}</div>
+        <div class="stat-values">
+          <span class="value-a" [class.bold]="row.boldA">{{ row.valueA }}</span>
+          <span class="value-b" [class.bold]="row.boldB">{{ row.valueB }}</span>
+        </div>
+      </div>
+    } @else {
+      <div class="stat-row-desktop">
+        <span class="value-a" [class.bold]="row.boldA">{{ row.valueA }}</span>
+        <span class="stat-label">{{ row.label }}</span>
+        <span class="value-b" [class.bold]="row.boldB">{{ row.valueB }}</span>
+      </div>
+    }
+  }
+</div>

--- a/src/app/shared/comparison-dialog/comparison-stats/comparison-stats.component.scss
+++ b/src/app/shared/comparison-dialog/comparison-stats/comparison-stats.component.scss
@@ -8,38 +8,49 @@
 
 .bold {
   font-weight: bold;
+  color: var(--mat-sys-primary);
 }
 
 // Desktop layout
 .stat-row-desktop {
   display: grid;
   grid-template-columns: 1fr auto 1fr;
-  align-items: center;
-  padding: 8px 16px;
+  align-items: stretch;
   border-bottom: 1px solid var(--mat-sys-outline-variant, rgba(0, 0, 0, 0.12));
 
   &:last-child {
     border-bottom: none;
   }
 
-  .value-a {
-    text-align: right;
-    padding-right: 24px;
+  .value-a,
+  .value-b {
+    display: flex;
+    align-items: center;
+    height: 48px;
+    background: var(--mat-sys-surface);
     font-variant-numeric: tabular-nums;
   }
 
+  .value-a {
+    justify-content: flex-end;
+    padding-right: 24px;
+  }
+
   .stat-label {
-    text-align: center;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 48px;
     font-size: 0.875rem;
     color: var(--mat-sys-on-surface-variant);
     white-space: nowrap;
     min-width: 160px;
+    padding: 0 8px;
   }
 
   .value-b {
-    text-align: left;
+    justify-content: flex-start;
     padding-left: 24px;
-    font-variant-numeric: tabular-nums;
   }
 }
 

--- a/src/app/shared/comparison-dialog/comparison-stats/comparison-stats.component.scss
+++ b/src/app/shared/comparison-dialog/comparison-stats/comparison-stats.component.scss
@@ -1,0 +1,93 @@
+.comparison-stats {
+  padding: 16px;
+  max-height: calc(var(--app-height, 100vh) - 250px);
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+  overscroll-behavior: contain;
+}
+
+.bold {
+  font-weight: bold;
+}
+
+// Desktop layout
+.stat-row-desktop {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  padding: 8px 16px;
+  border-bottom: 1px solid var(--mat-sys-outline-variant, rgba(0, 0, 0, 0.12));
+
+  &:last-child {
+    border-bottom: none;
+  }
+
+  .value-a {
+    text-align: right;
+    padding-right: 24px;
+    font-variant-numeric: tabular-nums;
+  }
+
+  .stat-label {
+    text-align: center;
+    font-size: 0.875rem;
+    color: var(--mat-sys-on-surface-variant);
+    white-space: nowrap;
+    min-width: 160px;
+  }
+
+  .value-b {
+    text-align: left;
+    padding-left: 24px;
+    font-variant-numeric: tabular-nums;
+  }
+}
+
+// Mobile layout
+.stat-row-mobile {
+  padding: 10px 16px;
+  border-bottom: 1px solid var(--mat-sys-outline-variant, rgba(0, 0, 0, 0.12));
+
+  &:last-child {
+    border-bottom: none;
+  }
+
+  .stat-label {
+    text-align: center;
+    font-size: 0.8125rem;
+    color: var(--mat-sys-on-surface-variant);
+    margin-bottom: 4px;
+  }
+
+  .stat-values {
+    display: flex;
+    justify-content: space-between;
+    padding: 0 16px;
+
+    .value-a,
+    .value-b {
+      font-variant-numeric: tabular-nums;
+    }
+  }
+}
+
+// Scrollbar styling
+.comparison-stats {
+  &::-webkit-scrollbar {
+    width: 8px;
+  }
+
+  &::-webkit-scrollbar-track {
+    background: var(--mat-sys-surface-container);
+    border-radius: 4px;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background: var(--mat-sys-outline);
+    border-radius: 4px;
+
+    &:hover {
+      background: var(--mat-sys-on-surface-variant);
+    }
+  }
+}

--- a/src/app/shared/comparison-dialog/comparison-stats/comparison-stats.component.spec.ts
+++ b/src/app/shared/comparison-dialog/comparison-stats/comparison-stats.component.spec.ts
@@ -1,0 +1,224 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { TranslateModule, TranslateService } from '@ngx-translate/core';
+import { ComparisonStatsComponent } from './comparison-stats.component';
+import type { Player, Goalie } from '@services/api.service';
+
+const mockPlayerA: Player = {
+  name: 'Mikko Rantanen', position: 'F', score: 100, scoreAdjustedByGames: 93.1,
+  games: 540, goals: 193, assists: 254, points: 447, plusMinus: 10,
+  penalties: 256, shots: 1182, ppp: 165, shp: 5, hits: 276, blocks: 41,
+};
+
+const mockPlayerB: Player = {
+  name: 'Aaron Ekblad', position: 'D', score: 94.31, scoreAdjustedByGames: 67.22,
+  games: 427, goals: 100, assists: 188, points: 288, plusMinus: 40,
+  penalties: 355, shots: 1413, ppp: 94, shp: 6, hits: 582, blocks: 574,
+};
+
+const mockGoalieCombinedA: Goalie = {
+  name: 'Juuse Saros', score: 100, scoreAdjustedByGames: 90,
+  games: 200, wins: 120, saves: 5000, shutouts: 15,
+  goals: 0, assists: 2, points: 2, penalties: 4, ppp: 0, shp: 0,
+};
+
+const mockGoalieCombinedB: Goalie = {
+  name: 'Andrei Vasilevskiy', score: 95, scoreAdjustedByGames: 85,
+  games: 250, wins: 150, saves: 6000, shutouts: 20,
+  goals: 0, assists: 5, points: 5, penalties: 6, ppp: 0, shp: 0,
+};
+
+const mockGoalieSeasonA: Goalie = {
+  name: 'Juuse Saros', score: 100, scoreAdjustedByGames: 90,
+  games: 60, wins: 35, saves: 1800, shutouts: 5,
+  goals: 0, assists: 1, points: 1, penalties: 2, ppp: 0, shp: 0,
+  gaa: '2.10', savePercent: '0.925',
+};
+
+const mockGoalieSeasonB: Goalie = {
+  name: 'Andrei Vasilevskiy', score: 95, scoreAdjustedByGames: 85,
+  games: 55, wins: 30, saves: 1600, shutouts: 3,
+  goals: 0, assists: 2, points: 2, penalties: 4, ppp: 0, shp: 0,
+  gaa: '2.50', savePercent: '0.910',
+};
+
+describe('ComparisonStatsComponent', () => {
+  let fixture: ComponentFixture<ComparisonStatsComponent>;
+  let component: ComparisonStatsComponent;
+  let translateService: TranslateService;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ComparisonStatsComponent, TranslateModule.forRoot()],
+    }).compileComponents();
+
+    translateService = TestBed.inject(TranslateService);
+    translateService.setTranslation('fi', {
+      tableColumn: {
+        score: 'FR',
+        scoreAdjustedByGames: 'FR/O',
+        games: 'Ottelut',
+        goals: 'Maalit',
+        assists: 'Syotot',
+        points: 'Pisteet',
+        plusMinus: 'Plusmiinus',
+        penalties: 'Jaahyt',
+        shots: 'Laukaukset',
+        ppp: 'YV-pisteet',
+        shp: 'AV-pisteet',
+        hits: 'Taklaukset',
+        blocks: 'Blokit',
+        wins: 'Voitot',
+        saves: 'Torjunnat',
+        shutouts: 'Nollat',
+        gaa: 'GAA',
+        savePercent: 'Torjunta%',
+      },
+    });
+    translateService.use('fi');
+  });
+
+  function createComponent(playerA: Player | Goalie, playerB: Player | Goalie, isMobile = false): void {
+    fixture = TestBed.createComponent(ComparisonStatsComponent);
+    component = fixture.componentInstance;
+    component.playerA = playerA;
+    component.playerB = playerB;
+    component.isMobile = isMobile;
+    fixture.detectChanges();
+  }
+
+  afterEach(() => {
+    fixture?.destroy();
+  });
+
+  describe('player stats', () => {
+    it('should render all player stat rows', () => {
+      createComponent(mockPlayerA, mockPlayerB);
+      // PLAYER_STAT_COLUMNS: score, scoreAdjustedByGames, games, goals, assists, points, plusMinus, penalties, shots, ppp, shp, hits, blocks
+      expect(component.statRows.length).toBe(13);
+    });
+
+    it('should have correct stat keys for players', () => {
+      createComponent(mockPlayerA, mockPlayerB);
+      const keys = component.statRows.map((r) => r.key);
+      expect(keys).toContain('score');
+      expect(keys).toContain('goals');
+      expect(keys).toContain('assists');
+      expect(keys).toContain('hits');
+      expect(keys).toContain('blocks');
+      expect(keys).not.toContain('name');
+      expect(keys).not.toContain('position');
+    });
+
+    it('should bold the higher value', () => {
+      createComponent(mockPlayerA, mockPlayerB);
+      // Player A has score=100, Player B has score=94.31
+      const scoreRow = component.statRows.find((r) => r.key === 'score')!;
+      expect(scoreRow.boldA).toBeTrue();
+      expect(scoreRow.boldB).toBeFalse();
+    });
+
+    it('should bold Player B when they have higher value', () => {
+      createComponent(mockPlayerA, mockPlayerB);
+      // Player A has hits=276, Player B has hits=582
+      const hitsRow = component.statRows.find((r) => r.key === 'hits')!;
+      expect(hitsRow.boldA).toBeFalse();
+      expect(hitsRow.boldB).toBeTrue();
+    });
+
+    it('should not bold either value when they are equal', () => {
+      const equalA = { ...mockPlayerA, goals: 100 };
+      const equalB = { ...mockPlayerB, goals: 100 };
+      createComponent(equalA, equalB);
+      const goalsRow = component.statRows.find((r) => r.key === 'goals')!;
+      expect(goalsRow.boldA).toBeFalse();
+      expect(goalsRow.boldB).toBeFalse();
+    });
+  });
+
+  describe('goalie stats (combined)', () => {
+    it('should render goalie combined stat rows', () => {
+      createComponent(mockGoalieCombinedA, mockGoalieCombinedB);
+      // GOALIE_STAT_COLUMNS: score, scoreAdjustedByGames, games, wins, saves, shutouts, goals, assists, points, penalties, ppp, shp
+      expect(component.statRows.length).toBe(12);
+    });
+
+    it('should not include gaa or savePercent for combined goalies', () => {
+      createComponent(mockGoalieCombinedA, mockGoalieCombinedB);
+      const keys = component.statRows.map((r) => r.key);
+      expect(keys).not.toContain('gaa');
+      expect(keys).not.toContain('savePercent');
+    });
+  });
+
+  describe('goalie stats (season)', () => {
+    it('should render goalie season stat rows including gaa and savePercent', () => {
+      createComponent(mockGoalieSeasonA, mockGoalieSeasonB);
+      // GOALIE_SEASON_STAT_COLUMNS: score, scoreAdjustedByGames, games, wins, saves, gaa, savePercent, shutouts, goals, assists, points, penalties, ppp, shp
+      expect(component.statRows.length).toBe(14);
+    });
+
+    it('should include gaa and savePercent for season goalies', () => {
+      createComponent(mockGoalieSeasonA, mockGoalieSeasonB);
+      const keys = component.statRows.map((r) => r.key);
+      expect(keys).toContain('gaa');
+      expect(keys).toContain('savePercent');
+    });
+
+    it('should bold the LOWER gaa value (lower is better)', () => {
+      createComponent(mockGoalieSeasonA, mockGoalieSeasonB);
+      // Goalie A: gaa=2.10, Goalie B: gaa=2.50; lower is better
+      const gaaRow = component.statRows.find((r) => r.key === 'gaa')!;
+      expect(gaaRow.boldA).toBeTrue();
+      expect(gaaRow.boldB).toBeFalse();
+    });
+
+    it('should bold higher savePercent (higher is better)', () => {
+      createComponent(mockGoalieSeasonA, mockGoalieSeasonB);
+      // Goalie A: savePercent=0.925, Goalie B: savePercent=0.910
+      const spRow = component.statRows.find((r) => r.key === 'savePercent')!;
+      expect(spRow.boldA).toBeTrue();
+      expect(spRow.boldB).toBeFalse();
+    });
+  });
+
+  describe('desktop layout', () => {
+    it('should render desktop rows when isMobile is false', () => {
+      createComponent(mockPlayerA, mockPlayerB, false);
+      const el: HTMLElement = fixture.nativeElement;
+      const desktopRows = el.querySelectorAll('.stat-row-desktop');
+      expect(desktopRows.length).toBe(13);
+      expect(el.querySelectorAll('.stat-row-mobile').length).toBe(0);
+    });
+  });
+
+  describe('mobile layout', () => {
+    it('should render mobile rows when isMobile is true', () => {
+      createComponent(mockPlayerA, mockPlayerB, true);
+      const el: HTMLElement = fixture.nativeElement;
+      const mobileRows = el.querySelectorAll('.stat-row-mobile');
+      expect(mobileRows.length).toBe(13);
+      expect(el.querySelectorAll('.stat-row-desktop').length).toBe(0);
+    });
+  });
+
+  describe('bold CSS class', () => {
+    it('should apply bold class to the higher value element', () => {
+      createComponent(mockPlayerA, mockPlayerB, false);
+      const el: HTMLElement = fixture.nativeElement;
+      // score: A=100 > B=94.31, so value-a should be bold
+      const firstRow = el.querySelector('.stat-row-desktop')!;
+      const valueA = firstRow.querySelector('.value-a')!;
+      const valueB = firstRow.querySelector('.value-b')!;
+      expect(valueA.classList.contains('bold')).toBeTrue();
+      expect(valueB.classList.contains('bold')).toBeFalse();
+    });
+  });
+
+  describe('translated labels', () => {
+    it('should use translated labels for stat rows', () => {
+      createComponent(mockPlayerA, mockPlayerB);
+      const scoreRow = component.statRows.find((r) => r.key === 'score')!;
+      expect(scoreRow.label).toBe('FR');
+    });
+  });
+});

--- a/src/app/shared/comparison-dialog/comparison-stats/comparison-stats.component.spec.ts
+++ b/src/app/shared/comparison-dialog/comparison-stats/comparison-stats.component.spec.ts
@@ -181,6 +181,15 @@ describe('ComparisonStatsComponent', () => {
     });
   });
 
+  describe('missing stat values', () => {
+    it('should show dash for undefined stat values', () => {
+      const playerMissingStat = { ...mockPlayerA, hits: undefined } as unknown as Player;
+      createComponent(playerMissingStat, mockPlayerB);
+      const hitsRow = component.statRows.find((r) => r.key === 'hits')!;
+      expect(hitsRow.valueA).toBe('-');
+    });
+  });
+
   describe('desktop layout', () => {
     it('should render desktop rows when isMobile is false', () => {
       createComponent(mockPlayerA, mockPlayerB, false);

--- a/src/app/shared/comparison-dialog/comparison-stats/comparison-stats.component.ts
+++ b/src/app/shared/comparison-dialog/comparison-stats/comparison-stats.component.ts
@@ -1,0 +1,91 @@
+import { Component, Input, OnInit, inject } from '@angular/core';
+import { TranslateModule, TranslateService } from '@ngx-translate/core';
+import type { Player, Goalie } from '@services/api.service';
+import {
+  PLAYER_STAT_COLUMNS,
+  GOALIE_STAT_COLUMNS,
+  GOALIE_SEASON_STAT_COLUMNS,
+} from '@shared/table-columns';
+
+export type StatRow = {
+  key: string;
+  label: string;
+  valueA: number | string;
+  valueB: number | string;
+  boldA: boolean;
+  boldB: boolean;
+};
+
+@Component({
+  selector: 'app-comparison-stats',
+  imports: [TranslateModule],
+  templateUrl: './comparison-stats.component.html',
+  styleUrl: './comparison-stats.component.scss',
+})
+export class ComparisonStatsComponent implements OnInit {
+  private translateService = inject(TranslateService);
+
+  @Input({ required: true }) playerA!: Player | Goalie;
+  @Input({ required: true }) playerB!: Player | Goalie;
+  @Input() isMobile = false;
+
+  statRows: StatRow[] = [];
+
+  get isGoalie(): boolean {
+    return 'wins' in this.playerA;
+  }
+
+  ngOnInit(): void {
+    this.buildStatRows();
+  }
+
+  private buildStatRows(): void {
+    const columns = this.getStatColumns();
+
+    this.statRows = columns.map((key) => {
+      const valueA = this.getStatValue(this.playerA, key);
+      const valueB = this.getStatValue(this.playerB, key);
+      const label = this.translateService.instant(`tableColumn.${key}`);
+      const { boldA, boldB } = this.computeBold(key, valueA, valueB);
+
+      return { key, label, valueA, valueB, boldA, boldB };
+    });
+  }
+
+  private getStatColumns(): string[] {
+    if (!this.isGoalie) {
+      return PLAYER_STAT_COLUMNS;
+    }
+
+    // Check if goalie has season-specific stats (gaa, savePercent)
+    const hasSeasonStats = 'gaa' in this.playerA && this.playerA.gaa !== undefined;
+    return hasSeasonStats ? GOALIE_SEASON_STAT_COLUMNS : GOALIE_STAT_COLUMNS;
+  }
+
+  private getStatValue(player: Player | Goalie, key: string): number | string {
+    const value = (player as Record<string, unknown>)[key];
+    if (value === undefined || value === null) return '-';
+    return value as number | string;
+  }
+
+  private computeBold(
+    key: string,
+    valueA: number | string,
+    valueB: number | string,
+  ): { boldA: boolean; boldB: boolean } {
+    const numA = typeof valueA === 'number' ? valueA : parseFloat(String(valueA));
+    const numB = typeof valueB === 'number' ? valueB : parseFloat(String(valueB));
+
+    if (isNaN(numA) || isNaN(numB) || numA === numB) {
+      return { boldA: false, boldB: false };
+    }
+
+    // GAA: lower is better
+    if (key === 'gaa') {
+      return { boldA: numA < numB, boldB: numB < numA };
+    }
+
+    // All other stats: higher is better
+    return { boldA: numA > numB, boldB: numB > numA };
+  }
+}

--- a/src/app/shared/stats-table/stats-table.component.html
+++ b/src/app/shared/stats-table/stats-table.component.html
@@ -13,6 +13,19 @@
 
   <div class="table-container">
     <table mat-table [dataSource]="dataSource" matSort matSortStart="desc" [attr.aria-describedby]="instructionsId">
+      <!-- Compare checkbox column -->
+      <ng-container matColumnDef="compare">
+        <th mat-header-cell *matHeaderCellDef></th>
+        <td mat-cell *matCellDef="let row" (click)="$event.stopPropagation()">
+          <mat-checkbox
+            [checked]="isCompareSelected(row)"
+            [disabled]="!isCompareSelected(row) && !(canSelectMore$ | async)"
+            (change)="onCompareToggle(row)"
+            [attr.aria-label]="'Valitse vertailuun: ' + row.name">
+          </mat-checkbox>
+        </td>
+      </ng-container>
+
       <!-- Auto increment position column -->
       <ng-container matColumnDef="position">
         <th mat-header-cell *matHeaderCellDef>

--- a/src/app/shared/stats-table/stats-table.component.scss
+++ b/src/app/shared/stats-table/stats-table.component.scss
@@ -74,6 +74,13 @@
   text-align: center;
 }
 
+.mat-column-compare {
+  max-width: 48px;
+  width: 48px;
+  padding: 0 4px;
+  text-align: center;
+}
+
 .mat-column-position {
   text-align: center;
 }

--- a/src/app/shared/stats-table/stats-table.component.scss
+++ b/src/app/shared/stats-table/stats-table.component.scss
@@ -170,4 +170,11 @@
   color: var(--mat-sys-on-primary-container);
 }
 
+// Improve disabled checkbox visibility in dark mode
+:host ::ng-deep .mat-mdc-checkbox.mat-mdc-checkbox-disabled {
+  opacity: 0.6;
 
+  .mdc-checkbox__background {
+    border-color: var(--mat-sys-outline) !important;
+  }
+}

--- a/src/app/shared/stats-table/stats-table.component.scss
+++ b/src/app/shared/stats-table/stats-table.component.scss
@@ -75,10 +75,11 @@
 }
 
 .mat-column-compare {
-  max-width: 48px;
-  width: 48px;
-  padding: 0 4px;
+  max-width: 44px;
+  width: 44px;
+  padding: 0 2px;
   text-align: center;
+  overflow: visible;
 }
 
 .mat-column-position {
@@ -170,11 +171,37 @@
   color: var(--mat-sys-on-primary-container);
 }
 
+// Brighten enabled checkbox borders for dark mode visibility
+:host ::ng-deep .mat-mdc-checkbox:not(.mat-mdc-checkbox-disabled) .mdc-checkbox__background {
+  border-color: var(--mat-sys-on-surface-variant) !important;
+}
+
 // Improve disabled checkbox visibility in dark mode
 :host ::ng-deep .mat-mdc-checkbox.mat-mdc-checkbox-disabled {
-  opacity: 0.6;
+  opacity: 0.5;
 
   .mdc-checkbox__background {
     border-color: var(--mat-sys-outline) !important;
+  }
+}
+
+// Checkbox on active/hovered row: ensure contrast with primary-container background
+:host ::ng-deep .mat-mdc-row:hover,
+:host ::ng-deep .mat-mdc-row.a11y-active {
+  .mat-mdc-checkbox .mdc-checkbox__background {
+    border-color: var(--mat-sys-on-primary-container) !important;
+  }
+
+  .mat-mdc-checkbox.mat-mdc-checkbox-checked .mdc-checkbox__background {
+    background-color: var(--mat-sys-on-primary-container) !important;
+    border-color: var(--mat-sys-on-primary-container) !important;
+  }
+
+  .mat-mdc-checkbox .mdc-checkbox__checkmark {
+    color: var(--mat-sys-primary-container) !important;
+  }
+
+  .mat-mdc-checkbox.mat-mdc-checkbox-disabled {
+    opacity: 0.5;
   }
 }

--- a/src/app/shared/stats-table/stats-table.component.spec.ts
+++ b/src/app/shared/stats-table/stats-table.component.spec.ts
@@ -9,6 +9,7 @@ import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { ElementRef, SimpleChange } from '@angular/core';
 import { Player, Goalie } from '@services/api.service';
 import { PlayerCardComponent } from '@shared/player-card/player-card.component';
+import { ComparisonService } from '@services/comparison.service';
 import { of } from 'rxjs';
 
 describe('StatsTableComponent', () => {
@@ -435,7 +436,7 @@ describe('StatsTableComponent', () => {
       expect(component.dataSource.data).toEqual(mockPlayerData as any);
     });
 
-    it('should set displayedColumns when columns are provided', () => {
+    it('should set displayedColumns with compare column prepended when columns are provided', () => {
       const changes = {
         data: new SimpleChange(null, mockPlayerData, true),
       };
@@ -444,7 +445,7 @@ describe('StatsTableComponent', () => {
       component.columns = playerColumns;
       component.ngOnChanges(changes);
 
-      expect(component.displayedColumns).toEqual(playerColumns);
+      expect(component.displayedColumns).toEqual(['compare', ...playerColumns]);
     });
 
     it('should filter static columns to create dynamicColumns', () => {
@@ -456,9 +457,12 @@ describe('StatsTableComponent', () => {
       component.columns = playerColumns;
       component.ngOnChanges(changes);
 
+      expect(component.dynamicColumns).not.toContain('compare');
       expect(component.dynamicColumns).not.toContain('position');
       expect(component.dynamicColumns).toContain('name');
       expect(component.dynamicColumns).toContain('games');
+      // playerColumns has 'position' (static), plus 'compare' is prepended (also static)
+      // dynamicColumns = displayedColumns minus both static columns
       expect(component.dynamicColumns.length).toBe(playerColumns.length - 1);
     });
 
@@ -764,7 +768,7 @@ describe('StatsTableComponent', () => {
       component.ngOnChanges(changes);
 
       expect(component.dataSource.data).toEqual(mockPlayerData as any);
-      expect(component.displayedColumns).toEqual(playerColumns);
+      expect(component.displayedColumns).toEqual(['compare', ...playerColumns]);
       expect(component.dynamicColumns.length).toBeGreaterThan(0);
     });
 
@@ -803,6 +807,41 @@ describe('StatsTableComponent', () => {
       component.ngOnChanges(changes);
 
       expect(component.dataSource.data).toEqual(mockGoalieData as any);
+    });
+  });
+
+  describe('comparison checkboxes', () => {
+    it('should include compare column as first displayed column', () => {
+      component.data = mockPlayerData;
+      component.columns = playerColumns;
+      component.ngOnChanges({
+        data: new SimpleChange(null, mockPlayerData, true),
+      });
+
+      expect(component.displayedColumns[0]).toBe('compare');
+    });
+
+    it('should toggle player selection when onCompareToggle called', () => {
+      const comparisonService = TestBed.inject(ComparisonService);
+      spyOn(comparisonService, 'toggle');
+      component.onCompareToggle(mockPlayerData[0]);
+      expect(comparisonService.toggle).toHaveBeenCalledWith(mockPlayerData[0]);
+    });
+
+    it('should check if player is selected', () => {
+      const comparisonService = TestBed.inject(ComparisonService);
+      spyOn(comparisonService, 'isSelected').and.returnValue(true);
+      expect(component.isCompareSelected(mockPlayerData[0])).toBeTrue();
+    });
+
+    it('should report player as not selected when not in comparison', () => {
+      const comparisonService = TestBed.inject(ComparisonService);
+      spyOn(comparisonService, 'isSelected').and.returnValue(false);
+      expect(component.isCompareSelected(mockPlayerData[0])).toBeFalse();
+    });
+
+    it('should expose canSelectMore$ observable from ComparisonService', () => {
+      expect(component.canSelectMore$).toBeDefined();
     });
   });
 

--- a/src/app/shared/stats-table/stats-table.component.ts
+++ b/src/app/shared/stats-table/stats-table.component.ts
@@ -12,6 +12,7 @@ import {
   AfterViewInit,
   OnDestroy,
 } from '@angular/core';
+import { AsyncPipe } from '@angular/common';
 
 import { TranslateModule } from '@ngx-translate/core';
 import { MatTableModule, MatTableDataSource } from '@angular/material/table';
@@ -20,15 +21,18 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatSort, MatSortModule } from '@angular/material/sort';
 import { MatTooltipModule } from '@angular/material/tooltip';
+import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatDialog } from '@angular/material/dialog';
 import { STATIC_COLUMNS } from '@shared/table-columns';
 import { Player, Goalie } from '@services/api.service';
+import { ComparisonService } from '@services/comparison.service';
 import { PlayerCardComponent, PlayerCardDialogData } from '@shared/player-card/player-card.component';
 import { TranslateService } from '@ngx-translate/core';
 
 @Component({
   selector: 'app-stats-table',
   imports: [
+    AsyncPipe,
     TranslateModule,
     MatTableModule,
     MatFormFieldModule,
@@ -36,6 +40,7 @@ import { TranslateService } from '@ngx-translate/core';
     MatProgressBarModule,
     MatSortModule,
     MatTooltipModule,
+    MatCheckboxModule,
   ],
   templateUrl: './stats-table.component.html',
   styleUrl: './stats-table.component.scss',
@@ -44,6 +49,8 @@ export class StatsTableComponent implements OnChanges, AfterViewInit, OnDestroy 
   private cdr = inject(ChangeDetectorRef);
   readonly dialog = inject(MatDialog);
   private translate = inject(TranslateService);
+  readonly comparisonService = inject(ComparisonService);
+  readonly canSelectMore$ = this.comparisonService.canSelectMore$;
 
   private loadingIntervalId?: ReturnType<typeof setInterval>;
   private loadingStartMs?: number;
@@ -85,7 +92,7 @@ export class StatsTableComponent implements OnChanges, AfterViewInit, OnDestroy 
       this.dataSource.data = this.data;
 
       if (this.columns?.length > 0) {
-        this.displayedColumns = this.columns;
+        this.displayedColumns = ['compare', ...this.columns];
         this.dynamicColumns = this.displayedColumns.filter(
           (column) => !STATIC_COLUMNS.includes(column)
         );
@@ -281,6 +288,14 @@ export class StatsTableComponent implements OnChanges, AfterViewInit, OnDestroy 
       default:
         return;
     }
+  }
+
+  onCompareToggle(player: Player | Goalie): void {
+    this.comparisonService.toggle(player);
+  }
+
+  isCompareSelected(player: Player | Goalie): boolean {
+    return this.comparisonService.isSelected(player);
   }
 
   getRowAriaLabel(row: Player | Goalie): string {

--- a/src/app/shared/table-columns.ts
+++ b/src/app/shared/table-columns.ts
@@ -38,4 +38,8 @@ export const GOALIE_SEASON_COLUMNS = [
   ...COMMON_COLUMNS,
 ];
 
+export const PLAYER_STAT_COLUMNS = PLAYER_COLUMNS.filter(c => c !== 'position' && c !== 'name');
+export const GOALIE_STAT_COLUMNS = GOALIE_COLUMNS.filter(c => c !== 'position' && c !== 'name');
+export const GOALIE_SEASON_STAT_COLUMNS = GOALIE_SEASON_COLUMNS.filter(c => c !== 'position' && c !== 'name');
+
 export const STATIC_COLUMNS = ['compare', 'position'];

--- a/src/app/shared/table-columns.ts
+++ b/src/app/shared/table-columns.ts
@@ -38,4 +38,4 @@ export const GOALIE_SEASON_COLUMNS = [
   ...COMMON_COLUMNS,
 ];
 
-export const STATIC_COLUMNS = ['position'];
+export const STATIC_COLUMNS = ['compare', 'position'];

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -191,7 +191,6 @@ button[mat-icon-button]:focus-visible,
   // Focus outline for the whole checkbox row (checkbox + label), drawn INSIDE to avoid clipping.
   .mat-mdc-checkbox:has(.mdc-checkbox__native-control:focus-visible) .mdc-form-field {
     box-sizing: border-box;
-    padding-right: 8px;
     border-radius: 12px;
     background-color: color-mix(in srgb, var(--mat-sys-primary) 7%, transparent);
     box-shadow: inset 0 0 0 2px color-mix(in srgb, var(--mat-sys-primary) 55%, transparent);
@@ -206,7 +205,6 @@ button[mat-icon-button]:focus-visible,
 
   .mat-mdc-checkbox:focus-within .mdc-form-field {
     box-sizing: border-box;
-    padding-right: 8px;
     border-radius: 12px;
     background-color: color-mix(in srgb, var(--mat-sys-primary) 7%, transparent);
     box-shadow: inset 0 0 0 2px color-mix(in srgb, var(--mat-sys-primary) 55%, transparent);
@@ -407,6 +405,40 @@ button[mat-icon-button]:focus-visible,
   }
 
   // Mobile: ensure consistent 95vw width and remove padding
+  @media (max-width: 768px) {
+    .mat-mdc-dialog-container {
+      max-width: 95vw !important;
+      width: 95vw !important;
+      padding: 0 !important;
+      max-height: calc(var(--app-height) - 8px) !important;
+
+      .mdc-dialog__surface {
+        max-width: 95vw !important;
+        width: 95vw !important;
+        padding: 0 !important;
+        max-height: calc(var(--app-height) - 8px) !important;
+      }
+    }
+  }
+}
+
+/* Comparison dialog styles */
+.comparison-dialog-panel {
+  .mat-mdc-dialog-container {
+    max-width: 95vw !important;
+    width: auto !important;
+    max-height: calc(var(--app-height) - 16px) !important;
+
+    .mdc-dialog__surface {
+      max-width: 95vw !important;
+      width: auto !important;
+      max-height: calc(var(--app-height) - 16px) !important;
+      overflow: auto;
+      -webkit-overflow-scrolling: touch;
+    }
+  }
+
+  // Mobile: match player card sizing (full width with margins)
   @media (max-width: 768px) {
     .mat-mdc-dialog-container {
       max-width: 95vw !important;


### PR DESCRIPTION
## Summary
- Add **Player Comparison Mode** — select 2 players via checkboxes, compare stats side-by-side in a dialog
- **Tilastot** tab: stat rows with value highlighting (bold + primary color for better value)
- **Graafit** tab: overlaid radar chart (Chart.js) with themed colors and formatted tooltips
- Full **dark mode** support with carefully tuned checkbox, button, and text contrast
- **Responsive layout**: desktop side-by-side at >480px, stacked mobile at ≤480px, 95vw dialog on mobile

## Changes

### New components
- `ComparisonService` — selection state management (max 2), auto-clears on team/season/report change
- `ComparisonBarComponent` — floating bottom bar with Vertaile/Tyhjennä buttons
- `ComparisonDialogComponent` — dialog with centered title, team name ingress, tab group
- `ComparisonStatsComponent` — side-by-side stat rows, surface-colored value cells, bold highlighting
- `ComparisonRadarComponent` — overlaid radar chart with goalie/player stat sets

### Modified components
- `StatsTableComponent` — checkbox column with 3-tier dark mode overrides (normal / disabled / active row)
- `styles.scss` — comparison dialog panel sizing, checkbox focus ring fix

### Other
- Finnish translations in `fi.json`
- E2E test suite with page objects (`ComparisonBar`, `ComparisonDialog`)
- Updated roadmap and project requirements docs

## Test plan
- [x] 677 unit tests passing, all coverage gates met (98.43% stmts, 96.49% branches, 98.41% fns)
- [x] Dark mode: checkbox visibility (normal, disabled, active row states)
- [x] Dark mode: Tyhjennä button neutral white color
- [x] Light mode: no visual regressions
- [x] Desktop (>768px): side-by-side stats, centered title, surface value backgrounds
- [x] Tablet (481–768px): side-by-side stats, shortened ingress names
- [x] Mobile (≤480px): stacked stats layout, 95vw dialog width matching player card
- [x] E2E tests for full comparison flow
