### PR TITLE
Refactor: Remove any type

### DIFF
--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -245,6 +245,7 @@ The API endpoint is configured in the service layer. Check:
 - [ ] Unit tests updated/added
 - [ ] `npm run verify` passes (coverage thresholds + production build)
 - [ ] No TypeScript errors
+- [ ] No `any` types — run `npm run lint` to verify
 - [ ] Components properly typed
 - [ ] RxJS subscriptions properly cleaned up
 - [ ] Material components used correctly

--- a/docs/roadmap-refactoring-needs.md
+++ b/docs/roadmap-refactoring-needs.md
@@ -16,27 +16,7 @@ Identified refactoring opportunities grouped into logical batches. Each batch is
 
 ---
 
-## Batch 3: Reduce `any` Usage — Improve Type Safety (~3-4h)
-
-**Problem:** Many places use `any` for callback parameters and data, which undermines the value of TypeScript. The most impactful instances:
-
-- `stats-table.component.ts`: `@Input() data: any = []`, callback types `(row: any) => ...`
-- `player-stats.component.ts` / `goalie-stats.component.ts`: row callbacks typed as `(row: any)`
-- `player-card.component.ts`: `(row as any)?.name` cast
-- `comparison-stats.component.ts` / `comparison-dialog.component.ts`: property access via `Record<string, unknown>` cast
-
-**Affected files:**
-- `src/app/shared/stats-table/stats-table.component.ts`
-- `src/app/player-stats/player-stats.component.ts`
-- `src/app/goalie-stats/goalie-stats.component.ts`
-- `src/app/shared/player-card/player-card.component.ts`
-- `src/app/shared/comparison-dialog/comparison-stats/comparison-stats.component.ts`
-
-**Proposed fix:** Introduce generics on `StatsTableComponent<T extends Player | Goalie>` and properly type all row callbacks. Centralize shared types under `src/app/shared/types/`.
-
----
-
-## Batch 4: Leaderboard Components Deduplication (~2-3h)
+## Batch 2: Leaderboard Components Deduplication (~2-3h)
 
 **Problem:** `LeaderboardRegularComponent` and `LeaderboardPlayoffsComponent` are near-identical — same data-fetching pattern (`OnInit` + `takeUntil` + subscribe), same loading/error state, same position derivation logic. They differ only in API call and column definitions.
 
@@ -48,7 +28,7 @@ Identified refactoring opportunities grouped into logical batches. Each batch is
 
 ---
 
-## Batch 5: Break Up PlayerCardComponent (~4-6h)
+## Batch 3: Break Up PlayerCardComponent (~4-6h)
 
 **Problem:** `player-card.component.ts` is 827 lines doing too many unrelated things:
 
@@ -69,5 +49,4 @@ Identified refactoring opportunities grouped into logical batches. Each batch is
 
 ## Notes
 
-- Batch 1 and Batch 4 are closely related and could be combined into a single "consolidate data-loading patterns" effort.
-- Batch 3 (type safety) can be done incrementally, file by file, without touching logic.
+- Batch 1 and Batch 2 are closely related and could be combined into a single "consolidate data-loading patterns" effort.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -35,9 +35,8 @@ See [roadmap-refactoring-needs.md](roadmap-refactoring-needs.md) for a detailed 
 Quick summary of areas identified:
 
 1. **Player/Goalie stats components** — ~95% duplicate, extract shared base (~4-6h)
-2. **Type safety** — widespread `any` usage, especially in stats-table callbacks (~3-4h)
-3. **Leaderboard components** — regular/playoffs are near-identical, could be one component (~2-3h)
-4. **PlayerCardComponent** — 827 lines, multiple unrelated concerns, should be split (~4-6h)
+2. **Leaderboard components** — regular/playoffs are near-identical, could be one component (~2-3h)
+3. **PlayerCardComponent** — 827 lines, multiple unrelated concerns, should be split (~4-6h)
 
 ## E2E Testing
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,24 @@
+import tsParser from '@typescript-eslint/parser';
+import tsPlugin from '@typescript-eslint/eslint-plugin';
+
+export default [
+  {
+    // Global ignores (no `files` key = applies to all)
+    ignores: ['**/*.spec.ts', 'src/app/services/api.types.generated.ts'],
+  },
+  {
+    files: ['src/**/*.ts'],
+    languageOptions: {
+      parser: tsParser,
+      parserOptions: {
+        project: './tsconfig.app.json',
+      },
+    },
+    plugins: {
+      '@typescript-eslint': tsPlugin,
+    },
+    rules: {
+      '@typescript-eslint/no-explicit-any': 'error',
+    },
+  },
+];

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -4,7 +4,7 @@ import tsPlugin from '@typescript-eslint/eslint-plugin';
 export default [
   {
     // Global ignores (no `files` key = applies to all)
-    ignores: ['**/*.spec.ts', 'src/app/services/api.types.generated.ts'],
+    ignores: ['**/*.spec.ts', 'src/app/services/api.types.generated.ts', 'src/environments/**'],
   },
   {
     files: ['src/**/*.ts'],

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,9 @@
         "@playwright/test": "^1.58.2",
         "@types/jasmine": "~5.1.0",
         "@types/node": "^24.10.13",
+        "@typescript-eslint/eslint-plugin": "^8.56.1",
+        "@typescript-eslint/parser": "^8.56.1",
+        "eslint": "^10.0.2",
         "jasmine-core": "~5.13.0",
         "karma": "~6.4.0",
         "karma-chrome-launcher": "~3.2.0",
@@ -746,6 +749,7 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -1494,6 +1498,139 @@
         "node": ">=18"
       }
     },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.2.tgz",
