### PR TITLE
Refactor: Centralize StatsContext type, simplify ReportSwitcher, add StatsTable template helpers

### DIFF
--- a/docs/roadmap-refactoring-needs.md
+++ b/docs/roadmap-refactoring-needs.md
@@ -16,27 +16,6 @@ Identified refactoring opportunities grouped into logical batches. Each batch is
 
 ---
 
-## Batch 2: Centralize Scattered Utilities (~2-3h)
-
-**Problem:** Small helper functions are copy-pasted across components instead of living in one place.
-
-- `toApiTeamId()` — duplicated in at least 5 files (player-stats, goalie-stats, season-switcher, start-from-season-switcher, player-card)
-- `toSeasonNumber()` — duplicated in season-switcher and start-from-season-switcher
-- `derivePositions()` — lives in `leaderboards/position-utils.ts` but could belong in a shared utils location
-- `toSlug()` — already isolated in `src/app/utils/slug.utils.ts` but the pattern is not followed for other utils
-
-**Affected files:**
-- `src/app/shared/top-controls/season-switcher/season-switcher.component.ts`
-- `src/app/shared/top-controls/start-from-season-switcher/start-from-season-switcher.component.ts`
-- `src/app/player-stats/player-stats.component.ts`
-- `src/app/goalie-stats/goalie-stats.component.ts`
-- `src/app/shared/player-card/player-card.component.ts`
-- `src/app/leaderboards/position-utils.ts`
-
-**Proposed fix:** Create `src/app/shared/utils/` with `season.utils.ts`, `api.utils.ts`, and move/consolidate existing utils there.
-
----
-
 ## Batch 3: Reduce `any` Usage — Improve Type Safety (~3-4h)
 
 **Problem:** Many places use `any` for callback parameters and data, which undermines the value of TypeScript. The most impactful instances:
@@ -88,54 +67,7 @@ Identified refactoring opportunities grouped into logical batches. Each batch is
 
 ---
 
-## Batch 6: Simplify ReportSwitcher Bidirectional Sync (~1-2h)
-
-**Problem:** `ReportSwitcherComponent` uses a `FormControl` kept manually in sync with the filter service — a fragile bidirectional loop:
-
-```typescript
-this.reportType$.subscribe(v => this.reportTypeControl.setValue(...))
-this.reportTypeControl.valueChanges.subscribe(v => filterService.update(...))
-```
-
-**Affected files:**
-- `src/app/shared/top-controls/report-switcher/report-switcher.component.ts`
-
-**Proposed fix:** Remove the `FormControl` and bind directly: reactive observable for display, `(change)` event for updates. Eliminates the sync loop entirely.
-
----
-
-## Batch 7: Centralize Shared Types (~1-2h)
-
-**Problem:** The string union `'player' | 'goalie'` (used as `@Input() context`) appears in 10+ files with no single source of truth. Other repeated inline types (filter shapes, column definitions) are also scattered.
-
-**Affected files:** Multiple components and services throughout.
-
-**Proposed fix:** Create `src/app/shared/types/` directory with:
-- `context.types.ts` — `export type StatsContext = 'player' | 'goalie'`
-- `filter.types.ts` — shared filter state interfaces
-- `stats.types.ts` — shared stats interfaces not already in API types
-
----
-
-## Batch 8: Reduce Template Complexity in StatsTable (~1-2h)
-
-**Problem:** `stats-table.component.html` has conditional rendering logic directly in the template that would be clearer as component methods:
-
-- Header icon selection (material vs emoji vs none) — repeated across header cells
-- Position cell rendering — 3 levels of nested `@if/@else`
-- Complex `[class.*]` bindings with inline boolean expressions
-
-**Affected files:**
-- `src/app/shared/stats-table/stats-table.component.html`
-- `src/app/shared/stats-table/stats-table.component.ts`
-
-**Proposed fix:** Add helper methods (`getHeaderIconType()`, `getPositionDisplay()`, `getCellClass()`) to the component and call them from the template.
-
----
-
 ## Notes
 
 - Batch 1 and Batch 4 are closely related and could be combined into a single "consolidate data-loading patterns" effort.
