### PR TITLE
Feature: Direction-aware slide transition for player card navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Live showcase: https://ffhl-stats.vercel.app/
 	- 📉 Graphs tab shows per-season line charts for key stats (games, goals, assists, points, shots, penalties, hits, blocks for skaters; games, wins, saves, shutouts for goalies) with selectable series and sensible axis scaling
 	- 🎯 Radar chart view showing 0-100 normalized score breakdown for individual stats, toggleable with line charts
 	- 🏆 Career bests highlighted in By Season tab with tooltip showing stat name (only for players with 2+ seasons)
-	- ⬅️➡️ Navigate between players/goalies without closing the card: keyboard arrows (←/→), touch swipe (mobile), or trackpad two-finger swipe (laptop). Wraps circularly with screen reader announcements. Active row in the stats table stays in sync
+	- ⬅️➡️ Navigate between players/goalies without closing the card: keyboard arrows (←/→), touch swipe (mobile), or trackpad two-finger swipe (laptop). Wraps circularly with screen reader announcements. Active row in the stats table stays in sync. Direction-aware slide transition provides visual feedback
 - 🔗 **Direct Player Links**: Shareable URLs for player/goalie cards
 	- Players: `/player/:teamSlug/:playerSlug` (e.g., `/player/colorado/jamie-benn`)
 	- Goalies: `/goalie/:teamSlug/:goalieSlug` (e.g., `/goalie/colorado/philipp-grubauer`)

--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -106,6 +106,7 @@ Accessibility details:
 - The stats table's active row stays in sync with the navigated player
 - On dialog close, focus returns to the row of the last-navigated player (not the originally opened row)
 - Browser back/forward gestures are suppressed while the dialog is open (`preventDefault()` on horizontal `wheel` events + `overscroll-behavior-x: none` CSS)
+- Navigation uses a direction-aware slide transition (125ms per phase). When `prefers-reduced-motion: reduce` is active, the transition is skipped entirely (instant data swap, no visual animation)
 
 ### Player Card (Graphs tab) focus shortcuts
 

--- a/docs/component-guide.md
+++ b/docs/component-guide.md
@@ -460,6 +460,7 @@ Navigation wraps circularly (last → first, first → last).
 - **Screen reader**: Live region announces player position and name on each navigation (e.g., "Pelaaja 3 / 25: Jamie Benn")
 - **Active row sync**: `onNavigate` callback keeps the stats table's active row in sync; on dialog close, focus returns to the navigated-to row
 - **Browser gesture prevention**: Horizontal wheel events are `preventDefault()`-ed and `overscroll-behavior-x: none` CSS is applied to block macOS trackpad back/forward navigation
+- **Navigation transition**: Direction-aware slide animation (125ms out + 125ms in) with opacity fade provides visual feedback during navigation. Respects `prefers-reduced-motion: reduce` (instant swap). Rapid navigation cancels in-progress animation
 
 **Position Filter Toggle (Players Only)**:
 

--- a/docs/project-requirements.md
+++ b/docs/project-requirements.md
@@ -280,6 +280,10 @@ npm start    # Development server
 npm test     # Run tests in watch mode
 ```
 
+### Before Writing Tests
+
+For UI/visual features, ask the user to review the implementation on `localhost:4200` before writing or updating unit tests. This avoids extra fix-test iteration cycles when the user requests adjustments to the visual result.
+
 ### Before Committing
 
 ```bash

--- a/docs/project-requirements.md
+++ b/docs/project-requirements.md
@@ -287,9 +287,7 @@ For UI/visual features, ask the user to review the implementation on `localhost:
 ### Before Committing
 
 ```bash