+      "integrity": "sha512-YF+fE6LV4v5MGWRGj7G404/OZzGNepVF8fxk7jqmqo3lrza7a0uUcDnROGRBG1WFC1omYUS/Wp1f42i0M+3Q3A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^3.0.2",
+        "debug": "^4.3.1",
+        "minimatch": "^10.2.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/brace-expansion": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.3.tgz",
+      "integrity": "sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/minimatch": {
+      "version": "10.2.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.5.2.tgz",
+      "integrity": "sha512-a5MxrdDXEvqnIq+LisyCX6tQMPF/dSJpCfBgBauY+pNZ28yCtSsTvyTYrMhaI+LK26bVyCJfJkT0u8KIj2i1dQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.1.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.1.0.tgz",
+      "integrity": "sha512-/nr9K9wkr3P1EzFTdFdMoLuo1PmIxjmwvPozwoSodjNBdefGujXQUF93u1DDZpEaTuDvMsIQddsd35BwtrW9Xw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.2.tgz",
+      "integrity": "sha512-HOy56KJt48Bx8KmJ+XGQNSUMT/6dZee/M54XyUyuvTvPXJmsERRvBchsUVx1UMe1WwIH49XLAczNC7V2INsuUw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.6.0.tgz",
+      "integrity": "sha512-bIZEUzOI1jkhviX2cp5vNyXQc6olzb2ohewQubuYlMXZ2Q/XjBO0x0XhGPvc9fjSIiUN0vw+0hq53BJ4eQSJKQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.1.0",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
     "node_modules/@fortawesome/angular-fontawesome": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@fortawesome/angular-fontawesome/-/angular-fontawesome-4.0.0.tgz",
@@ -1564,6 +1701,58 @@
       },
       "peerDependencies": {
         "hono": "^4"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
+      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.7",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
+      "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.1",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
       }
     },
     "node_modules/@inquirer/ansi": {
@@ -4086,6 +4275,13 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/esrecurse": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
+      "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -4100,6 +4296,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "24.10.13",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.13.tgz",
@@ -4109,6 +4312,279 @@
       "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.56.1.tgz",
+      "integrity": "sha512-Jz9ZztpB37dNC+HU2HI28Bs9QXpzCz+y/twHOwhyrIRdbuVDxSytJNDl6z/aAKlaRIwC7y8wJdkBv7FxYGgi0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.56.1",
+        "@typescript-eslint/type-utils": "8.56.1",
+        "@typescript-eslint/utils": "8.56.1",
+        "@typescript-eslint/visitor-keys": "8.56.1",
+        "ignore": "^7.0.5",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.4.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.56.1",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.56.1.tgz",
+      "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.56.1",
+        "@typescript-eslint/types": "8.56.1",
+        "@typescript-eslint/typescript-estree": "8.56.1",
+        "@typescript-eslint/visitor-keys": "8.56.1",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.56.1.tgz",
+      "integrity": "sha512-TAdqQTzHNNvlVFfR+hu2PDJrURiwKsUvxFn1M0h95BB8ah5jejas08jUWG4dBA68jDMI988IvtfdAI53JzEHOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.56.1",
+        "@typescript-eslint/types": "^8.56.1",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.56.1.tgz",
+      "integrity": "sha512-YAi4VDKcIZp0O4tz/haYKhmIDZFEUPOreKbfdAN3SzUDMcPhJ8QI99xQXqX+HoUVq8cs85eRKnD+rne2UAnj2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.56.1",
+        "@typescript-eslint/visitor-keys": "8.56.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.56.1.tgz",
+      "integrity": "sha512-qOtCYzKEeyr3aR9f28mPJqBty7+DBqsdd63eO0yyDwc6vgThj2UjWfJIcsFeSucYydqcuudMOprZ+x1SpF3ZuQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.56.1.tgz",
+      "integrity": "sha512-yB/7dxi7MgTtGhZdaHCemf7PuwrHMenHjmzgUW1aJpO+bBU43OycnM3Wn+DdvDO/8zzA9HlhaJ0AUGuvri4oGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.56.1",
+        "@typescript-eslint/typescript-estree": "8.56.1",
+        "@typescript-eslint/utils": "8.56.1",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.4.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.56.1.tgz",
+      "integrity": "sha512-dbMkdIUkIkchgGDIv7KLUpa0Mda4IYjo4IAMJUZ+3xNoUXxMsk9YtKpTHSChRS85o+H9ftm51gsK1dZReY9CVw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.56.1.tgz",
+      "integrity": "sha512-qzUL1qgalIvKWAf9C1HpvBjif+Vm6rcT5wZd4VoMb9+Km3iS3Cv9DY6dMRMDtPnwRAFyAi7YXJpTIEXLvdfPxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.56.1",
+        "@typescript-eslint/tsconfig-utils": "8.56.1",
+        "@typescript-eslint/types": "8.56.1",
+        "@typescript-eslint/visitor-keys": "8.56.1",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.4.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.3.tgz",
+      "integrity": "sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+      "version": "10.2.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.56.1.tgz",
+      "integrity": "sha512-HPAVNIME3tABJ61siYlHzSWCGtOoeP2RTIaHXFMPqjrQKCGB9OgUVdiNgH7TJS2JNIQ5qQ4RsAUDuGaGme/KOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.56.1",
+        "@typescript-eslint/types": "8.56.1",
+        "@typescript-eslint/typescript-estree": "8.56.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.56.1.tgz",
+      "integrity": "sha512-KiROIzYdEV85YygXw6BI/Dx4fnBlFQu6Mq4QE4MOH9fFnhohw6wX/OAvDY2/C+ut0I3RSPKenvZJIVYqJNkhEw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.56.1",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/@vitejs/plugin-basic-ssl": {
@@ -4153,6 +4629,30 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
     "node_modules/agent-base": {
@@ -5067,6 +5567,13 @@
         }
       }
     },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -5453,6 +5960,284 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.0.2.tgz",