-- Batch 2 is a good low-risk warm-up — pure moves with no behavioral change.
 - Batch 3 (type safety) can be done incrementally, file by file, without touching logic.
-- Batches 6, 7, 8 are small and self-contained — good candidates for quick wins.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -35,13 +35,9 @@ See [roadmap-refactoring-needs.md](roadmap-refactoring-needs.md) for a detailed 
 Quick summary of areas identified:
 
 1. **Player/Goalie stats components** — ~95% duplicate, extract shared base (~4-6h)
-2. **Scattered utility functions** — `toApiTeamId`, `toSeasonNumber` etc. copied in 5+ places (~2-3h)
-3. **Type safety** — widespread `any` usage, especially in stats-table callbacks (~3-4h)
-4. **Leaderboard components** — regular/playoffs are near-identical, could be one component (~2-3h)
-5. **PlayerCardComponent** — 827 lines, multiple unrelated concerns, should be split (~4-6h)
-6. **ReportSwitcher bidirectional sync** — fragile FormControl loop, can be simplified (~1-2h)
-7. **Shared types** — `'player' | 'goalie'` union and other inline types duplicated across 10+ files (~1-2h)
-8. **StatsTable template complexity** — nested conditionals belong in component methods (~1-2h)
+2. **Type safety** — widespread `any` usage, especially in stats-table callbacks (~3-4h)
+3. **Leaderboard components** — regular/playoffs are near-identical, could be one component (~2-3h)
+4. **PlayerCardComponent** — 827 lines, multiple unrelated concerns, should be split (~4-6h)
 
 ## E2E Testing
 

--- a/src/app/services/drawer-context.service.ts
+++ b/src/app/services/drawer-context.service.ts
@@ -1,7 +1,8 @@
 import { Injectable } from '@angular/core';
 import { BehaviorSubject, map } from 'rxjs';
+import { StatsContext } from '@shared/types/context.types';
 
