### PR TITLE
Refactor: Extract StatsBaseComponent to eliminate Player/Goalie duplication

### DIFF
--- a/docs/roadmap-refactoring-needs.md
+++ b/docs/roadmap-refactoring-needs.md
@@ -4,19 +4,7 @@ Identified refactoring opportunities grouped into logical batches. Each batch is
 
 ---
 
-## Batch 1: Consolidate Player/Goalie Stats Components (~4-6h)
-
-**Problem:** `PlayerStatsComponent` and `GoalieStatsComponent` are ~95% identical — same RxJS pipeline, same filter handling, same loading/error state, same `toApiTeamId()` helper. About 400 lines of near-duplicate code.
-
-**Affected files:**
-- `src/app/player-stats/player-stats.component.ts`
-- `src/app/goalie-stats/goalie-stats.component.ts`
-
-**Proposed fix:** Extract an abstract base component or shared mixin with the common data-fetching pipeline and let each component only define its type-specific parts (columns, API call, data transform).
-
----
-
-## Batch 2: Break Up PlayerCardComponent (~4-6h)
+## Batch 1: Break Up PlayerCardComponent (~4-6h)
 
 **Problem:** `player-card.component.ts` is 827 lines doing too many unrelated things:
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -34,8 +34,7 @@ See [roadmap-refactoring-needs.md](roadmap-refactoring-needs.md) for a detailed 
 
 Quick summary of areas identified:
 
-1. **Player/Goalie stats components** — ~95% duplicate, extract shared base (~4-6h)
-2. **PlayerCardComponent** — 827 lines, multiple unrelated concerns, should be split (~4-6h)
+1. **PlayerCardComponent** — 827 lines, multiple unrelated concerns, should be split (~4-6h)
 
 ## E2E Testing
 