+      "integrity": "sha512-uYixubwmqJZH+KLVYIVKY1JQt7tysXhtj21WSvjcSmU5SVNzMus1bgLe+pAt816yQ8opKfheVVoPLqvVMGejYw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.2",
+        "@eslint/config-array": "^0.23.2",
+        "@eslint/config-helpers": "^0.5.2",
+        "@eslint/core": "^1.1.0",
+        "@eslint/plugin-kit": "^0.6.0",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^9.1.1",
+        "eslint-visitor-keys": "^5.0.1",
+        "espree": "^11.1.1",
+        "esquery": "^1.7.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "minimatch": "^10.2.1",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.1.tgz",
+      "integrity": "sha512-GaUN0sWim5qc8KVErfPBWmc31LEsOkrUJbvJZV+xuL3u2phMUK4HIvXlWAakfC8W4nzlK+chPEAkYOYb5ZScIw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@types/esrecurse": "^4.3.1",
+        "@types/estree": "^1.0.8",
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/ajv": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/eslint/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/eslint/node_modules/brace-expansion": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.3.tgz",
+      "integrity": "sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/eslint/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/eslint/node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/eslint/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/eslint/node_modules/minimatch": {
+      "version": "10.2.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/espree": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-11.1.1.tgz",
+      "integrity": "sha512-AVHPqQoZYc+RUM4/3Ly5udlZY/U4LS8pIG05jEjWM2lQMU/oaZ7qshzAl2YP1tfNmXfftH3ohurfwNAug+MnsQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^5.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/etag": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
@@ -5578,6 +6363,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fast-uri": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
@@ -5613,6 +6412,19 @@
         }
       }
     },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -5646,6 +6458,37 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/flatted": {
@@ -6104,6 +6947,16 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/ignore-walk": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-8.0.0.tgz",
@@ -6527,6 +7380,13 @@
         "node": ">=6"
       }
     },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/json-parse-even-better-errors": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-5.0.0.tgz",
@@ -6550,6 +7410,13 @@
       "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
       "dev": true,
       "license": "BSD-2-Clause"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -7059,12 +7926,37 @@
         "node": ">=10"
       }
     },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/listr2": {
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/listr2/-/listr2-9.0.5.tgz",
       "integrity": "sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cli-truncate": "^5.0.0",
         "colorette": "^2.0.20",
@@ -7146,6 +8038,22 @@
         "@lmdb/lmdb-linux-x64": "3.4.4",
         "@lmdb/lmdb-win32-arm64": "3.4.4",
         "@lmdb/lmdb-win32-x64": "3.4.4"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/lodash": {
@@ -7645,6 +8553,13 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/negotiator": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
@@ -7992,6 +8907,24 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/ora": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/ora/-/ora-9.0.0.tgz",
@@ -8023,6 +8956,38 @@
       "dev": true,
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/p-map": {
       "version": "7.0.4",