-npm test -- --browsers=ChromeHeadless --watch=false  # Full test run
-npm run build                                         # Verify build
-# All must pass before commit
+npm run verify  # Runs tests (headless), coverage check, and production build — single command, don't run these separately
 ```
 
 ### Commit Message Format

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -10,12 +10,6 @@ Planned improvements and future development ideas, roughly ordered by priority.
 
 Star/bookmark players, persisted in localStorage. Add a "Suosikit" filter toggle to quickly view only watched players. No API changes needed.
 
-### Medium priority
-
-#### Player Card Navigation Transitions (~2-3h)
-
-Add smooth transitions when navigating between players in the player card (currently instant swap). Options: fade, slide, or direction-aware animations. Enhances polish and provides clearer visual feedback during navigation.
-
 ### Low priority
 
 #### Extend Player Card Navigation (~3-4h)

--- a/src/app/shared/player-card/player-card.component.html
+++ b/src/app/shared/player-card/player-card.component.html
@@ -6,6 +6,7 @@
   <button mat-icon-button (click)="onNoClick()" #closeButton [attr.aria-label]="'a11y.closePlayerCard' | translate">
     <mat-icon fontIcon="close" />
   </button>
+  <div [class]="slideClass" class="card-content-wrapper">
   <mat-card-header>
     <mat-card-title>
       <mat-icon mat-card-avatar class="card-title-icon letter-avatar" [matTooltip]="positionTooltip">{{
@@ -127,4 +128,5 @@
     </table>
     }
   </mat-card-content>
+  </div>
 </mat-card>

--- a/src/app/shared/player-card/player-card.component.scss
+++ b/src/app/shared/player-card/player-card.component.scss
@@ -195,29 +195,29 @@ mat-card-title {
 // --- Navigation transition ---
 
 .card-content-wrapper {
-  transition: transform 75ms ease-out, opacity 75ms ease-out;
+  transition: transform 125ms ease-out, opacity 125ms ease-out;
 }
 
 .slide-out-left {
-  transform: translateX(-30px);
+  transform: translateX(-50px);
   opacity: 0.3;
 }
 
 .slide-out-right {
-  transform: translateX(30px);
+  transform: translateX(50px);
   opacity: 0.3;
 }
 
 // slide-in classes position the element at the entry point with no transition
 // so the browser can then animate back to origin
 .slide-in-left {
-  transform: translateX(30px);
+  transform: translateX(50px);
   opacity: 0.3;
   transition: none;
 }
 
 .slide-in-right {
-  transform: translateX(-30px);
+  transform: translateX(-50px);
   opacity: 0.3;
   transition: none;
 }

--- a/src/app/shared/player-card/player-card.component.scss
+++ b/src/app/shared/player-card/player-card.component.scss
@@ -192,6 +192,51 @@ mat-card-title {
   color: var(--mat-sys-on-surface-variant);
 }
 
+// --- Navigation transition ---
+
+.card-content-wrapper {
+  transition: transform 75ms ease-out, opacity 75ms ease-out;
+}
+
+.slide-out-left {
+  transform: translateX(-30px);
+  opacity: 0.3;
+}
+
+.slide-out-right {
+  transform: translateX(30px);
+  opacity: 0.3;
+}
+
+// slide-in classes position the element at the entry point with no transition
+// so the browser can then animate back to origin
+.slide-in-left {
+  transform: translateX(30px);
+  opacity: 0.3;
+  transition: none;
+}
+
+.slide-in-right {
+  transform: translateX(-30px);
+  opacity: 0.3;
+  transition: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .card-content-wrapper {
+    transition: none;
+  }
+
+  .slide-out-left,
+  .slide-out-right,
+  .slide-in-left,
+  .slide-in-right {
+    transform: none;
+    opacity: 1;
+    transition: none;
+  }
+}
+
 .season-table {
   // Let the table grow wider than the container (so columns keep a readable width)
   // and rely on `.season-table-container { overflow-x: auto; }` for horizontal scrolling.

--- a/src/app/shared/player-card/player-card.component.spec.ts
+++ b/src/app/shared/player-card/player-card.component.spec.ts
@@ -3641,7 +3641,7 @@ describe("PlayerCardComponent", () => {
         (c as any).navigateToNext();
 
         expect(c.slideClass).toContain('slide-out-left');
-        tick(150); // clean up timers
+        tick(250); // clean up timers
       }));
 
       it('should apply slide-out-right class when navigating to previous player', fakeAsync(async () => {
@@ -3650,7 +3650,7 @@ describe("PlayerCardComponent", () => {
         (c as any).navigateToPrevious();
 
         expect(c.slideClass).toContain('slide-out-right');
-        tick(150);
+        tick(250);
       }));
 
       it('should swap player data after slide-out animation completes', fakeAsync(async () => {
@@ -3659,10 +3659,10 @@ describe("PlayerCardComponent", () => {
         (c as any).navigateToNext();
         expect(c.data.name).toBe('Player 1'); // Not yet swapped
 
-        tick(75); // slide-out completes
+        tick(125); // slide-out completes
         expect(c.data.name).toBe('Player 2'); // Now swapped
 
-        tick(75); // slide-in completes
+        tick(125); // slide-in completes
         expect(c.slideClass).toBe('card-content-wrapper'); // Clean state
       }));
 
@@ -3683,15 +3683,15 @@ describe("PlayerCardComponent", () => {
         const c = await createNavComponent(threePlayers);
 
         (c as any).navigateToNext(); // Start animating to Player 2
-        tick(40); // Mid-animation — data not yet swapped, still at index 0
+        tick(60); // Mid-animation — data not yet swapped, still at index 0
 
         (c as any).navigateToNext(); // Cancels first, starts new from index 0 → 1
-        tick(75); // New slide-out completes, data swaps to Player 2
+        tick(125); // New slide-out completes, data swaps to Player 2
 
         // First animation was canceled before it could swap data
         expect(c.data.name).toBe('Player 2');
 
-        tick(75); // Clean up
+        tick(125); // Clean up
       }));
 
       it('should return to clean slideClass after full animation cycle', fakeAsync(async () => {
@@ -3699,10 +3699,10 @@ describe("PlayerCardComponent", () => {
 
         (c as any).navigateToNext();
 
-        tick(75); // slide-out done, slide-in starts
+        tick(125); // slide-out done, slide-in starts
         expect(c.slideClass).toBe('card-content-wrapper');
 
-        tick(75); // slide-in done
+        tick(125); // slide-in done
         expect(c.slideClass).toBe('card-content-wrapper');
       }));
     });

--- a/src/app/shared/player-card/player-card.component.spec.ts
+++ b/src/app/shared/player-card/player-card.component.spec.ts
@@ -2854,6 +2854,17 @@ describe("PlayerCardComponent", () => {
       apiServiceSpy.getTeams.and.returnValue(
         of([{ id: "1", name: "colorado", presentName: "Colorado Avalanche" }]),
       );
+      // Default to reduced motion so existing navigation tests get instant data swap
+      spyOn(window, 'matchMedia').and.returnValue({
+        matches: true,
+        media: '',
+        onchange: null,
+        addListener: () => {},
+        removeListener: () => {},
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        dispatchEvent: () => false,
+      } as MediaQueryList);
     });
 
     it('should navigate to next player on ArrowRight', async () => {
@@ -3560,6 +3571,140 @@ describe("PlayerCardComponent", () => {
       c.onKeydown(event);
 
       expect(c.liveRegionMessage).toBe('Pelaaja 2 / 2: Player 2');
+    });
+
+    describe('navigation transition', () => {
+      function mockMatchMedia(reducedMotion: boolean): MediaQueryList {
+        return {
+          matches: reducedMotion,
+          media: '',
+          onchange: null,
+          addListener: () => {},
+          removeListener: () => {},
+          addEventListener: () => {},
+          removeEventListener: () => {},
+          dispatchEvent: () => false,
+        } as MediaQueryList;
+      }
+
+      async function createNavComponent(players: Player[], startIndex = 0) {
+        (window.matchMedia as jasmine.Spy).and.returnValue(mockMatchMedia(false));
+
+        const dialogData: PlayerCardDialogData = {
+          player: players[startIndex],
+          navigationContext: {
+            allPlayers: players,
+            currentIndex: startIndex,
+            onNavigate: jasmine.createSpy('onNavigate'),
+          },
+        };
+
+        dialogRefSpy = jasmine.createSpyObj<MatDialogRef<PlayerCardComponent>>(
+          'MatDialogRef',
+          ['close'],
+        );
+
+        await TestBed.configureTestingModule({
+          imports: [
+            PlayerCardComponent,
+            TranslateModule.forRoot(),
+            NoopAnimationsModule,
+          ],
+          providers: [
+            { provide: MAT_DIALOG_DATA, useValue: dialogData },
+            { provide: MatDialogRef, useValue: dialogRefSpy },
+            { provide: ApiService, useValue: apiServiceSpy },
+            { provide: TeamService, useValue: teamServiceSpy },
+          ],
+        }).compileComponents();
+
+        const f = TestBed.createComponent(PlayerCardComponent);
+        const c = f.componentInstance;
+        f.detectChanges();
+        return c;
+      }
+
+      const twoPlayers: Player[] = [
+        { name: 'Player 1', games: 10, goals: 5, assists: 3, points: 8, score: 100 } as Player,
+        { name: 'Player 2', games: 12, goals: 6, assists: 4, points: 10, score: 120 } as Player,
+      ];
+
+      const threePlayers: Player[] = [
+        { name: 'Player 1', games: 10, goals: 5, assists: 3, points: 8, score: 100 } as Player,
+        { name: 'Player 2', games: 12, goals: 6, assists: 4, points: 10, score: 120 } as Player,
+        { name: 'Player 3', games: 14, goals: 7, assists: 5, points: 12, score: 140 } as Player,
+      ];
+
+      it('should apply slide-out-left class when navigating to next player', fakeAsync(async () => {
+        const c = await createNavComponent(twoPlayers);
+
+        (c as any).navigateToNext();
+
+        expect(c.slideClass).toContain('slide-out-left');
+        tick(150); // clean up timers
+      }));
+
+      it('should apply slide-out-right class when navigating to previous player', fakeAsync(async () => {
+        const c = await createNavComponent(twoPlayers, 1);
+
+        (c as any).navigateToPrevious();
+
+        expect(c.slideClass).toContain('slide-out-right');
+        tick(150);
+      }));
+
+      it('should swap player data after slide-out animation completes', fakeAsync(async () => {
+        const c = await createNavComponent(twoPlayers);
+
+        (c as any).navigateToNext();
+        expect(c.data.name).toBe('Player 1'); // Not yet swapped
+
+        tick(75); // slide-out completes
+        expect(c.data.name).toBe('Player 2'); // Now swapped
+
+        tick(75); // slide-in completes
+        expect(c.slideClass).toBe('card-content-wrapper'); // Clean state
+      }));
+
+      it('should skip animation when prefers-reduced-motion is set', fakeAsync(async () => {
+        (window.matchMedia as jasmine.Spy).and.returnValue(mockMatchMedia(true));
+
+        const c = await createNavComponent(twoPlayers);
+        // Override again since createNavComponent sets it to false
+        (window.matchMedia as jasmine.Spy).and.returnValue(mockMatchMedia(true));
+
+        (c as any).navigateToNext();
+
+        expect(c.slideClass).toBe(''); // No animation classes
+        expect(c.data.name).toBe('Player 2'); // Immediate swap
+      }));
+
+      it('should cancel in-progress animation on rapid navigation', fakeAsync(async () => {
+        const c = await createNavComponent(threePlayers);
+
+        (c as any).navigateToNext(); // Start animating to Player 2
+        tick(40); // Mid-animation — data not yet swapped, still at index 0
+
+        (c as any).navigateToNext(); // Cancels first, starts new from index 0 → 1
+        tick(75); // New slide-out completes, data swaps to Player 2
+
+        // First animation was canceled before it could swap data
+        expect(c.data.name).toBe('Player 2');
+
+        tick(75); // Clean up
+      }));
+
+      it('should return to clean slideClass after full animation cycle', fakeAsync(async () => {
+        const c = await createNavComponent(twoPlayers);
+
+        (c as any).navigateToNext();
+
+        tick(75); // slide-out done, slide-in starts
+        expect(c.slideClass).toBe('card-content-wrapper');
+
+        tick(75); // slide-in done
+        expect(c.slideClass).toBe('card-content-wrapper');
+      }));
     });
   });
 });

--- a/src/app/shared/player-card/player-card.component.ts
+++ b/src/app/shared/player-card/player-card.component.ts
@@ -106,6 +106,11 @@ export class PlayerCardComponent implements OnDestroy {
   // Screen reader announcement
   liveRegionMessage = '';
 
+  // Navigation transition state
+  slideClass = '';
+  private animationTimer: ReturnType<typeof setTimeout> | null = null;
+  private readonly animationDuration = 75; // ms per phase (out + in)
+
   readonly isGoalie = 'wins' in this.data;
 
   private isWrappedData(data: Player | Goalie | PlayerCardDialogData): data is PlayerCardDialogData {
@@ -222,6 +227,7 @@ export class PlayerCardComponent implements OnDestroy {
   ngOnDestroy(): void {
     document.removeEventListener('wheel', this.wheelHandler);
     if (this.wheelResetTimer) clearTimeout(this.wheelResetTimer);
+    if (this.animationTimer) clearTimeout(this.animationTimer);
   }
 
   // --- Navigation ---
@@ -316,15 +322,58 @@ export class PlayerCardComponent implements OnDestroy {
   private navigateToPrevious(): void {
     const newIndex = this.currentIndex - 1;
     const wrappedIndex = newIndex < 0 ? this.allPlayers.length - 1 : newIndex;
-    this.navigateToIndex(wrappedIndex);
+    this.navigateToIndex(wrappedIndex, 'right');
   }
 
   private navigateToNext(): void {
     const newIndex = (this.currentIndex + 1) % this.allPlayers.length;
-    this.navigateToIndex(newIndex);
+    this.navigateToIndex(newIndex, 'left');
   }
 
-  private navigateToIndex(newIndex: number): void {
+  private navigateToIndex(newIndex: number, direction: 'left' | 'right'): void {
+    // Cancel any in-progress animation
+    if (this.animationTimer) {
+      clearTimeout(this.animationTimer);
+      this.animationTimer = null;
+    }
+
+    // Check reduced motion preference
+    const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+    if (prefersReducedMotion) {
+      this.applyNavigation(newIndex);
+      return;
+    }
+
+    // Phase 1: Slide out
+    this.slideClass = `card-content-wrapper slide-out-${direction}`;
+    this.cdr.detectChanges();
+
+    this.animationTimer = setTimeout(() => {
+      // Swap data while content is faded out
+      this.applyNavigation(newIndex);
+
+      // Phase 2: Position at entry point (no transition)
+      const enterFrom = direction === 'left' ? 'left' : 'right';
+      this.slideClass = `card-content-wrapper slide-in-${enterFrom}`;
+      this.cdr.detectChanges();
+
+      // Force reflow so the browser registers the start position
+      // before we remove the class to trigger the slide-in transition
+      const wrapper = this.host.nativeElement.querySelector('.card-content-wrapper');
+      wrapper?.getBoundingClientRect();
+
+      // Phase 3: Animate to origin
+      this.slideClass = 'card-content-wrapper';
+      this.cdr.detectChanges();
+
+      this.animationTimer = setTimeout(() => {
+        this.animationTimer = null;
+      }, this.animationDuration);
+    }, this.animationDuration);
+  }
+
+  private applyNavigation(newIndex: number): void {
     this.currentIndex = newIndex;
     this.data = this.allPlayers[newIndex];
 

--- a/src/app/shared/player-card/player-card.component.ts
+++ b/src/app/shared/player-card/player-card.component.ts
@@ -109,7 +109,7 @@ export class PlayerCardComponent implements OnDestroy {
   // Navigation transition state
   slideClass = '';
   private animationTimer: ReturnType<typeof setTimeout> | null = null;
-  private readonly animationDuration = 75; // ms per phase (out + in)
+  private readonly animationDuration = 125; // ms per phase (out + in)
 
   readonly isGoalie = 'wins' in this.data;
 


### PR DESCRIPTION
## Summary

- Add direction-aware slide transition when navigating between players in the player card dialog
- Card content slides left/right matching the navigation direction (next = left, previous = right) with an opacity fade
- 125ms per phase (250ms total: slide-out → data swap → slide-in), 50px slide distance
- Respects `prefers-reduced-motion: reduce` — animation is skipped entirely (instant swap)
- Rapid navigation cancels any in-progress animation and starts fresh
- Pure CSS transitions triggered by class toggling — no Angular Animations module needed
- Simplify pre-commit verification docs to single `npm run verify` command
- Add "Before Writing Tests" user review step to development workflow

## Implementation

- Wrapper `<div class="card-content-wrapper">` around card content (close button stays fixed)
- Three-phase animation in `navigateToIndex()`: slide-out class → setTimeout → data swap + slide-in positioning → reflow → transition back to origin
- 6 new unit tests covering slide classes, timing, reduced motion, rapid navigation, and full cycle cleanup
- All 709 tests pass, coverage gates met (98.06% statements, 96.13% branches, 98.06% functions, 98.52% lines)

## Docs updated

- README: navigation feature description
- `docs/component-guide.md`: Player Navigation section
- `docs/accessibility.md`: reduced motion behavior
- `docs/project-requirements.md`: simplified pre-commit verification, added user review step
- `docs/roadmap.md`: removed completed item

## Test plan

- [x] Navigate with keyboard arrows — content slides in correct direction
- [x] Navigate with trackpad swipe — same slide effect
- [x] Rapid keyboard presses — animation stays smooth, doesn't get stuck
- [x] `prefers-reduced-motion: reduce` — transition is instant (no slide)
- [x] Unit tests pass (`npm run verify`)