--- a/src/app/base/stats/stats-base.component.ts
+++ b/src/app/base/stats/stats-base.component.ts
@@ -1,0 +1,187 @@
+import { Directive, OnInit, OnDestroy, inject } from '@angular/core';
+import {
+  Subject,
+  Observable,
+  auditTime,
+  catchError,
+  combineLatest,
+  distinctUntilChanged,
+  EMPTY,
+  map,
+  of,
+  switchMap,
+  takeUntil,
+} from 'rxjs';
+import { ApiParams, ApiService, Player, Goalie, ReportType } from '@services/api.service';
+import { FilterService, FilterState, PositionFilter } from '@services/filter.service';
+import { StatsService } from '@services/stats.service';
+import { TeamService } from '@services/team.service';
+import { SettingsService } from '@services/settings.service';
+import { DrawerContextService } from '@services/drawer-context.service';
+import { ViewportService } from '@services/viewport.service';
+import { TableRow } from '@shared/stats-table/stats-table.component';
+import { Column } from '@shared/column.types';
+import { ComparisonService } from '@services/comparison.service';
+import { toApiTeamId } from '@shared/utils/api.utils';
+
+@Directive()
+export abstract class StatsBaseComponent<T extends Player | Goalie> implements OnInit, OnDestroy {
+  protected apiService = inject(ApiService);
+  protected filterService = inject(FilterService);
+  protected statsService = inject(StatsService);
+  protected teamService = inject(TeamService);
+  protected settingsService = inject(SettingsService);
+  protected drawerContextService = inject(DrawerContextService);
+  protected destroy$ = new Subject<void>();
+
+  readonly isMobile$ = inject(ViewportService).isMobile$;
+  readonly comparisonService = inject(ComparisonService);
+  readonly canSelectRow$ = this.comparisonService.canSelectMore$;
+
+  abstract isRowSelected: (row: TableRow) => boolean;
+  abstract onRowSelect: (row: TableRow) => void;
+
+  reportType: ReportType = 'regular';
+  season?: number;
+  statsPerGame: boolean = false;
+  minGames: number = 0;
+  maxGames: number = 0;
+  positionFilter: PositionFilter = 'all';
+  tableData: T[] = [];
+  tableColumns: Column[] = [];
+  defaultSortColumn: 'score' | 'scoreAdjustedByGames' = 'score';
+  loading = false;
+  apiError = false;
+
+  protected abstract get filters$(): Observable<FilterState>;
+  protected abstract fetchApi(params: ApiParams): Observable<T[]>;
+  protected abstract applyPerGame(data: T[]): T[];
+  protected abstract getColumns(statsPerGame: boolean, season?: number): Column[];
+  protected abstract readonly drawerKey: 'player' | 'goalie';
+
+  /** Override to add extra fields to the distinctUntilChanged check (e.g. positionFilter). */
+  protected extraSameCheck(_a: FilterState, _b: FilterState): boolean {
+    return true;
+  }
+
+  /** Override to apply post-fetch filtering (e.g. position filtering for players). */
+  protected applyFilters(data: T[]): T[] {
+    return data;
+  }
+
+  ngOnInit(): void {
+    combineLatest([
+      this.filters$,
+      this.teamService.selectedTeamId$,
+      this.settingsService.startFromSeason$,
+    ])
+      .pipe(
+        // Team switch + filter reset emits multiple times synchronously.
+        // Coalesce to the final "settled" state so we only fetch once.
+        auditTime(0),
+        map(([filters, teamId, startFromSeason]) => {
+          const apiTeamId = toApiTeamId(teamId);
+          const startFrom = filters.season === undefined ? startFromSeason : undefined;
+
+          const params: ApiParams = apiTeamId
+            ? {
+                reportType: filters.reportType,
+                season: filters.season,
+                teamId: apiTeamId,
+                ...(startFrom === undefined ? {} : { startFrom }),
+              }
+            : {
+                reportType: filters.reportType,
+                season: filters.season,
+                ...(startFrom === undefined ? {} : { startFrom }),
+              };
+
+          return { filters, params, apiTeamId, startFrom };
+        }),
+        distinctUntilChanged(
+          (a, b) =>
+            a.filters.reportType === b.filters.reportType &&
+            a.filters.season === b.filters.season &&
+            a.filters.statsPerGame === b.filters.statsPerGame &&
+            a.filters.minGames === b.filters.minGames &&
+            a.apiTeamId === b.apiTeamId &&
+            a.startFrom === b.startFrom &&
+            this.extraSameCheck(a.filters, b.filters)
+        ),
+        switchMap(({ filters, params }) => {
+          this.reportType = filters.reportType;
+          this.season = filters.season;
+          this.statsPerGame = filters.statsPerGame;
+          this.minGames = filters.minGames;
+          this.positionFilter = filters.positionFilter;
+          this.tableColumns = this.getColumns(filters.statsPerGame, filters.season);
+          this.defaultSortColumn = filters.statsPerGame ? 'scoreAdjustedByGames' : 'score';
+          this.loading = true;
+          this.apiError = false;
+
+          // During team changes, startFromSeason is briefly cleared so we don't fetch with the
+          // previous team's value. Wait until StartFromSeasonSwitcher resolves the new team's
+          // oldest season.
+          if (filters.season === undefined && params.startFrom === undefined) {
+            this.tableData = [];
+            this.maxGames = 0;
+            this.drawerContextService.setMaxGames(this.drawerKey, 0);
+            return EMPTY;
+          }
+
+          return this.fetchApi(params).pipe(
+            map((data) => ({ data, isError: false as const })),
+            // Keep stream alive on error so subsequent changes still work.
+            catchError(() => of({ data: [] as T[], isError: true as const }))
+          );
+        }),
+        takeUntil(this.destroy$)
+      )
+      .subscribe({
+        next: ({ data, isError }) => {
+          if (isError) {
+            this.tableData = [];
+            this.maxGames = 0;
+            this.loading = false;
+            this.apiError = true;
+            return;
+          }
+          let processedData = this.statsPerGame ? this.applyPerGame(data) : data;
+          processedData = this.applyFilters(processedData);
+          this.maxGames = Math.max(0, ...processedData.map(({ games }) => games));
+          this.drawerContextService.setMaxGames(this.drawerKey, this.maxGames);
+          this.tableData = processedData.filter((g) => g.games >= this.minGames);
+          this.loading = false;
+        },
+        // Stream should not error due to catchError above.
+      });
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
+
+  fetchData(params: ApiParams = {}): void {
+    this.loading = true;
+    this.apiError = false;
+
+    this.fetchApi(params)
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        next: (data) => {
+          const baseData = this.statsPerGame ? this.applyPerGame(data) : data;
+          this.maxGames = Math.max(0, ...baseData.map(({ games }) => games));
+          this.drawerContextService.setMaxGames(this.drawerKey, this.maxGames);
+          this.tableData = baseData.filter((g) => g.games >= this.minGames);
+          this.loading = false;
+        },
+        error: () => {
+          this.tableData = [];
+          this.maxGames = 0;
+          this.loading = false;
+          this.apiError = true;
+        },
+      });
+  }
+}