-export type ControlsContext = 'player' | 'goalie';
+export type ControlsContext = StatsContext;
 
 type DrawerContextState = {
   playerMaxGames: number;

--- a/src/app/shared/comparison-bar/comparison-bar.component.ts
+++ b/src/app/shared/comparison-bar/comparison-bar.component.ts
@@ -7,6 +7,7 @@ import { Observable } from 'rxjs';
 import { map, first } from 'rxjs/operators';
 import { ComparisonService } from '@services/comparison.service';
 import { ComparisonDialogComponent, ComparisonDialogData } from '@shared/comparison-dialog/comparison-dialog.component';
+import { StatsContext } from '@shared/types/context.types';
 
 @Component({
   selector: 'app-comparison-bar',
@@ -15,7 +16,7 @@ import { ComparisonDialogComponent, ComparisonDialogData } from '@shared/compari
   styleUrl: './comparison-bar.component.scss',
 })
 export class ComparisonBarComponent implements OnChanges {
-  @Input() context: 'player' | 'goalie' = 'player';
+  @Input() context: StatsContext = 'player';
   private comparisonService = inject(ComparisonService);
   private translateService = inject(TranslateService);
   private dialog = inject(MatDialog);

--- a/src/app/shared/comparison-dialog/comparison-dialog.component.ts
+++ b/src/app/shared/comparison-dialog/comparison-dialog.component.ts
@@ -16,9 +16,10 @@ import { FilterService } from '@services/filter.service';
 import { ComparisonStatsComponent } from './comparison-stats/comparison-stats.component';
 import { ComparisonRadarComponent } from './comparison-radar/comparison-radar.component';
 import { ComparisonService } from '@services/comparison.service';
+import { StatsContext } from '@shared/types/context.types';
 
 export type ComparisonDialogData = {
-  context: 'player' | 'goalie';
+  context: StatsContext;
   playerA: Player | Goalie;
   playerB: Player | Goalie;
 };

--- a/src/app/shared/comparison-dialog/comparison-radar/comparison-radar.component.ts
+++ b/src/app/shared/comparison-dialog/comparison-radar/comparison-radar.component.ts
@@ -4,6 +4,7 @@ import { BaseChartDirective, provideCharts, withDefaultRegisterables } from 'ng2
 import type { ChartConfiguration, ChartData } from 'chart.js';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import type { Player, Goalie, PlayerScores } from '@services/api.service';
+import { StatsContext } from '@shared/types/context.types';
 
 @Component({
   selector: 'app-comparison-radar',
@@ -16,7 +17,7 @@ export class ComparisonRadarComponent implements OnInit {
   private document = inject(DOCUMENT);
   private translateService = inject(TranslateService);
 
-  @Input() context: 'player' | 'goalie' = 'player';
+  @Input() context: StatsContext = 'player';
   @Input({ required: true }) playerA!: Player | Goalie;
   @Input({ required: true }) playerB!: Player | Goalie;
 

--- a/src/app/shared/comparison-dialog/comparison-stats/comparison-stats.component.ts
+++ b/src/app/shared/comparison-dialog/comparison-stats/comparison-stats.component.ts
@@ -3,6 +3,7 @@ import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import type { Player, Goalie } from '@services/api.service';
 import { FilterService } from '@services/filter.service';
 import { take } from 'rxjs';
+import { StatsContext } from '@shared/types/context.types';
 import {
   PLAYER_STAT_COLUMNS,
   GOALIE_STAT_COLUMNS,
@@ -27,7 +28,7 @@ export type StatRow = {
 export class ComparisonStatsComponent implements OnInit {
   private translateService = inject(TranslateService);
 
-  @Input() context: 'player' | 'goalie' = 'player';
+  @Input() context: StatsContext = 'player';
   @Input({ required: true }) playerA!: Player | Goalie;
   @Input({ required: true }) playerB!: Player | Goalie;
   @Input() isMobile = false;

--- a/src/app/shared/settings-panel/min-games-slider/min-games-slider.component.ts
+++ b/src/app/shared/settings-panel/min-games-slider/min-games-slider.component.ts
@@ -11,6 +11,7 @@ import { TranslateModule } from '@ngx-translate/core';
 import { MatSliderModule } from '@angular/material/slider';
 import { Subject, takeUntil } from 'rxjs';
 import { FilterService, FilterState } from '@services/filter.service';
+import { StatsContext } from '@shared/types/context.types';
 
 @Component({
   selector: 'app-min-games-slider',
@@ -19,7 +20,7 @@ import { FilterService, FilterState } from '@services/filter.service';
   styleUrl: './min-games-slider.component.scss',
 })
 export class MinGamesSliderComponent implements OnInit, OnDestroy, OnChanges {
-  @Input() context: 'player' | 'goalie' = 'player';
+  @Input() context: StatsContext = 'player';
   @Input() maxGames = 0;
 
   minGames: number = 0;

--- a/src/app/shared/settings-panel/position-filter-toggle/position-filter-toggle.component.ts
+++ b/src/app/shared/settings-panel/position-filter-toggle/position-filter-toggle.component.ts
@@ -7,6 +7,7 @@ import { TranslateModule } from '@ngx-translate/core';
 
 import { Subject, takeUntil } from 'rxjs';
 import { FilterService, FilterState, PositionFilter } from '@services/filter.service';
+import { StatsContext } from '@shared/types/context.types';
 
 @Component({
   selector: 'app-position-filter-toggle',
@@ -15,7 +16,7 @@ import { FilterService, FilterState, PositionFilter } from '@services/filter.ser
   styleUrl: './position-filter-toggle.component.scss',
 })
 export class PositionFilterToggleComponent implements OnInit, OnDestroy {
-  @Input() context: 'player' | 'goalie' = 'player';
+  @Input() context: StatsContext = 'player';
   positionFilter: PositionFilter = 'all';
 
   filterService = inject(FilterService);

--- a/src/app/shared/settings-panel/settings-panel.component.ts
+++ b/src/app/shared/settings-panel/settings-panel.component.ts
@@ -1,4 +1,5 @@
 import { Component, Input } from '@angular/core';
+import { StatsContext } from '@shared/types/context.types';
 import { TranslateModule } from '@ngx-translate/core';
 import { PositionFilterToggleComponent } from './position-filter-toggle/position-filter-toggle.component';
 import { StatsModeToggleComponent } from './stats-mode-toggle/stats-mode-toggle.component';
@@ -16,7 +17,7 @@ import { MinGamesSliderComponent } from './min-games-slider/min-games-slider.com
   styleUrl: './settings-panel.component.scss',
 })
 export class SettingsPanelComponent {
-  @Input() context: 'player' | 'goalie' = 'player';
+  @Input() context: StatsContext = 'player';
   @Input() maxGames = 0;
   @Input() contentOnly = false;
   isExpanded = false;

--- a/src/app/shared/settings-panel/stats-mode-toggle/stats-mode-toggle.component.ts
+++ b/src/app/shared/settings-panel/stats-mode-toggle/stats-mode-toggle.component.ts
@@ -7,6 +7,7 @@ import { TranslateModule } from '@ngx-translate/core';
 
 import { Subject, takeUntil } from 'rxjs';
 import { FilterService, FilterState } from '@services/filter.service';
+import { StatsContext } from '@shared/types/context.types';
 
 @Component({
   selector: 'app-stats-mode-toggle',
@@ -15,7 +16,7 @@ import { FilterService, FilterState } from '@services/filter.service';
   styleUrl: './stats-mode-toggle.component.scss',
 })
 export class StatsModeToggleComponent implements OnInit, OnDestroy {
-  @Input() context: 'player' | 'goalie' = 'player';
+  @Input() context: StatsContext = 'player';
   statsPerGame = false;
 
   filterService = inject(FilterService);

--- a/src/app/shared/stats-table/stats-table.component.html
+++ b/src/app/shared/stats-table/stats-table.component.html
@@ -39,10 +39,10 @@
                 [disabled]="!isRowSelected(row) && !(canSelectRow$ | async)"
                 (change)="onRowSelectToggle(row)"
                 [attr.aria-label]="getRowAriaLabel(row, 'a11y.selectToCompare')">
-                {{ positionValue ? positionValue(row, i) : (i + 1) }}
+                {{ getPositionDisplay(row, i) }}
               </mat-checkbox>
             } @else {
-              {{ positionValue ? positionValue(row, i) : (i + 1) }}
+              {{ getPositionDisplay(row, i) }}
             }
           </td>
         </ng-container>
@@ -53,12 +53,11 @@
         <ng-container [matColumnDef]="column.field">
           @if (column.sortable !== false) {
             <th mat-header-cell *matHeaderCellDef mat-sort-header
-              [class.col-left]="column.align === 'left'"
-              [class.col-center]="column.align !== 'left'"
+              [ngClass]="getCellClass(column)"
               matTooltip="{{ 'tableColumn.' + column.field | translate }}">
-              @if (column.icon?.type === 'emoji') {
+              @if (getHeaderIconType(column) === 'emoji') {
                 {{ column.icon!.name }}
-              } @else if (column.icon?.type === 'material') {
+              } @else if (getHeaderIconType(column) === 'material') {
                 <mat-icon>{{ column.icon!.name }}</mat-icon>
               }
               <span [class.sr-only]="column.icon">
@@ -67,12 +66,11 @@
             </th>
           } @else {
             <th mat-header-cell *matHeaderCellDef
-              [class.col-left]="column.align === 'left'"
-              [class.col-center]="column.align !== 'left'"
+              [ngClass]="getCellClass(column)"
               matTooltip="{{ 'tableColumn.' + column.field | translate }}">
-              @if (column.icon?.type === 'emoji') {
+              @if (getHeaderIconType(column) === 'emoji') {
                 {{ column.icon!.name }}
-              } @else if (column.icon?.type === 'material') {
+              } @else if (getHeaderIconType(column) === 'material') {
                 <mat-icon>{{ column.icon!.name }}</mat-icon>
               }
               <span [class.sr-only]="column.icon">
@@ -81,8 +79,7 @@
             </th>
           }
           <td mat-cell *matCellDef="let element"
-            [class.col-left]="column.align === 'left'"
-            [class.col-center]="column.align !== 'left'">
+            [ngClass]="getCellClass(column)">
             {{ formatCell
                 ? formatCell(column.field, element[column.field])
                 : (element[column.field] ?? "-") }}

--- a/src/app/shared/stats-table/stats-table.component.spec.ts
+++ b/src/app/shared/stats-table/stats-table.component.spec.ts
@@ -1063,6 +1063,56 @@ describe('StatsTableComponent', () => {
     });
   });
 
+  describe('template helpers', () => {
+    describe('getHeaderIconType', () => {
+      it('returns emoji for emoji icon column', () => {
+        const col: Column = { field: 'goals', icon: { type: 'emoji', name: '🏆' } };
+        expect(component.getHeaderIconType(col)).toBe('emoji');
+      });
+
+      it('returns material for material icon column', () => {
+        const col: Column = { field: 'goals', icon: { type: 'material', name: 'star' } };
+        expect(component.getHeaderIconType(col)).toBe('material');
+      });
+
+      it('returns null when column has no icon', () => {
+        const col: Column = { field: 'goals' };
+        expect(component.getHeaderIconType(col)).toBeNull();
+      });
+    });
+
+    describe('getCellClass', () => {
+      it('returns col-left true for left-aligned column', () => {
+        const col: Column = { field: 'name', align: 'left' };
+        expect(component.getCellClass(col)).toEqual({ 'col-left': true, 'col-center': false });
+      });
+
+      it('returns col-center true when align is not set', () => {
+        const col: Column = { field: 'score' };
+        expect(component.getCellClass(col)).toEqual({ 'col-left': false, 'col-center': true });
+      });
+
+      it('returns col-center true when align is center', () => {
+        const col: Column = { field: 'score', align: 'center' };
+        expect(component.getCellClass(col)).toEqual({ 'col-left': false, 'col-center': true });
+      });
+    });
+
+    describe('getPositionDisplay', () => {
+      it('returns i+1 when positionValue is not provided', () => {
+        component.positionValue = undefined;
+        expect(component.getPositionDisplay({}, 0)).toBe(1);
+        expect(component.getPositionDisplay({}, 4)).toBe(5);
+      });
+
+      it('returns positionValue(row, i) when positionValue is provided', () => {
+        component.positionValue = (_row: any, i: number) => `#${i + 1}`;
+        expect(component.getPositionDisplay({}, 0)).toBe('#1');
+        expect(component.getPositionDisplay({}, 2)).toBe('#3');
+      });
+    });
+  });
+
   describe('clickable', () => {
     it('should not open dialog on Enter when clickable is false', () => {
       const selectSpy = spyOn(component, 'selectItem');

--- a/src/app/shared/stats-table/stats-table.component.ts
+++ b/src/app/shared/stats-table/stats-table.component.ts
@@ -10,7 +10,7 @@ import {
   AfterViewInit,
   OnDestroy,
 } from '@angular/core';
-import { AsyncPipe } from '@angular/common';
+import { AsyncPipe, NgClass } from '@angular/common';
 import { Observable, of } from 'rxjs';
 
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
@@ -23,7 +23,7 @@ import { MatTooltipModule } from '@angular/material/tooltip';
 import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatIconModule } from '@angular/material/icon';
 import { MatDialog } from '@angular/material/dialog';
-import { Column } from '@shared/column.types';
+import { Column, ColumnIcon } from '@shared/column.types';
 import { Player, Goalie } from '@services/api.service';
 import { PlayerCardComponent, PlayerCardDialogData } from '@shared/player-card/player-card.component';
 
@@ -31,6 +31,7 @@ import { PlayerCardComponent, PlayerCardDialogData } from '@shared/player-card/p
   selector: 'app-stats-table',
   imports: [
     AsyncPipe,
+    NgClass,
     TranslateModule,
     MatTableModule,
     MatFormFieldModule,
@@ -202,6 +203,21 @@ export class StatsTableComponent implements OnChanges, AfterViewInit, OnDestroy 
 
     this.sort.active = canUseDesired ? desired : (fallback ?? desired);
     this.sort.direction = 'desc';
+  }
+
+  getHeaderIconType(column: Column): ColumnIcon['type'] | null {
+    return column.icon?.type ?? null;
+  }
+
+  getCellClass(column: Column): { 'col-left': boolean; 'col-center': boolean } {
+    return {
+      'col-left': column.align === 'left',
+      'col-center': column.align !== 'left',
+    };
+  }
+
+  getPositionDisplay(row: any, i: number): string | number {
+    return this.positionValue ? this.positionValue(row, i) : i + 1;
   }
 
   filterItems(event: Event) {

--- a/src/app/shared/top-controls/report-switcher/report-switcher.component.html
+++ b/src/app/shared/top-controls/report-switcher/report-switcher.component.html
@@ -4,10 +4,11 @@
   <mat-select
     name="reportType"
     aria-label="Stats report type"
-    [formControl]="reportTypeControl"
+    [value]="reportType$ | async"
+    (selectionChange)="changeReportType($event.value)"
   >
     <mat-select-trigger>
-      {{ ('reportType.' + reportTypeControl.value) | translate }}
+      {{ ('reportType.' + (reportType$ | async)) | translate }}
     </mat-select-trigger>
 
     <mat-option value="regular">

--- a/src/app/shared/top-controls/report-switcher/report-switcher.component.spec.ts
+++ b/src/app/shared/top-controls/report-switcher/report-switcher.component.spec.ts
@@ -41,10 +41,6 @@ describe('ReportSwitcherComponent', () => {
       expect(component.context).toBe('player');
     });
 
-    it('should initialize reportType to regular', () => {
-      expect(component.reportTypeControl.value).toBe('regular');
-    });
-
     it('should initialize reportType$ observable', () => {
       expect(component.reportType$).toBeDefined();
     });
@@ -68,8 +64,6 @@ describe('ReportSwitcherComponent', () => {
 
       filterService.updatePlayerFilters({ reportType: 'playoffs' });
       tick();
-
-      expect(component.reportTypeControl.value).toBe('playoffs');
 
       component.reportType$.subscribe((value) => {
         expect(value).toBe('playoffs');
@@ -115,8 +109,6 @@ describe('ReportSwitcherComponent', () => {
       filterService.updateGoalieFilters({ reportType: 'playoffs' });
       tick();
 
-      expect(component.reportTypeControl.value).toBe('playoffs');
-
       component.reportType$.subscribe((value) => {
         expect(value).toBe('playoffs');
       });
@@ -130,88 +122,68 @@ describe('ReportSwitcherComponent', () => {
       filterService.updatePlayerFilters({ reportType: 'playoffs' });
       tick();
 
-      expect(component.reportTypeControl.value).toBe('playoffs');
-
       component.reportType$.subscribe((value) => {
         expect(value).toBe('playoffs');
       });
     }));
   });
 
-  describe('user interactions', () => {
-    it('should update player filters when control value changes', fakeAsync(() => {
+  describe('changeReportType', () => {
+    it('updates player filters when called in player context', fakeAsync(() => {
       component.context = 'player';
       component.ngOnInit();
       tick();
 
-      let result: string | undefined;
-      filterService.playerFilters$.subscribe((filters) => {
-        result = filters.reportType;
-      });
-
-      component.reportTypeControl.setValue('playoffs');
+      component.changeReportType('playoffs');
       tick();
 
-      expect(result).toBe('playoffs');
+      filterService.playerFilters$.subscribe((f) => expect(f.reportType).toBe('playoffs'));
     }));
 
-    it('should sync reportType to goalie filters (global sync)', fakeAsync(() => {
-      component.context = 'player';
-      component.ngOnInit();
-      tick();
-
-      component.reportTypeControl.setValue('playoffs');
-      tick();
-
-      filterService.goalieFilters$.subscribe((filters) => {
-        expect(filters.reportType).toBe('playoffs');
-      });
-    }));
-
-    it('should support selecting both', fakeAsync(() => {
-      component.context = 'player';
-      component.ngOnInit();
-      tick();
-
-      component.reportTypeControl.setValue('both');
-      tick();
-
-      filterService.playerFilters$.subscribe((filters) => {
-        expect(filters.reportType).toBe('both');
-      });
-    }));
-
-    it('should update goalie filters when control value changes in goalie context', fakeAsync(() => {
+    it('updates goalie filters when called in goalie context', fakeAsync(() => {
       component.context = 'goalie';
       component.ngOnChanges({
-        context: {
-          currentValue: 'goalie',
-          previousValue: 'player',
-          firstChange: true,
-          isFirstChange: () => true,
-        },
+        context: { currentValue: 'goalie', previousValue: 'player', firstChange: true, isFirstChange: () => true },
       });
-
       component.ngOnInit();
       tick();
 
-      component.reportTypeControl.setValue('both');
+      component.changeReportType('both');
       tick();
 
-      filterService.goalieFilters$.subscribe((filters) => {
-        expect(filters.reportType).toBe('both');
-      });
+      filterService.goalieFilters$.subscribe((f) => expect(f.reportType).toBe('both'));
     }));
 
-    it('should work correctly after context change', fakeAsync(() => {
+    it('supports all report type values', fakeAsync(() => {
       component.context = 'player';
       component.ngOnInit();
       tick();
 
-      component.reportTypeControl.setValue('playoffs');
+      component.changeReportType('both');
       tick();
 
-      // simulate input change
+      filterService.playerFilters$.subscribe((f) => expect(f.reportType).toBe('both'));
+    }));
+
+    it('syncs reportType to goalie filters via global sync', fakeAsync(() => {
+      component.context = 'player';
+      component.ngOnInit();
+      tick();
+
+      component.changeReportType('playoffs');
+      tick();
+
+      filterService.goalieFilters$.subscribe((f) => expect(f.reportType).toBe('playoffs'));
+    }));
+
+    it('works correctly after context change', fakeAsync(() => {
+      component.context = 'player';
+      component.ngOnInit();
+      tick();
+
+      component.changeReportType('playoffs');
+      tick();
+
       component.context = 'goalie';
       component.ngOnChanges({
         context: {
@@ -223,7 +195,7 @@ describe('ReportSwitcherComponent', () => {
       });
       tick();
 
-      expect(component.reportTypeControl.value).toBe('playoffs');
+      component.reportType$.subscribe((value) => expect(value).toBe('playoffs'));
     }));
   });
 
@@ -308,7 +280,7 @@ describe('ReportSwitcherComponent', () => {
       });
       tick();
 
-      expect(component.reportTypeControl.value).toBe('playoffs');
+      component.reportType$.subscribe((value) => expect(value).toBe('playoffs'));
     }));
   });
 });

--- a/src/app/shared/top-controls/report-switcher/report-switcher.component.ts
+++ b/src/app/shared/top-controls/report-switcher/report-switcher.component.ts
@@ -1,32 +1,28 @@
 import { Component, Input, inject, OnInit, OnDestroy, OnChanges, SimpleChanges } from '@angular/core';
-import { CommonModule } from '@angular/common';
+import { AsyncPipe } from '@angular/common';
 import { TranslateModule } from '@ngx-translate/core';
-import { Subject, takeUntil, map, Observable, of, BehaviorSubject, distinctUntilChanged, switchMap, withLatestFrom, filter } from 'rxjs';
+import { Subject, takeUntil, map, Observable, of, BehaviorSubject, distinctUntilChanged, switchMap } from 'rxjs';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatSelectModule } from '@angular/material/select';
-import { FormControl, ReactiveFormsModule } from '@angular/forms';
 import { ReportType } from '@services/api.service';
 import { FilterService, FilterState } from '@services/filter.service';
+import { StatsContext } from '@shared/types/context.types';
 
 @Component({
   selector: 'app-report-switcher',
-  imports: [MatFormFieldModule, MatSelectModule, TranslateModule, CommonModule, ReactiveFormsModule],
+  imports: [MatFormFieldModule, MatSelectModule, TranslateModule, AsyncPipe],
   templateUrl: './report-switcher.component.html',
   styleUrl: './report-switcher.component.scss',
 })
 export class ReportSwitcherComponent implements OnInit, OnDestroy, OnChanges {
-  @Input() context: 'player' | 'goalie' = 'player';
+  @Input() context: StatsContext = 'player';
   readonly reportTypeOptions: ReportType[] = ['regular', 'playoffs', 'both'];
   destroy$ = new Subject<void>();
 
   filterService = inject(FilterService);
   reportType$: Observable<ReportType> = of('regular');
 
-  readonly reportTypeControl = new FormControl<ReportType>('regular', {
-    nonNullable: true,
-  });
-
-  private readonly context$ = new BehaviorSubject<'player' | 'goalie'>(this.context);
+  private readonly context$ = new BehaviorSubject<StatsContext>(this.context);
 
   ngOnChanges(changes: SimpleChanges): void {
     if (changes['context']) {
@@ -49,26 +45,13 @@ export class ReportSwitcherComponent implements OnInit, OnDestroy, OnChanges {
       distinctUntilChanged(),
       takeUntil(this.destroy$)
     );
+  }
 
-    // Drive the control from the filter state (source of truth).
-    this.reportType$
-      .pipe(takeUntil(this.destroy$))
-      .subscribe((value) => this.reportTypeControl.setValue(value, { emitEvent: false }));
-
-    // Push user changes back into the filter state.
-    this.reportTypeControl.valueChanges
-      .pipe(
-        distinctUntilChanged(),
-        withLatestFrom(this.context$),
-        filter(([value]) => !!value),
-        takeUntil(this.destroy$)
-      )
-      .subscribe(([value, context]) => {
-        const reportType = value as ReportType;
-        context === 'goalie'
-          ? this.filterService.updateGoalieFilters({ reportType })
-          : this.filterService.updatePlayerFilters({ reportType });
-      });
+  changeReportType(value: ReportType): void {
+    const context = this.context$.value;
+    context === 'goalie'
+      ? this.filterService.updateGoalieFilters({ reportType: value })
+      : this.filterService.updatePlayerFilters({ reportType: value });
   }
 
   ngOnDestroy(): void {

--- a/src/app/shared/top-controls/season-switcher/season-switcher.component.ts
+++ b/src/app/shared/top-controls/season-switcher/season-switcher.component.ts
@@ -23,6 +23,7 @@ import { TeamService } from '@services/team.service';
 import { SettingsService } from '@services/settings.service';
 import { toApiTeamId } from '@shared/utils/api.utils';
 import { toSeasonNumber } from '@shared/utils/season.utils';
+import { StatsContext } from '@shared/types/context.types';
 
 @Component({
   selector: 'app-season-switcher',
@@ -37,7 +38,7 @@ import { toSeasonNumber } from '@shared/utils/season.utils';
   styleUrl: './season-switcher.component.scss',
 })
 export class SeasonSwitcherComponent implements OnInit, OnDestroy {
-  @Input() context: 'player' | 'goalie' = 'player';
+  @Input() context: StatsContext = 'player';
   seasons: Season[] = [];
   selectedSeason: number | 'all' = 'all';
   selectedSeasonText?: string;

--- a/src/app/shared/top-controls/top-controls.component.ts
+++ b/src/app/shared/top-controls/top-controls.component.ts
@@ -5,6 +5,7 @@ import { ReportSwitcherComponent } from './report-switcher/report-switcher.compo
 import { SeasonSwitcherComponent } from './season-switcher/season-switcher.component';
 import { StartFromSeasonSwitcherComponent } from './start-from-season-switcher/start-from-season-switcher.component';
 import { SettingsService } from '@services/settings.service';
+import { StatsContext } from '@shared/types/context.types';
 
 @Component({
   selector: 'app-top-controls',
@@ -19,7 +20,7 @@ import { SettingsService } from '@services/settings.service';
   styleUrl: './top-controls.component.scss',
 })
 export class TopControlsComponent implements OnInit {
-  @Input() context: 'player' | 'goalie' = 'player';
+  @Input() context: StatsContext = 'player';
   @Input() contentOnly = false;
 
   isExpanded = true;

--- a/src/app/shared/types/context.types.ts
+++ b/src/app/shared/types/context.types.ts
@@ -1,0 +1,1 @@
+export type StatsContext = 'player' | 'goalie';


### PR DESCRIPTION


- Introduce StatsContext type in shared/types/context.types.ts and update 11 components
- Remove FormControl bidirectional loop from ReportSwitcher, use direct event binding
- Add getHeaderIconType/getCellClass/getPositionDisplay helpers to StatsTableComponent
- Clean up roadmap docs by removing completed batches