### PR TITLE
feat: Highlight career bests in player card By Season tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Live showcase: https://ffhl-stats.vercel.app/
 - 📇 **Player Card**: Dialog with per-player / per-goalie details, including combined career stats, season-by-season breakdown, and a graphs tab in separate tabs, using the same stat keys (including `score`) as the main tables
 	- 📉 Graphs tab shows per-season line charts for key stats (games, goals, assists, points, shots, penalties, hits, blocks for skaters; games, wins, saves, shutouts for goalies) with selectable series and sensible axis scaling
 	- 🎯 Radar chart view showing 0-100 normalized score breakdown for individual stats, toggleable with line charts
+	- 🏆 Career bests highlighted in By Season tab with tooltip showing stat name (only for players with 2+ seasons)
 - 🔗 **Direct Player Links**: Shareable URLs for player/goalie cards
 	- Players: `/player/:teamSlug/:playerSlug` (e.g., `/player/colorado/jamie-benn`)
 	- Goalies: `/goalie/:teamSlug/:goalieSlug` (e.g., `/goalie/colorado/philipp-grubauer`)

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -16,10 +16,6 @@ Star/bookmark players, persisted in localStorage. Add a "Suosikit" filter toggle
 
 Navigate to the next/previous player in the current table sort order from within the player card. No visible UI buttons — use keyboard arrows and swipe gestures (mobile/touchpad/mouse), similar to carousel grid interaction patterns.
 
-#### Highlight Career Bests in Player Card (~3-4h)
-
-In the "Kausittain" (By Season) tab, bold the career-best value for each individual stat column. Only applies to players with more than one season of data. Show a tooltip on hover/keyboard focus: "Kauden paras {statName}" (personal best). Should be subtle — not draw too much visual attention.
-
 ### Low priority
 
 #### URL-Persisted Filter State (~4-6h)

--- a/e2e/specs/player-card.spec.ts
+++ b/e2e/specs/player-card.spec.ts
@@ -43,6 +43,21 @@ test.describe('Player Card', () => {
 
     await playerCard.switchToTab('by-season');
     await playerCard.verifyTabContent('by-season');
+
+    // Verify career best highlighting in by-season tab
+    const seasonTable = page.locator('.season-table');
+    const highlightedCells = seasonTable.locator('td.stat-highlight');
+    const highlightCount = await highlightedCells.count();
+    expect(highlightCount).toBeGreaterThan(0);
+
+    // Verify tooltip on career best cell
+    const firstHighlight = highlightedCells.first();
+    await firstHighlight.hover();
+    const tooltip = page.locator('.mat-mdc-tooltip');
+    await expect(tooltip).toBeVisible({ timeout: 3000 });
+    const tooltipText = await tooltip.textContent();
+    expect(tooltipText).toContain('uran paras');
+
     await playerCard.switchToTab('graphs');
     await playerCard.verifyTabContent('graphs');
     await playerCard.switchToTab('stats');

--- a/public/i18n/fi.json
+++ b/public/i18n/fi.json
@@ -211,7 +211,8 @@
     "graphs": "Graafit",
     "graphsSelectStats": "Valitse tilastot käyrille",
     "copyLink": "Kopioi linkki leikepöydälle",
-    "linkCopied": "Linkki kopioitu!"
+    "linkCopied": "Linkki kopioitu!",
+    "careerBest": "uran paras"
   },
   "graphs": {
     "seasonalTrends": "Kausittaiset käyrät",

--- a/src/app/shared/comparison-dialog/comparison-stats/comparison-stats.component.html
+++ b/src/app/shared/comparison-dialog/comparison-stats/comparison-stats.component.html
@@ -4,15 +4,15 @@
   <div class="stat-row-mobile">
     <div class="stat-label">{{ row.label }}</div>
     <div class="stat-values">
-      <span class="value-a" [class.bold]="row.boldA">{{ row.valueA }}</span>
-      <span class="value-b" [class.bold]="row.boldB">{{ row.valueB }}</span>
+      <span class="value-a" [class.stat-highlight]="row.boldA">{{ row.valueA }}</span>
+      <span class="value-b" [class.stat-highlight]="row.boldB">{{ row.valueB }}</span>
     </div>
   </div>
   } @else {
   <div class="stat-row-desktop">
-    <span class="value-a" [class.bold]="row.boldA">{{ row.valueA }}</span>
+    <span class="value-a" [class.stat-highlight]="row.boldA">{{ row.valueA }}</span>
     <span class="stat-label">{{ row.label }}</span>
-    <span class="value-b" [class.bold]="row.boldB">{{ row.valueB }}</span>
+    <span class="value-b" [class.stat-highlight]="row.boldB">{{ row.valueB }}</span>
   </div>
   }
   }