--- a/src/app/goalie-stats/goalie-stats.component.spec.ts
+++ b/src/app/goalie-stats/goalie-stats.component.spec.ts
@@ -423,6 +423,20 @@ describe('GoalieStatsComponent', () => {
     });
   }));
 
+  it('should deduplicate identical emissions (exercises default extraSameCheck)', fakeAsync(() => {
+    apiServiceMock.getGoalieData.and.returnValue(of([]));
+    component.ngOnInit();
+    tick(1);
+    const callCount = apiServiceMock.getGoalieData.calls.count();
+
+    // Re-emitting the same startFromSeason triggers combineLatest again; distinctUntilChanged
+    // calls extraSameCheck (all other conditions equal) and blocks the duplicate fetch.
+    startFromSeasonSubject.next(2012);
+    tick(1);
+
+    expect(apiServiceMock.getGoalieData.calls.count()).toBe(callCount);
+  }));
+
   it('should complete destroy$ on ngOnDestroy', () => {
     const nextSpy = spyOn<any>(component['destroy$'], 'next');
     const completeSpy = spyOn<any>(component['destroy$'], 'complete');

--- a/src/app/goalie-stats/goalie-stats.component.ts
+++ b/src/app/goalie-stats/goalie-stats.component.ts
@@ -1,35 +1,13 @@
 import { AsyncPipe } from '@angular/common';
-import { OnInit, Component, inject, OnDestroy } from '@angular/core';
-import {
-  Subject,
-  auditTime,
-  catchError,
-  combineLatest,
-  distinctUntilChanged,
-  EMPTY,
-  map,
-  of,
-  switchMap,
-  takeUntil,
-} from 'rxjs';
-import {
-  ApiParams,
-  ApiService,
-  Goalie,
-  ReportType,
-} from '@services/api.service';
-import { FilterService } from '@services/filter.service';
-import { StatsService } from '@services/stats.service';
-import { TeamService } from '@services/team.service';
-import { SettingsService } from '@services/settings.service';
-import { DrawerContextService } from '@services/drawer-context.service';
-import { ViewportService } from '@services/viewport.service';
+import { Component } from '@angular/core';
+import { Observable } from 'rxjs';
+import { ApiParams, Goalie } from '@services/api.service';
+import { FilterState } from '@services/filter.service';
 import { SettingsPanelComponent } from '@shared/settings-panel/settings-panel.component';
 import { StatsTableComponent, TableRow } from '@shared/stats-table/stats-table.component';
 import { Column } from '@shared/column.types';
 import { GOALIE_COLUMNS, GOALIE_SEASON_COLUMNS } from '@shared/table-columns';
-import { ComparisonService } from '@services/comparison.service';
-import { toApiTeamId } from '@shared/utils/api.utils';
+import { StatsBaseComponent } from '@base/stats/stats-base.component';
 
 @Component({
   selector: 'app-goalie-stats',
@@ -37,157 +15,26 @@ import { toApiTeamId } from '@shared/utils/api.utils';
   templateUrl: './goalie-stats.component.html',
   styleUrl: './goalie-stats.component.scss',
 })
-export class GoalieStatsComponent implements OnInit, OnDestroy {
-  private apiService = inject(ApiService);
-  private filterService = inject(FilterService);
-  private statsService = inject(StatsService);
-  private teamService = inject(TeamService);
-  private settingsService = inject(SettingsService);
-  private drawerContextService = inject(DrawerContextService);
-  private destroy$ = new Subject<void>();
+export class GoalieStatsComponent extends StatsBaseComponent<Goalie> {
+  protected override readonly drawerKey = 'goalie' as const;
 
-  readonly isMobile$ = inject(ViewportService).isMobile$;
-  readonly comparisonService = inject(ComparisonService);
-  readonly canSelectRow$ = this.comparisonService.canSelectMore$;
+  override isRowSelected = (row: TableRow) => this.comparisonService.isSelected(row as Goalie);
+  override onRowSelect = (row: TableRow) => this.comparisonService.toggle(row as Goalie);
 
-  isRowSelected = (row: TableRow) => this.comparisonService.isSelected(row as Goalie);
-  onRowSelect = (row: TableRow) => this.comparisonService.toggle(row as Goalie);
-
-  reportType: ReportType = 'regular';
-  season?: number;
-  statsPerGame: boolean = false;
-  minGames: number = 0;
-  maxGames: number = 0;
-  tableData: Goalie[] = [];
-  tableColumns: Column[] = GOALIE_COLUMNS;
-  defaultSortColumn: 'score' | 'scoreAdjustedByGames' = 'score';
-  loading = false;
-  apiError = false;
-
-  ngOnInit() {
-    combineLatest([
-      this.filterService.goalieFilters$,
-      this.teamService.selectedTeamId$,
-      this.settingsService.startFromSeason$,
-    ])
-      .pipe(
-        auditTime(0),
-        map(([filters, teamId, startFromSeason]) => {
-          const apiTeamId = toApiTeamId(teamId);
-          const startFrom = filters.season === undefined ? startFromSeason : undefined;
-
-          const params: ApiParams = apiTeamId
-            ? {
-                reportType: filters.reportType,
-                season: filters.season,
-                teamId: apiTeamId,
-                ...(startFrom === undefined ? {} : { startFrom }),
-              }
-            : {
-                reportType: filters.reportType,
-                season: filters.season,
-                ...(startFrom === undefined ? {} : { startFrom }),
-              };
-
-          return {
-            filters,
-            params,
-            apiTeamId,
-            startFrom,
-          };
-        }),
-        distinctUntilChanged((a, b) => {
-          return (
-            a.filters.reportType === b.filters.reportType &&
-            a.filters.season === b.filters.season &&
-            a.filters.statsPerGame === b.filters.statsPerGame &&
-            a.filters.minGames === b.filters.minGames &&
-            a.apiTeamId === b.apiTeamId &&
-            a.startFrom === b.startFrom
-          );
-        }),
-        switchMap(({ filters, params }) => {
-          const { reportType, season, statsPerGame, minGames } = filters;
-          this.reportType = reportType;
-          this.season = season;
-          this.statsPerGame = statsPerGame;
-          this.minGames = minGames;
-
-          const baseColumns = this.season ? GOALIE_SEASON_COLUMNS : GOALIE_COLUMNS;
-          this.tableColumns = statsPerGame
-            ? baseColumns.filter((c) => c.field !== 'score')
-            : baseColumns;
-          this.defaultSortColumn = statsPerGame ? 'scoreAdjustedByGames' : 'score';
-          this.loading = true;
-          this.apiError = false;
-
-          // During team changes, startFromSeason is briefly cleared so we don't fetch with the
-          // previous team's value. Wait until StartFromSeasonSwitcher resolves the new team's
-          // oldest season.
-          if (filters.season === undefined && params.startFrom === undefined) {
-            this.tableData = [];
-            this.maxGames = 0;
-            this.drawerContextService.setMaxGames('goalie', 0);
-            return EMPTY;
-          }
-
-          return this.apiService.getGoalieData(params).pipe(
-            map((data) => ({ data, isError: false as const })),
-            catchError(() => of({ data: [] as Goalie[], isError: true as const }))
-          );
-        }),
-        takeUntil(this.destroy$)
-      )
-      .subscribe({
-        next: ({ data, isError }) => {
-          if (isError) {
-            this.tableData = [];
-            this.maxGames = 0;
-            this.loading = false;
-            this.apiError = true;
-            return;
-          }
-          const baseData = this.statsPerGame
-            ? this.statsService.getGoalieStatsPerGame(data)
-            : data;
-          this.maxGames = Math.max(0, ...baseData.map(({ games }) => games));
-          this.drawerContextService.setMaxGames('goalie', this.maxGames);
-          this.tableData = baseData.filter((g) => g.games >= this.minGames);
-          this.loading = false;
-        },
-        // Stream should not error due to catchError above.
-      });
+  protected override get filters$(): Observable<FilterState> {
+    return this.filterService.goalieFilters$;
   }
 
-  ngOnDestroy(): void {
-    this.destroy$.next();
-    this.destroy$.complete();
+  protected override fetchApi(params: ApiParams) {
+    return this.apiService.getGoalieData(params);
   }
 
-  fetchData(params: ApiParams = {}) {
-    this.loading = true;
-    this.apiError = false;
-
-    this.apiService
-      .getGoalieData(params)
-      .pipe(takeUntil(this.destroy$))
-      .subscribe({
-        next: (data) => {
-          const baseData = this.statsPerGame
-            ? this.statsService.getGoalieStatsPerGame(data)
-            : data;
-          this.maxGames = Math.max(0, ...baseData.map(({ games }) => games));
-          this.drawerContextService.setMaxGames('goalie', this.maxGames);
-          this.tableData = baseData.filter((g) => g.games >= this.minGames);
-          this.loading = false;
-        },
-        error: () => {
-          this.tableData = [];
-          this.maxGames = 0;
-          this.loading = false;
-          this.apiError = true;
-        },
-      });
+  protected override applyPerGame(data: Goalie[]): Goalie[] {
+    return this.statsService.getGoalieStatsPerGame(data);
   }
 
+  protected override getColumns(statsPerGame: boolean, season?: number): Column[] {
+    const baseColumns = season ? GOALIE_SEASON_COLUMNS : GOALIE_COLUMNS;
+    return statsPerGame ? baseColumns.filter((c) => c.field !== 'score') : baseColumns;
+  }
 }

--- a/src/app/player-stats/player-stats.component.ts
+++ b/src/app/player-stats/player-stats.component.ts
@@ -1,35 +1,13 @@
 import { AsyncPipe } from '@angular/common';
-import { OnInit, OnDestroy, Component, inject } from '@angular/core';
-import {
-  Subject,
-  auditTime,
-  catchError,
-  combineLatest,
-  distinctUntilChanged,
-  EMPTY,
-  map,
-  of,
-  switchMap,
-  takeUntil,
-} from 'rxjs';
-import {
-  ApiService,
-  ApiParams,
-  Player,
-  ReportType,
-} from '@services/api.service';
-import { FilterService, PositionFilter } from '@services/filter.service';
-import { StatsService } from '@services/stats.service';
-import { TeamService } from '@services/team.service';
-import { SettingsService } from '@services/settings.service';
-import { DrawerContextService } from '@services/drawer-context.service';
-import { ViewportService } from '@services/viewport.service';
+import { Component } from '@angular/core';
+import { Observable } from 'rxjs';
+import { ApiParams, Player } from '@services/api.service';
+import { FilterState } from '@services/filter.service';
 import { SettingsPanelComponent } from '@shared/settings-panel/settings-panel.component';
 import { StatsTableComponent, TableRow } from '@shared/stats-table/stats-table.component';
 import { Column } from '@shared/column.types';
 import { PLAYER_COLUMNS } from '@shared/table-columns';
-import { ComparisonService } from '@services/comparison.service';
-import { toApiTeamId } from '@shared/utils/api.utils';
+import { StatsBaseComponent } from '@base/stats/stats-base.component';
 
 @Component({
   selector: 'app-player-stats',
@@ -37,143 +15,37 @@ import { toApiTeamId } from '@shared/utils/api.utils';
   templateUrl: './player-stats.component.html',
   styleUrl: './player-stats.component.scss',
 })
-export class PlayerStatsComponent implements OnInit, OnDestroy {
-  private apiService = inject(ApiService);
-  private filterService = inject(FilterService);
-  private statsService = inject(StatsService);
-  private teamService = inject(TeamService);
-  private settingsService = inject(SettingsService);
-  private drawerContextService = inject(DrawerContextService);
-  private destroy$ = new Subject<void>();
+export class PlayerStatsComponent extends StatsBaseComponent<Player> {
+  protected override readonly drawerKey = 'player' as const;
 
-  readonly isMobile$ = inject(ViewportService).isMobile$;
-  readonly comparisonService = inject(ComparisonService);
-  readonly canSelectRow$ = this.comparisonService.canSelectMore$;
+  override isRowSelected = (row: TableRow) => this.comparisonService.isSelected(row as Player);
+  override onRowSelect = (row: TableRow) => this.comparisonService.toggle(row as Player);
 
-  isRowSelected = (row: TableRow) => this.comparisonService.isSelected(row as Player);
-  onRowSelect = (row: TableRow) => this.comparisonService.toggle(row as Player);
-
-  reportType: ReportType = 'regular';
-  season?: number;
-  statsPerGame: boolean = false;
-  minGames: number = 0;
-  maxGames: number = 0;
-  positionFilter: PositionFilter = 'all';
-  tableData: Player[] = [];
-  tableColumns = PLAYER_COLUMNS;
-  defaultSortColumn: 'score' | 'scoreAdjustedByGames' = 'score';
-  loading = false;
-  apiError = false;
-
-  ngOnInit() {
-    combineLatest([
-      this.filterService.playerFilters$,
-      this.teamService.selectedTeamId$,
-      this.settingsService.startFromSeason$,
-    ])
-      .pipe(
-        // Team switch + filter reset emits multiple times synchronously.
-        // Coalesce to the final "settled" state so we only fetch once.
-        auditTime(0),
-        map(([filters, teamId, startFromSeason]) => {
-          const apiTeamId = toApiTeamId(teamId);
-          const startFrom = filters.season === undefined ? startFromSeason : undefined;
-
-          const params: ApiParams = apiTeamId
-            ? {
-                reportType: filters.reportType,
-                season: filters.season,
-                teamId: apiTeamId,
-                ...(startFrom === undefined ? {} : { startFrom }),
-              }
-            : {
-                reportType: filters.reportType,
-                season: filters.season,
-                ...(startFrom === undefined ? {} : { startFrom }),
-              };
-
-          return {
-            filters,
-            params,
-            apiTeamId,
-            startFrom,
-          };
-        }),
-        distinctUntilChanged((a, b) => {
-          return (
-            a.filters.reportType === b.filters.reportType &&
-            a.filters.season === b.filters.season &&
-            a.filters.statsPerGame === b.filters.statsPerGame &&
-            a.filters.minGames === b.filters.minGames &&
-            a.filters.positionFilter === b.filters.positionFilter &&
-            a.apiTeamId === b.apiTeamId &&
-            a.startFrom === b.startFrom
-          );
-        }),
-        switchMap(({ filters, params }) => {
-          const { reportType, season, statsPerGame, minGames, positionFilter } = filters;
-          this.reportType = reportType;
-          this.season = season;
-          this.statsPerGame = statsPerGame;
-          this.minGames = minGames;
-          this.positionFilter = positionFilter;
-          this.tableColumns = this.getTableColumns(statsPerGame);
-          this.defaultSortColumn = statsPerGame ? 'scoreAdjustedByGames' : 'score';
-          this.loading = true;
-          this.apiError = false;
-
-          // During team changes, startFromSeason is briefly cleared so we don't fetch with the
-          // previous team's value. Wait until StartFromSeasonSwitcher resolves the new team's
-          // oldest season.
-          if (filters.season === undefined && params.startFrom === undefined) {
-            this.tableData = [];
-            this.maxGames = 0;
-            this.drawerContextService.setMaxGames('player', 0);
-            return EMPTY;
-          }
-
-          return this.apiService.getPlayerData(params).pipe(
-            map((data) => ({ data, isError: false as const })),
-            // Keep stream alive on error so subsequent changes still work.
-            catchError(() => of({ data: [] as Player[], isError: true as const }))
-          );
-        }),
-        takeUntil(this.destroy$)
-      )
-      .subscribe({
-        next: ({ data, isError }) => {
-          if (isError) {
-            this.tableData = [];
-            this.maxGames = 0;
-            this.loading = false;
-            this.apiError = true;
-            return;
-          }
-          let processedData = this.statsPerGame
-            ? this.statsService.getPlayerStatsPerGame(data)
-            : data;
-
-          // Filter by position if position filter is active
-          if (this.positionFilter !== 'all') {
-            processedData = processedData.filter(
-              (player) => player.position === this.positionFilter
-            );
-            // Transform scores to position-based values
-            processedData = this.transformToPositionScores(processedData, this.statsPerGame);
-          }
-
-          this.maxGames = Math.max(0, ...processedData.map(({ games }) => games));
-          this.drawerContextService.setMaxGames('player', this.maxGames);
-          this.tableData = processedData.filter((g) => g.games >= this.minGames);
-          this.loading = false;
-        },
-        // Stream should not error due to catchError above.
-      });
+  protected override get filters$(): Observable<FilterState> {
+    return this.filterService.playerFilters$;
   }
 
-  private getTableColumns(statsPerGame: boolean): Column[] {
+  protected override fetchApi(params: ApiParams) {
+    return this.apiService.getPlayerData(params);
+  }
+
+  protected override applyPerGame(data: Player[]): Player[] {
+    return this.statsService.getPlayerStatsPerGame(data);
+  }
+
+  protected override getColumns(statsPerGame: boolean): Column[] {
     if (!statsPerGame) return PLAYER_COLUMNS;
     return PLAYER_COLUMNS.filter((c) => c.field !== 'score');
+  }
+
+  protected override extraSameCheck(a: FilterState, b: FilterState): boolean {
+    return a.positionFilter === b.positionFilter;
+  }
+
+  protected override applyFilters(data: Player[]): Player[] {
+    if (this.positionFilter === 'all') return data;
+    const filtered = data.filter((player) => player.position === this.positionFilter);
+    return this.transformToPositionScores(filtered, this.statsPerGame);
   }
 
   private transformToPositionScores(data: Player[], statsPerGame: boolean): Player[] {
@@ -189,36 +61,4 @@ export class PlayerStatsComponent implements OnInit, OnDestroy {
       scoreAdjustedByGames: player.scoreByPositionAdjustedByGames ?? player.scoreAdjustedByGames,
     }));
   }
-
-  ngOnDestroy(): void {
-    this.destroy$.next();
-    this.destroy$.complete();
-  }
-
-  fetchData(params: ApiParams = {}) {
-    this.loading = true;
-    this.apiError = false;
-
-    this.apiService
-      .getPlayerData(params)
-      .pipe(takeUntil(this.destroy$))
-      .subscribe({
-        next: (data) => {
-          const baseData = this.statsPerGame
-            ? this.statsService.getPlayerStatsPerGame(data)
-            : data;
-          this.maxGames = Math.max(0, ...baseData.map(({ games }) => games));
-          this.drawerContextService.setMaxGames('player', this.maxGames);
-          this.tableData = baseData.filter((g) => g.games >= this.minGames);
-          this.loading = false;
-        },
-        error: () => {
-          this.tableData = [];
-          this.maxGames = 0;
-          this.loading = false;
-          this.apiError = true;
-        },
-      });
-  }
-
 }


### PR DESCRIPTION
## Summary

- Extract `StatsBaseComponent<T>` abstract base class (`src/app/base/stats/`) with the full shared RxJS pipeline (`combineLatest` → `auditTime` → `distinctUntilChanged` → `switchMap`), service injections, and state fields
- Reduce `PlayerStatsComponent` from ~224 to ~65 lines and `GoalieStatsComponent` from ~193 to ~40 lines — each now only defines its API call, column config, per-game transform, and position-filter hook
- Add `@Directive()` decorator to the abstract base to satisfy Angular's NG2007 requirement for classes using `inject()`
- Remove Batch 1 from refactoring roadmap docs