@@ -8160,6 +9125,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/path-is-absolute": {
@@ -8347,6 +9322,16 @@
       "integrity": "sha512-3sOlxmbKcSHMjlUXQZKQ06jOswE7oVkXPxmZdoB1r5l0q6gTFTQSHxNxOrCccElbW7dxNytifNEo8qidX2Vsig==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
     },
     "node_modules/proc-log": {
       "version": "6.1.0",
@@ -9354,6 +10339,19 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/ts-api-utils": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.4.0.tgz",
+      "integrity": "sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -9374,6 +10372,19 @@
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/type-fest": {
@@ -9540,12 +10551,32 @@
         "browserslist": ">= 4.21.0"
       }
     },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
     "node_modules/uri-js-replace": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/uri-js-replace/-/uri-js-replace-1.0.1.tgz",
       "integrity": "sha512-W+C9NWNLFOoBI2QWDp4UT9pv65r2w5Cx+3sTYFvtMdDBxkKt1syCqsUdSFAChbEe1uK5TfS04wt/nGwmaeIQ0g==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/uri-js/node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/utils-merge": {
       "version": "1.0.1",
@@ -9583,6 +10614,7 @@
       "integrity": "sha512-dZwN5L1VlUBewiP6H9s2+B3e3Jg96D0vzN+Ry73sOefebhYr9f94wwkMNN/9ouoU8pV1BqA1d1zGk8928cx0rg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -9713,6 +10745,16 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/wrap-ansi": {
@@ -9908,6 +10950,19 @@
       "license": "ISC",
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/yoctocolors": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "test:coverage": "npm test -- --code-coverage --progress=false",
     "test:coverage:headless": "npm test -- --watch=false --code-coverage --browsers=ChromeHeadlessNoSandbox --progress=false",
     "test:headless": "npm test -- --watch=false --browsers=ChromeHeadlessNoSandbox --progress=false",
-    "verify": "npm run test:coverage:headless && npm run build",
+    "lint": "eslint src --ext .ts --ignore-pattern '*.spec.ts'",
+    "verify": "npm run lint && npm run test:coverage:headless && npm run build",
     "clean:playwright": "rm -rf .playwright-mcp",
     "e2e": "playwright test",
     "e2e:ui": "playwright test --ui",
@@ -29,6 +30,7 @@
   "engines": {
     "node": ">=24 <25"
   },
+  "type": "module",
   "private": true,
   "dependencies": {
     "@angular/animations": "^21.1.5",
@@ -60,6 +62,9 @@
     "@playwright/test": "^1.58.2",
     "@types/jasmine": "~5.1.0",
     "@types/node": "^24.10.13",
+    "@typescript-eslint/eslint-plugin": "^8.56.1",
+    "@typescript-eslint/parser": "^8.56.1",
+    "eslint": "^10.0.2",
     "jasmine-core": "~5.13.0",
     "karma": "~6.4.0",
     "karma-chrome-launcher": "~3.2.0",

--- a/src/app/goalie-stats/goalie-stats.component.ts
+++ b/src/app/goalie-stats/goalie-stats.component.ts
@@ -25,7 +25,7 @@ import { SettingsService } from '@services/settings.service';
 import { DrawerContextService } from '@services/drawer-context.service';
 import { ViewportService } from '@services/viewport.service';
 import { SettingsPanelComponent } from '@shared/settings-panel/settings-panel.component';
-import { StatsTableComponent } from '@shared/stats-table/stats-table.component';
+import { StatsTableComponent, TableRow } from '@shared/stats-table/stats-table.component';
 import { Column } from '@shared/column.types';
 import { GOALIE_COLUMNS, GOALIE_SEASON_COLUMNS } from '@shared/table-columns';
 import { ComparisonService } from '@services/comparison.service';
@@ -50,8 +50,8 @@ export class GoalieStatsComponent implements OnInit, OnDestroy {
   readonly comparisonService = inject(ComparisonService);
   readonly canSelectRow$ = this.comparisonService.canSelectMore$;
 
-  isRowSelected = (row: any) => this.comparisonService.isSelected(row);
-  onRowSelect = (row: any) => this.comparisonService.toggle(row);
+  isRowSelected = (row: TableRow) => this.comparisonService.isSelected(row as Goalie);
+  onRowSelect = (row: TableRow) => this.comparisonService.toggle(row as Goalie);
 
   reportType: ReportType = 'regular';
   season?: number;
@@ -124,7 +124,7 @@ export class GoalieStatsComponent implements OnInit, OnDestroy {
           // During team changes, startFromSeason is briefly cleared so we don't fetch with the
           // previous team's value. Wait until StartFromSeasonSwitcher resolves the new team's
           // oldest season.
-          if (filters.season === undefined && (params as any).startFrom === undefined) {
+          if (filters.season === undefined && params.startFrom === undefined) {
             this.tableData = [];
             this.maxGames = 0;
             this.drawerContextService.setMaxGames('goalie', 0);

--- a/src/app/leaderboards/regular/leaderboard-regular.component.ts
+++ b/src/app/leaderboards/regular/leaderboard-regular.component.ts
@@ -34,9 +34,9 @@ export class LeaderboardRegularComponent implements OnInit, OnDestroy {
     { field: 'winPercent' },
   ];
 
-  readonly formatCell = (column: string, value: any): string => {
-    if (column === 'winPercent' || column === 'pointsPercent') return this.formatWinPercent(value);
-    return value ?? '';
+  readonly formatCell = (column: string, value: number | string | undefined): string => {
+    if ((column === 'winPercent' || column === 'pointsPercent') && typeof value === 'number') return this.formatWinPercent(value);
+    return String(value ?? '');
   };
 
   ngOnInit(): void {

--- a/src/app/player-stats/player-stats.component.ts
+++ b/src/app/player-stats/player-stats.component.ts
@@ -25,7 +25,7 @@ import { SettingsService } from '@services/settings.service';
 import { DrawerContextService } from '@services/drawer-context.service';
 import { ViewportService } from '@services/viewport.service';
 import { SettingsPanelComponent } from '@shared/settings-panel/settings-panel.component';
-import { StatsTableComponent } from '@shared/stats-table/stats-table.component';
+import { StatsTableComponent, TableRow } from '@shared/stats-table/stats-table.component';
 import { Column } from '@shared/column.types';
 import { PLAYER_COLUMNS } from '@shared/table-columns';
 import { ComparisonService } from '@services/comparison.service';
@@ -50,8 +50,8 @@ export class PlayerStatsComponent implements OnInit, OnDestroy {
   readonly comparisonService = inject(ComparisonService);
   readonly canSelectRow$ = this.comparisonService.canSelectMore$;
 
-  isRowSelected = (row: any) => this.comparisonService.isSelected(row);
-  onRowSelect = (row: any) => this.comparisonService.toggle(row);
+  isRowSelected = (row: TableRow) => this.comparisonService.isSelected(row as Player);
+  onRowSelect = (row: TableRow) => this.comparisonService.toggle(row as Player);
 
   reportType: ReportType = 'regular';
   season?: number;
@@ -125,7 +125,7 @@ export class PlayerStatsComponent implements OnInit, OnDestroy {
           // During team changes, startFromSeason is briefly cleared so we don't fetch with the
           // previous team's value. Wait until StartFromSeasonSwitcher resolves the new team's
           // oldest season.
-          if (filters.season === undefined && (params as any).startFrom === undefined) {
+          if (filters.season === undefined && params.startFrom === undefined) {
             this.tableData = [];
             this.maxGames = 0;
             this.drawerContextService.setMaxGames('player', 0);

--- a/src/app/services/cache.service.ts
+++ b/src/app/services/cache.service.ts
@@ -4,7 +4,7 @@ import { Injectable } from '@angular/core';
   providedIn: 'root',
 })
 export class CacheService {
-  private cache = new Map<string, { data: any; expiry: number }>();
+  private cache = new Map<string, { data: unknown; expiry: number }>();
 
   set<T>(key: string, data: T, ttl: number = 300000) {
     const expiry = Date.now() + ttl;
@@ -19,7 +19,7 @@ export class CacheService {
       this.cache.delete(key);
       return null;
     }
-    return cached.data;
+    return cached.data as T;
   }
 
   clear(key: string) {

--- a/src/app/services/stats.service.ts
+++ b/src/app/services/stats.service.ts
@@ -40,7 +40,7 @@ export class StatsService {
         ...perGameStats,
         score: scoreAdjustedByGames,
         scoreAdjustedByGames: scoreAdjustedByGames,
-        seasons: (item as any).seasons, // Preserve seasons if they exist
+        seasons: (item as Record<string, unknown>)['seasons'], // Preserve seasons if they exist
         ...Object.fromEntries(fixedFields.map((field) => [field, (item as Record<string, unknown>)[field]])),
       } as unknown as T;
     });

--- a/src/app/shared/comparison-dialog/comparison-radar/comparison-radar.component.ts
+++ b/src/app/shared/comparison-dialog/comparison-radar/comparison-radar.component.ts
@@ -1,7 +1,7 @@
 import { DOCUMENT } from '@angular/common';
 import { Component, Input, OnInit, inject } from '@angular/core';
 import { BaseChartDirective, provideCharts, withDefaultRegisterables } from 'ng2-charts';
-import type { ChartConfiguration, ChartData } from 'chart.js';
+import type { ChartConfiguration, ChartData, TooltipItem } from 'chart.js';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import type { Player, Goalie, PlayerScores } from '@services/api.service';
 import { StatsContext } from '@shared/types/context.types';
@@ -73,7 +73,7 @@ export class ComparisonRadarComponent implements OnInit {
         },
         tooltip: {
           callbacks: {
-            label: (context: any) => {
+            label: (context: TooltipItem<'radar'>) => {
               const label = context.dataset.label || '';
               const value = context.parsed.r;
               return `${label}: ${value}/100`;
@@ -85,7 +85,7 @@ export class ComparisonRadarComponent implements OnInit {
           backgroundColor: tooltipBg,
           borderColor: gridColor,
           borderWidth: 1,
-        } as any,
+        },
       },
     };
   }

--- a/src/app/shared/player-card/player-card-graphs/player-card-graphs.component.ts
+++ b/src/app/shared/player-card/player-card-graphs/player-card-graphs.component.ts
@@ -14,7 +14,7 @@ import {
 import type { Subscription } from 'rxjs';
 import { MatCheckboxChange, MatCheckboxModule } from '@angular/material/checkbox';
 import { BaseChartDirective, provideCharts, withDefaultRegisterables } from 'ng2-charts';
-import type { ChartConfiguration, ChartData, ChartDataset } from 'chart.js';
+import type { ChartConfiguration, ChartData, ChartDataset, TooltipItem } from 'chart.js';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import type {
   Goalie,
@@ -104,13 +104,13 @@ export class PlayerCardGraphsComponent implements OnInit, OnChanges, AfterViewIn
       },
       tooltip: {
         callbacks: {
-          label: (context: any) => {
+          label: (context: TooltipItem<'radar'>) => {
             const label = context.dataset.label || '';
             const value = context.parsed.r;
             return `${label}: ${value}/100`;
           },
         },
-      } as any,
+      },
     },
   };
 
@@ -254,41 +254,41 @@ export class PlayerCardGraphsComponent implements OnInit, OnChanges, AfterViewIn
         legend: {
           ...(plugins.legend ?? {}),
           labels: {
-            ...((plugins.legend as any)?.labels ?? {}),
+            ...(plugins.legend?.labels ?? {}),
             color: textColor,
           },
         },
         tooltip: {
-          ...((plugins as any).tooltip ?? {}),
+          ...(plugins.tooltip ?? {}),
           titleColor: textColor,
           bodyColor: textColor,
           footerColor: textColor,
           backgroundColor: tooltipBg,
           borderColor: gridColor,
           borderWidth: 1,
-        } as any,
+        },
       },
       scales: {
         ...scales,
         x: {
           ...(scales['x'] ?? {}),
           ticks: {
-            ...(((scales['x'] as any) ?? {})?.ticks ?? {}),
+            ...((scales['x'] as { ticks?: Record<string, unknown> })?.ticks ?? {}),
             color: textColor,
           },
           grid: {
-            ...(((scales['x'] as any) ?? {})?.grid ?? {}),
+            ...((scales['x'] as { grid?: Record<string, unknown> })?.grid ?? {}),
             color: gridColor,
           },
         },
         y: {
           ...(scales['y'] ?? {}),
           ticks: {
-            ...(((scales['y'] as any) ?? {})?.ticks ?? {}),
+            ...((scales['y'] as { ticks?: Record<string, unknown> })?.ticks ?? {}),
             color: textColor,
           },
           grid: {
-            ...(((scales['y'] as any) ?? {})?.grid ?? {}),
+            ...((scales['y'] as { grid?: Record<string, unknown> })?.grid ?? {}),
             color: gridColor,
           },
         },
@@ -312,7 +312,7 @@ export class PlayerCardGraphsComponent implements OnInit, OnChanges, AfterViewIn
       const root = this.document.documentElement;
       const rootStyle = root ? getComputedStyle(root) : undefined;
       const computedSchemeRaw =
-        (rootStyle as any)?.colorScheme || rootStyle?.getPropertyValue('color-scheme') || '';
+        (rootStyle as CSSStyleDeclaration & { colorScheme?: string })?.colorScheme || rootStyle?.getPropertyValue('color-scheme') || '';
       const schemeTokens = computedSchemeRaw.trim().split(/\s+/).filter(Boolean);
       const schemeToken = schemeTokens.length === 1 ? schemeTokens[0] : undefined;
 
@@ -432,7 +432,7 @@ export class PlayerCardGraphsComponent implements OnInit, OnChanges, AfterViewIn
         },
         tooltip: {
           callbacks: {
-            label: (context: any) => {
+            label: (context: TooltipItem<'radar'>) => {
               const label = context.dataset.label || '';
               const value = context.parsed.r;
               return `${label}: ${value}/100`;
@@ -444,7 +444,7 @@ export class PlayerCardGraphsComponent implements OnInit, OnChanges, AfterViewIn
           backgroundColor: tooltipBg,
           borderColor: outlineColor,
           borderWidth: 1,
-        } as any,
+        },
       },
     };
   }
@@ -524,14 +524,16 @@ export class PlayerCardGraphsComponent implements OnInit, OnChanges, AfterViewIn
   }
 
   private buildGoalieRadarData(): void {
-    const goalie = this.data as any;
+    const goalie = this.data as Goalie;
 
     if (!goalie.scores) {
       return;
     }
 
+    const scores = goalie.scores;
+
     // Check if gaa/savePercent are available (season endpoint)
-    const hasExtendedStats = 'gaa' in goalie.scores;
+    const hasExtendedStats = 'gaa' in scores;
 
     const statKeys = hasExtendedStats
       ? ['wins', 'saves', 'shutouts', 'gaa', 'savePercent']
@@ -541,7 +543,7 @@ export class PlayerCardGraphsComponent implements OnInit, OnChanges, AfterViewIn
       this.translateService.instant(`tableColumn.${key}`)
     );
 
-    const data = statKeys.map((key) => goalie.scores[key]);
+    const data = statKeys.map((key) => (scores as Record<string, number>)[key]);
 
     this.radarChartData = {
       labels,
@@ -642,15 +644,16 @@ export class PlayerCardGraphsComponent implements OnInit, OnChanges, AfterViewIn
         }
 
         // Use position-based score values when filter is active
-        let value: any;
+        const seasonRecord = season as Record<string, unknown>;
+        let value: number | string | undefined;
         if (usePositionScores && key === 'score') {
           const playerSeason = season as PlayerSeasonStats;
-          value = playerSeason.scoreByPosition ?? (season as any)[key];
+          value = playerSeason.scoreByPosition ?? (seasonRecord[key] as number | undefined);
         } else if (usePositionScores && key === 'scoreAdjustedByGames') {
           const playerSeason = season as PlayerSeasonStats;
-          value = playerSeason.scoreByPositionAdjustedByGames ?? (season as any)[key];
+          value = playerSeason.scoreByPositionAdjustedByGames ?? (seasonRecord[key] as number | undefined);
         } else {
-          value = (season as any)[key];
+          value = seasonRecord[key] as number | string | undefined;
         }
 
         const numeric = typeof value === 'string' ? parseFloat(value) : value;

--- a/src/app/shared/player-card/player-card.component.ts
+++ b/src/app/shared/player-card/player-card.component.ts
@@ -525,25 +525,19 @@ export class PlayerCardComponent implements OnDestroy {
     const usePositionScores = !this.isGoalie && this.positionFilter !== 'all';
 
     this.seasonDataSource = sortedSeasons.map((season) => {
-      const seasonData = {
+      const playerSeason = season as PlayerSeasonStats;
+      const scoreOverrides = usePositionScores ? {
+        ...(playerSeason.scoreByPosition != null ? { score: playerSeason.scoreByPosition } : {}),
+        ...(playerSeason.scoreByPositionAdjustedByGames != null ? { scoreAdjustedByGames: playerSeason.scoreByPositionAdjustedByGames } : {}),
+      } : {};
+
+      return {
         ...season,
         seasonDisplay: this.isMobile
           ? this.formatSeasonShort(season.season)
           : this.formatSeasonDisplay(season.season),
+        ...scoreOverrides,
       };
-
-      // Transform score values when position filter is active
-      if (usePositionScores) {
-        const playerSeason = season as PlayerSeasonStats;
-        if (playerSeason.scoreByPosition != null) {
-          (seasonData as any).score = playerSeason.scoreByPosition;
-        }
-        if (playerSeason.scoreByPositionAdjustedByGames != null) {
-          (seasonData as any).scoreAdjustedByGames = playerSeason.scoreByPositionAdjustedByGames;
-        }
-      }
-
-      return seasonData;
     }) as (PlayerSeasonStats | GoalieSeasonStats)[];
 
     // Get column names from the first season object

--- a/src/app/shared/stats-table/stats-table.component.html
+++ b/src/app/shared/stats-table/stats-table.component.html
@@ -81,8 +81,8 @@
           <td mat-cell *matCellDef="let element"
             [ngClass]="getCellClass(column)">
             {{ formatCell
-                ? formatCell(column.field, element[column.field])
-                : (element[column.field] ?? "-") }}
+                ? formatCell(column.field, getCellValue(element, column.field))
+                : (getCellValue(element, column.field) ?? "-") }}
           </td>
         </ng-container>
       }

--- a/src/app/shared/stats-table/stats-table.component.spec.ts
+++ b/src/app/shared/stats-table/stats-table.component.spec.ts
@@ -1,5 +1,5 @@
 import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
-import { StatsTableComponent } from './stats-table.component';
+import { StatsTableComponent, TableRow } from './stats-table.component';
 import { MatTableDataSource } from '@angular/material/table';
 import { MatDialog, MatDialogModule } from '@angular/material/dialog';
 import { MatSortModule } from '@angular/material/sort';
@@ -1021,7 +1021,7 @@ describe('StatsTableComponent', () => {
   describe('formatCell', () => {
     it('should use default rendering when formatCell is not provided', () => {
       component.columns = [{ field: 'goals' }];
-      component.data = [{ goals: 10 }];
+      component.data = [{ goals: 10 }] as Player[];
       component.ngOnChanges({ data: new SimpleChange(null, [{ goals: 10 }], true) });
       fixture.detectChanges();
 
@@ -1031,8 +1031,8 @@ describe('StatsTableComponent', () => {
 
     it('should apply formatCell when provided', () => {
       component.columns = [{ field: 'goals' }];
-      component.formatCell = (col, val) => col === 'goals' ? `${val}G` : val;
-      component.data = [{ goals: 10 }];
+      component.formatCell = (col, val) => col === 'goals' ? `${val}G` : String(val ?? '');
+      component.data = [{ goals: 10 }] as Player[];
       component.ngOnChanges({ data: new SimpleChange(null, [{ goals: 10 }], true) });
       fixture.detectChanges();
 
@@ -1101,14 +1101,14 @@ describe('StatsTableComponent', () => {
     describe('getPositionDisplay', () => {
       it('returns i+1 when positionValue is not provided', () => {
         component.positionValue = undefined;
-        expect(component.getPositionDisplay({}, 0)).toBe(1);
-        expect(component.getPositionDisplay({}, 4)).toBe(5);
+        expect(component.getPositionDisplay({} as Player, 0)).toBe(1);
+        expect(component.getPositionDisplay({} as Player, 4)).toBe(5);
       });
 
       it('returns positionValue(row, i) when positionValue is provided', () => {
-        component.positionValue = (_row: any, i: number) => `#${i + 1}`;
-        expect(component.getPositionDisplay({}, 0)).toBe('#1');
-        expect(component.getPositionDisplay({}, 2)).toBe('#3');
+        component.positionValue = (_row: TableRow, i: number) => `#${i + 1}`;
+        expect(component.getPositionDisplay({} as Player, 0)).toBe('#1');
+        expect(component.getPositionDisplay({} as Player, 2)).toBe('#3');
       });
     });
 

--- a/src/app/shared/stats-table/stats-table.component.spec.ts
+++ b/src/app/shared/stats-table/stats-table.component.spec.ts
@@ -1111,6 +1111,24 @@ describe('StatsTableComponent', () => {
         expect(component.getPositionDisplay({}, 2)).toBe('#3');
       });
     });
+
+    describe('getCellValue', () => {
+      it('returns the numeric value for a known field on a Player row', () => {
+        expect(component.getCellValue(mockPlayerData[0], 'goals')).toBe(50);
+      });
+
+      it('returns the string value for a name field', () => {
+        expect(component.getCellValue(mockPlayerData[0], 'name')).toBe('Player 1');
+      });
+
+      it('returns undefined for a field not present on the row', () => {
+        expect(component.getCellValue(mockPlayerData[0], 'nonexistent')).toBeUndefined();
+      });
+
+      it('works for Goalie rows', () => {
+        expect(component.getCellValue(mockGoalieData[0], 'wins')).toBe(40);
+      });
+    });
   });
 
   describe('clickable', () => {

--- a/src/app/shared/stats-table/stats-table.component.ts
+++ b/src/app/shared/stats-table/stats-table.component.ts
@@ -56,7 +56,7 @@ export class StatsTableComponent implements OnChanges, AfterViewInit, OnDestroy 
   loadingProgress = 0;
   loadingBuffer = 0;
 
-  @Input() data: any = [];
+  @Input() data: (Player | Goalie)[] = [];
   @Input() columns: Column[] = [];
   @Input() defaultSortColumn = 'score';
   @Input() loading = false;
@@ -64,18 +64,18 @@ export class StatsTableComponent implements OnChanges, AfterViewInit, OnDestroy 
   @Input() tableId = 'stats-table';
   @Input() showSearch = true;
   @Input() showPositionColumn = true;
-  @Input() positionValue?: (row: any, index: number) => string | number;
+  @Input() positionValue?: (row: Player | Goalie, index: number) => string | number;
   @Input() selectRow = false;
-  @Input() isRowSelected: (row: any) => boolean = () => false;
+  @Input() isRowSelected: (row: Player | Goalie) => boolean = () => false;
   @Input() canSelectRow$: Observable<boolean> = of(true);
-  @Input() onRowSelect?: (row: any) => void;
+  @Input() onRowSelect?: (row: Player | Goalie) => void;
   @Input() clickable = true;
-  @Input() formatCell?: (column: string, value: any) => string;
+  @Input() formatCell?: (column: string, value: number | string | undefined) => string;
 
   instructionsId = 'stats-table-instructions';
   activeRowIndex = 0;
 
-  dataSource = new MatTableDataSource<any>([]);
+  dataSource = new MatTableDataSource<Player | Goalie>([]);
   dynamicColumns: Column[] = [];
   displayedFields: string[] = [];
 
@@ -216,8 +216,12 @@ export class StatsTableComponent implements OnChanges, AfterViewInit, OnDestroy 
     };
   }
 
-  getPositionDisplay(row: any, i: number): string | number {
+  getPositionDisplay(row: Player | Goalie, i: number): string | number {
     return this.positionValue ? this.positionValue(row, i) : i + 1;
+  }
+
+  getCellValue(row: Player | Goalie, field: string): number | string | undefined {
+    return (row as Record<string, unknown>)[field] as number | string | undefined;
   }
 
   filterItems(event: Event) {
@@ -257,7 +261,7 @@ export class StatsTableComponent implements OnChanges, AfterViewInit, OnDestroy 
     });
   }
 
-  onRowSelectToggle(row: any): void {
+  onRowSelectToggle(row: Player | Goalie): void {
     this.onRowSelect?.(row);
   }
 
@@ -353,7 +357,7 @@ export class StatsTableComponent implements OnChanges, AfterViewInit, OnDestroy 
   }
 
   getRowAriaLabel(row: Player | Goalie, translateKey: string): string {
-    const name = (row as any)?.name ?? '';
+    const name = row?.name ?? '';
     return this.translate.instant(translateKey, { name });
   }
 

--- a/src/app/shared/stats-table/stats-table.component.ts
+++ b/src/app/shared/stats-table/stats-table.component.ts
@@ -24,7 +24,9 @@ import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatIconModule } from '@angular/material/icon';
 import { MatDialog } from '@angular/material/dialog';
 import { Column, ColumnIcon } from '@shared/column.types';
-import { Player, Goalie } from '@services/api.service';
+import { Player, Goalie, RegularLeaderboardEntry, PlayoffLeaderboardEntry } from '@services/api.service';
+
+export type TableRow = Player | Goalie | RegularLeaderboardEntry | PlayoffLeaderboardEntry;
 import { PlayerCardComponent, PlayerCardDialogData } from '@shared/player-card/player-card.component';
 
 @Component({
@@ -56,7 +58,7 @@ export class StatsTableComponent implements OnChanges, AfterViewInit, OnDestroy 
   loadingProgress = 0;
   loadingBuffer = 0;
 
-  @Input() data: (Player | Goalie)[] = [];
+  @Input() data: TableRow[] = [];
   @Input() columns: Column[] = [];
   @Input() defaultSortColumn = 'score';
   @Input() loading = false;
@@ -64,18 +66,18 @@ export class StatsTableComponent implements OnChanges, AfterViewInit, OnDestroy 
   @Input() tableId = 'stats-table';
   @Input() showSearch = true;
   @Input() showPositionColumn = true;
-  @Input() positionValue?: (row: Player | Goalie, index: number) => string | number;
+  @Input() positionValue?: (row: TableRow, index: number) => string | number;
   @Input() selectRow = false;
-  @Input() isRowSelected: (row: Player | Goalie) => boolean = () => false;
+  @Input() isRowSelected: (row: TableRow) => boolean = () => false;
   @Input() canSelectRow$: Observable<boolean> = of(true);
-  @Input() onRowSelect?: (row: Player | Goalie) => void;
+  @Input() onRowSelect?: (row: TableRow) => void;
   @Input() clickable = true;
   @Input() formatCell?: (column: string, value: number | string | undefined) => string;
 
   instructionsId = 'stats-table-instructions';
   activeRowIndex = 0;
 
-  dataSource = new MatTableDataSource<Player | Goalie>([]);
+  dataSource = new MatTableDataSource<TableRow>([]);
   dynamicColumns: Column[] = [];
   displayedFields: string[] = [];
 
@@ -216,11 +218,11 @@ export class StatsTableComponent implements OnChanges, AfterViewInit, OnDestroy 
     };
   }
 
-  getPositionDisplay(row: Player | Goalie, i: number): string | number {
+  getPositionDisplay(row: TableRow, i: number): string | number {
     return this.positionValue ? this.positionValue(row, i) : i + 1;
   }
 
-  getCellValue(row: Player | Goalie, field: string): number | string | undefined {
+  getCellValue(row: TableRow, field: string): number | string | undefined {
     return (row as Record<string, unknown>)[field] as number | string | undefined;
   }
 
@@ -230,15 +232,15 @@ export class StatsTableComponent implements OnChanges, AfterViewInit, OnDestroy 
     setTimeout(() => this.ensureActiveRowInRange(), 0);
   }
 
-  selectItem(data: Player | Goalie) {
+  selectItem(data: TableRow) {
     // Track navigated index in a closure so CDK focus restoration
     // (which triggers onRowFocus) cannot overwrite it before afterClosed fires.
     let navigatedIndex = this.dataSource.filteredData.indexOf(data);
 
     const dialogData: PlayerCardDialogData = {
-      player: data,
+      player: data as Player | Goalie,
       navigationContext: {
-        allPlayers: this.dataSource.filteredData,
+        allPlayers: this.dataSource.filteredData as (Player | Goalie)[],
         currentIndex: navigatedIndex,
         onNavigate: (newIndex: number) => {
           navigatedIndex = newIndex;
@@ -261,7 +263,7 @@ export class StatsTableComponent implements OnChanges, AfterViewInit, OnDestroy 
     });
   }
 
-  onRowSelectToggle(row: Player | Goalie): void {
+  onRowSelectToggle(row: TableRow): void {
     this.onRowSelect?.(row);
   }
 
@@ -313,7 +315,7 @@ export class StatsTableComponent implements OnChanges, AfterViewInit, OnDestroy 
     return index === this.activeRowIndex ? 0 : -1;
   }
 
-  onRowKeydown(event: KeyboardEvent, row: Player | Goalie, index: number): void {
+  onRowKeydown(event: KeyboardEvent, row: TableRow, index: number): void {
     switch (event.key) {
       case 'Enter': {
         if (!this.clickable) return;
@@ -356,8 +358,8 @@ export class StatsTableComponent implements OnChanges, AfterViewInit, OnDestroy 
     }
   }
 
-  getRowAriaLabel(row: Player | Goalie, translateKey: string): string {
-    const name = row?.name ?? '';
+  getRowAriaLabel(row: TableRow, translateKey: string): string {
+    const name = (row as { name?: string })?.name ?? '';
     return this.translate.instant(translateKey, { name });
   }
 

--- a/src/app/shared/top-controls/season-switcher/season-switcher.component.ts
+++ b/src/app/shared/top-controls/season-switcher/season-switcher.component.ts
@@ -17,7 +17,7 @@ import {
   switchMap,
   takeUntil,
 } from 'rxjs';
-import { ApiService, Season } from '@services/api.service';
+import { ApiService, ReportType, Season } from '@services/api.service';
 import { FilterService, FilterState } from '@services/filter.service';
 import { TeamService } from '@services/team.service';
 import { SettingsService } from '@services/settings.service';
@@ -95,7 +95,7 @@ export class SeasonSwitcherComponent implements OnInit, OnDestroy {
           }),
           {
             prevTeamId: undefined as string | undefined,
-            reportType: 'regular' as any,
+            reportType: 'regular' as ReportType,
             teamId: undefined as string | undefined,
             startFrom: undefined as number | undefined,
             initialized: false,
@@ -132,7 +132,7 @@ export class SeasonSwitcherComponent implements OnInit, OnDestroy {
           this.seasons = [...data]
             .reverse()
             .map((s) => {
-              const normalizedSeason = toSeasonNumber((s as any).season);
+              const normalizedSeason = toSeasonNumber(s.season);
               return normalizedSeason === undefined ? s : { ...s, season: normalizedSeason };
             });
 

--- a/src/app/shared/top-controls/start-from-season-switcher/start-from-season-switcher.component.ts
+++ b/src/app/shared/top-controls/start-from-season-switcher/start-from-season-switcher.component.ts
@@ -77,14 +77,14 @@ export class StartFromSeasonSwitcherComponent implements OnInit, OnDestroy {
       )
       .subscribe(({ data, teamChanged }) => {
         const normalized = [...data].map((s) => {
-          const normalizedSeason = toSeasonNumber((s as any).season);
+          const normalizedSeason = toSeasonNumber(s.season);
           return normalizedSeason === undefined ? s : { ...s, season: normalizedSeason };
         });
 
         // User intent is selecting a "starting" season, so present oldest → newest.
         this.seasons = normalized.sort((a, b) => {
-          const aSeason = toSeasonNumber((a as any).season);
-          const bSeason = toSeasonNumber((b as any).season);
+          const aSeason = toSeasonNumber(a.season);
+          const bSeason = toSeasonNumber(b.season);
           if (aSeason === undefined || bSeason === undefined) return 0;
           return aSeason - bSeason;
         });


### PR DESCRIPTION
## Summary

- **Eliminates all explicit `any` types** across the codebase (36 → 0 ESLint violations)
- **Adds `TableRow` union type** (`Player | Goalie | RegularLeaderboardEntry | PlayoffLeaderboardEntry`) exported from `StatsTableComponent` — covers all real usages of the table
- **Adds TDD-tested `getCellValue` helper** on `StatsTableComponent` for type-safe cell access in templates
- **Fixes Chart.js typing** — tooltip callbacks use `TooltipItem<'radar'>`, scale/plugin spreads use `Record<string, unknown>` casts instead of `as any`
- Adds `npm run lint` (ESLint `no-explicit-any` rule) to the `verify` pipeline and code review checklist

## Files changed

- `eslint.config.js` — new; enforces `@typescript-eslint/no-explicit-any`, excludes spec files and generated types
- `stats-table.component.ts` — `TableRow` union, typed `@Input()` callbacks, new `getCellValue`
- `player-stats / goalie-stats` — row callbacks use `TableRow`, cast to `Player/Goalie` at call site
- `cache.service.ts` — internal map stores `unknown`, getter casts to `T`
- `stats.service.ts` — seasons preserved via `Record<string, unknown>` cast
- `season-switcher / start-from-season-switcher` — `s.season` (typed `number`) used directly
- `leaderboard-regular` — `formatCell` value typed as `number | string | undefined`
- `player-card.component.ts` — score overrides built with object spread instead of mutation
- `player-card-graphs.component.ts` — Chart.js `TooltipItem<'radar'>`, `CSSStyleDeclaration & { colorScheme? }` cast, goalie cast to `Goalie`
- `comparison-radar.component.ts` — same Chart.js tooltip fix