--- a/src/app/shared/comparison-dialog/comparison-stats/comparison-stats.component.scss
+++ b/src/app/shared/comparison-dialog/comparison-stats/comparison-stats.component.scss
@@ -12,12 +12,6 @@
   padding: 0 8px;
 }
 
-
-.bold {
-  font-weight: 700;
-  color: var(--mat-sys-primary);
-}
-
 // Desktop layout
 .stat-row-desktop {
   display: grid;

--- a/src/app/shared/comparison-dialog/comparison-stats/comparison-stats.component.spec.ts
+++ b/src/app/shared/comparison-dialog/comparison-stats/comparison-stats.component.spec.ts
@@ -213,16 +213,16 @@ describe('ComparisonStatsComponent', () => {
     });
   });
 
-  describe('bold CSS class', () => {
-    it('should apply bold class to the higher value element', () => {
+  describe('stat-highlight CSS class', () => {
+    it('should apply stat-highlight class to the higher value element', () => {
       createComponent(mockPlayerA, mockPlayerB, 'player', false);
       const el: HTMLElement = fixture.nativeElement;
-      // score: A=100 > B=94.31, so value-a should be bold
+      // score: A=100 > B=94.31, so value-a should be highlighted
       const firstRow = el.querySelector('.stat-row-desktop')!;
       const valueA = firstRow.querySelector('.value-a')!;
       const valueB = firstRow.querySelector('.value-b')!;
-      expect(valueA.classList.contains('bold')).toBeTrue();
-      expect(valueB.classList.contains('bold')).toBeFalse();
+      expect(valueA.classList.contains('stat-highlight')).toBeTrue();
+      expect(valueB.classList.contains('stat-highlight')).toBeFalse();
     });
   });
 

--- a/src/app/shared/player-card/player-card.component.html
+++ b/src/app/shared/player-card/player-card.component.html
@@ -71,7 +71,11 @@
                     {{ "tableColumnShort." + column | translate }}
                   </span>
                 </th>
-                <td mat-cell *matCellDef="let season">
+                <td mat-cell *matCellDef="let season"
+                    [class.stat-highlight]="isCareerBest(column, season.season)"
+                    [matTooltip]="isCareerBest(column, season.season)
+                      ? ('tableColumn.' + column | translate) + ' - ' + ('playerCard.careerBest' | translate)
+                      : ''">
                   {{ season[column] !== "" ? season[column] : "-" }}
                 </td>
               </ng-container>

--- a/src/app/shared/player-card/player-card.component.scss
+++ b/src/app/shared/player-card/player-card.component.scss
@@ -207,6 +207,12 @@ mat-card-title {
     min-width: 52px;
   }
 
+  // Career best highlighting (needs component-level specificity to override .mat-mdc-cell color)
+  td.stat-highlight {
+    font-weight: 700;
+    color: var(--mat-sys-primary);
+  }
+
   .mat-mdc-header-cell:first-child,
   .mat-mdc-cell:first-child {
     min-width: 58px;

--- a/src/app/shared/player-card/player-card.component.spec.ts
+++ b/src/app/shared/player-card/player-card.component.spec.ts
@@ -895,6 +895,219 @@ describe("PlayerCardComponent", () => {
 
       expect(focusSpy).toHaveBeenCalled();
     });
+
+    describe("career best highlighting", () => {
+      it("should highlight max values as career best for standard stats", () => {
+        // 2024 has 8 wins, 2023 has 10 wins -> 2023 should be best
+        expect(component.isCareerBest("wins", 2023)).toBeTrue();
+        expect(component.isCareerBest("wins", 2024)).toBeFalse();
+
+        // 2024 has 300 saves, 2023 has 450 saves -> 2023 should be best
+        expect(component.isCareerBest("saves", 2023)).toBeTrue();
+        expect(component.isCareerBest("saves", 2024)).toBeFalse();
+      });
+
+      it("should highlight min values as career best for GAA (lower is better)", () => {
+        // 2024 has GAA 2.00, 2023 has GAA 2.10 -> 2024 should be best (lower)
+        expect(component.isCareerBest("gaa", 2024)).toBeTrue();
+        expect(component.isCareerBest("gaa", 2023)).toBeFalse();
+      });
+
+      it("should highlight all tied seasons when values are equal", fakeAsync(() => {
+        // Create data with tied values
+        const tiedData: Goalie & { seasons: GoalieSeasonStats[] } = {
+          name: "Tied Goalie",
+          score: 0,
+          scoreAdjustedByGames: 0,
+          games: 20,
+          wins: 15,
+          saves: 600,
+          shutouts: 4,
+          goals: 0,
+          assists: 2,
+          points: 2,
+          penalties: 0,
+          ppp: 0,
+          shp: 0,
+          seasons: [
+            {
+              season: 2024,
+              games: 10,
+              score: 50,
+              scoreAdjustedByGames: 5,
+              wins: 8,
+              saves: 300,
+              shutouts: 2,
+              goals: 0,
+              assists: 1,
+              points: 1,
+              penalties: 0,
+              ppp: 0,
+              shp: 0,
+              gaa: "2.00",
+              savePercent: "0.920",
+            },
+            {
+              season: 2023,
+              games: 10,
+              score: 50,
+              scoreAdjustedByGames: 5,
+              wins: 8, // Same as 2024
+              saves: 300, // Same as 2024
+              shutouts: 2,
+              goals: 0,
+              assists: 1,
+              points: 1,
+              penalties: 0,
+              ppp: 0,
+              shp: 0,
+              gaa: "2.00", // Same as 2024
+              savePercent: "0.920",
+            },
+          ],
+        };
+
+        TestBed.resetTestingModule();
+        TestBed.configureTestingModule({
+          imports: [
+            PlayerCardComponent,
+            TranslateModule.forRoot(),
+            NoopAnimationsModule,
+          ],
+          providers: [
+            { provide: MAT_DIALOG_DATA, useValue: tiedData },
+            { provide: MatDialogRef, useValue: dialogRefSpy },
+            { provide: ApiService, useValue: apiServiceSpy },
+          ],
+        });
+
+        const tiedFixture = TestBed.createComponent(PlayerCardComponent);
+        const tiedComponent = tiedFixture.componentInstance;
+        tiedFixture.detectChanges();
+        tick();
+
+        // Both seasons should be highlighted for tied values
+        expect(tiedComponent.isCareerBest("wins", 2024)).toBeTrue();
+        expect(tiedComponent.isCareerBest("wins", 2023)).toBeTrue();
+        expect(tiedComponent.isCareerBest("saves", 2024)).toBeTrue();
+        expect(tiedComponent.isCareerBest("saves", 2023)).toBeTrue();
+        expect(tiedComponent.isCareerBest("gaa", 2024)).toBeTrue();
+        expect(tiedComponent.isCareerBest("gaa", 2023)).toBeTrue();
+      }));
+
+      it("should not highlight when all values are zero", () => {
+        // ppp and shp are 0 for all seasons in mock data
+        expect(component.isCareerBest("ppp", 2024)).toBeFalse();
+        expect(component.isCareerBest("ppp", 2023)).toBeFalse();
+        expect(component.isCareerBest("shp", 2024)).toBeFalse();
+        expect(component.isCareerBest("shp", 2023)).toBeFalse();
+      });
+
+      it("should return false for non-existent column", () => {
+        expect(component.isCareerBest("nonexistent", 2024)).toBeFalse();
+      });
+
+      it("should return false for non-existent season", () => {
+        expect(component.isCareerBest("wins", 1999)).toBeFalse();
+      });
+
+      it("should apply stat-highlight class to career best cells in template", fakeAsync(() => {
+        // Switch to by-season tab
+        const tabGroupDebug = fixture.debugElement.query(
+          By.css("mat-tab-group"),
+        );
+        const tabGroup = tabGroupDebug.componentInstance as MatTabGroup;
+        tabGroup.selectedIndex = 1;
+        fixture.detectChanges();
+        tick();
+
+        // Find cells in season table
+        const seasonTable = fixture.debugElement.query(By.css(".season-table"));
+        expect(seasonTable).toBeTruthy();
+
+        const cells = seasonTable.queryAll(By.css("td.mat-mdc-cell"));
+        const highlightedCells = cells.filter((cell) =>
+          cell.nativeElement.classList.contains("stat-highlight"),
+        );
+
+        // Should have some highlighted cells (career bests)
+        expect(highlightedCells.length).toBeGreaterThan(0);
+      }));
+    });
+  });
+
+  describe("career best with single season", () => {
+    let apiServiceSpy: jasmine.SpyObj<ApiService>;
+
+    beforeEach(async () => {
+      dialogRefSpy = jasmine.createSpyObj<MatDialogRef<PlayerCardComponent>>(
+        "MatDialogRef",
+        ["close"],
+      );
+      apiServiceSpy = jasmine.createSpyObj("ApiService", ["getTeams"]);
+      apiServiceSpy.getTeams.and.returnValue(
+        of([{ id: "1", name: "colorado", presentName: "Colorado Avalanche" }]),
+      );
+
+      const singleSeasonData: Goalie & { seasons: GoalieSeasonStats[] } = {
+        name: "Single Season Goalie",
+        score: 50,
+        scoreAdjustedByGames: 5,
+        games: 10,
+        wins: 8,
+        saves: 300,
+        shutouts: 2,
+        goals: 0,
+        assists: 1,
+        points: 1,
+        penalties: 0,
+        ppp: 0,
+        shp: 0,
+        seasons: [
+          {
+            season: 2024,
+            games: 10,
+            score: 50,
+            scoreAdjustedByGames: 5,
+            wins: 8,
+            saves: 300,
+            shutouts: 2,
+            goals: 0,
+            assists: 1,
+            points: 1,
+            penalties: 0,
+            ppp: 0,
+            shp: 0,
+            gaa: "2.00",
+            savePercent: "0.920",
+          },
+        ],
+      };
+
+      await TestBed.configureTestingModule({
+        imports: [
+          PlayerCardComponent,
+          TranslateModule.forRoot(),
+          NoopAnimationsModule,
+        ],
+        providers: [
+          { provide: MAT_DIALOG_DATA, useValue: singleSeasonData },
+          { provide: MatDialogRef, useValue: dialogRefSpy },
+          { provide: ApiService, useValue: apiServiceSpy },
+        ],
+      }).compileComponents();
+
+      fixture = TestBed.createComponent(PlayerCardComponent);
+      component = fixture.componentInstance;
+      fixture.detectChanges();
+    });
+
+    it("should not highlight any values with only one season", () => {
+      expect(component.careerBests.size).toBe(0);
+      expect(component.isCareerBest("wins", 2024)).toBeFalse();
+      expect(component.isCareerBest("saves", 2024)).toBeFalse();
+      expect(component.isCareerBest("gaa", 2024)).toBeFalse();
+    });
   });
 
   describe("without seasons data", () => {

--- a/src/app/shared/player-card/player-card.component.ts
+++ b/src/app/shared/player-card/player-card.component.ts
@@ -129,6 +129,7 @@ export class PlayerCardComponent {
   // Columns for season breakdown table
   seasonColumns: string[] = [];
   seasonDataSource: (PlayerSeasonStats | GoalieSeasonStats)[] = [];
+  careerBests: Map<string, Set<number>> = new Map();
   graphsComponent: Type<unknown> | null = null;
   graphsLoading = false;
   graphsLoadPromise: Promise<void> | null = null;
@@ -384,6 +385,8 @@ export class PlayerCardComponent {
 
       this.seasonColumns = prioritizedColumns;
     }
+
+    this.computeCareerBests();
   }
 
 
@@ -398,6 +401,48 @@ export class PlayerCardComponent {
     const nextYear = year + 1;
     const endShort = String(nextYear).slice(-2);
     return `${startShort}-${endShort}`;
+  }
+
+  private parseStatValue(value: unknown): number | null {
+    if (value === '' || value === '-' || value === null || value === undefined) {
+      return null;
+    }
+    const num = typeof value === 'number' ? value : parseFloat(String(value));
+    return isNaN(num) ? null : num;
+  }
+
+  private computeCareerBests(): void {
+    this.careerBests.clear();
+
+    if (this.seasonDataSource.length < 2) return;
+
+    const statColumns = this.seasonColumns.filter(col => col !== 'seasonDisplay');
+
+    for (const column of statColumns) {
+      const values = this.seasonDataSource.map(s => ({
+        season: s.season,
+        value: this.parseStatValue((s as Record<string, unknown>)[column])
+      })).filter(v => v.value !== null) as { season: number; value: number }[];
+
+      // Skip if no valid values or all zeros
+      if (values.length === 0 || values.every(v => v.value === 0)) continue;
+
+      // Find best value (min for GAA, max for others)
+      const bestValue = column === 'gaa'
+        ? Math.min(...values.map(v => v.value))
+        : Math.max(...values.map(v => v.value));
+
+      // Store all seasons with the best value
+      const bestSeasons = values
+        .filter(v => v.value === bestValue)
+        .map(v => v.season);
+
+      this.careerBests.set(column, new Set(bestSeasons));
+    }
+  }
+
+  isCareerBest(column: string, season: number): boolean {
+    return this.careerBests.get(column)?.has(season) ?? false;
   }
 
   private reorderStatsForDisplay(keys: string[]): string[] {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -517,3 +517,9 @@ mat-checkbox .mdc-label {
     margin: 1em 0 0 0 !important;
   }
 }
+
+// Shared highlight style for career bests, comparison winners, etc.
+.stat-highlight {
+  font-weight: 700;
+  color: var(--mat-sys-primary);
+}


### PR DESCRIPTION
- Add shared .stat-highlight class for consistent highlighting
- Refactor comparison-stats to use shared class instead of .bold
- Calculate career-best values per stat column (max for most, min for GAA)
- Highlight all tied seasons when values are equal
- Skip highlighting when all values are zero or only 1 season
- Show tooltip "{statName} - uran paras" on hover/focus
- Add comprehensive unit tests for career best logic
- Extend E2E tests to verify highlighting and tooltips
- Update README features and remove from roadmap