### PR TITLE
Feature: Expand settings memory

### DIFF
--- a/docs/service-guide.md
+++ b/docs/service-guide.md
@@ -14,7 +14,7 @@ Services in this application handle data fetching, business logic, state managem
 **Responsibilities**:
 - Store user settings in a single `localStorage` key: `fantrax.settings`
 - Provide reactive settings slices as observables (team id, start-from season, top-controls expanded, season, report type)
-- Remove legacy keys (`fantrax.selectedTeamId`, `fantrax.topControls.expanded`) from localStorage on first load after migration
+- Validate all fields on load; invalid or missing fields fall back to defaults
 
 **Notes**:
 - `startFromSeason` defaults to the oldest available season for the selected team

--- a/docs/service-guide.md
+++ b/docs/service-guide.md
@@ -13,15 +13,50 @@ Services in this application handle data fetching, business logic, state managem
 
 **Responsibilities**:
 - Store user settings in a single `localStorage` key: `fantrax.settings`
-- Provide reactive settings slices as observables (team id, start-from season, top-controls expanded)
-- Migrate legacy keys on first run (best-effort):
-  - `fantrax.selectedTeamId`
-  - `fantrax.topControls.expanded`
+- Provide reactive settings slices as observables (team id, start-from season, top-controls expanded, season, report type)
+- Remove legacy keys (`fantrax.selectedTeamId`, `fantrax.topControls.expanded`) from localStorage on first load after migration
 
 **Notes**:
 - `startFromSeason` defaults to the oldest available season for the selected team
 - When the selected team changes, `startFromSeason` resets to that team's oldest season
 - Storage failures are ignored (privacy mode, quota, etc.)
+- `season` defaults to `null` (all seasons); `reportType` defaults to `'regular'`
+- Settings are validated field-by-field on load; invalid or missing fields fall back to defaults
+
+**Key API**:
+```typescript
+class SettingsService {
+  readonly settings$: Observable<AppSettings>;
+  readonly selectedTeamId$: Observable<string>;
+  readonly startFromSeason$: Observable<number | undefined>;
+  readonly topControlsExpanded$: Observable<boolean>;
+  readonly season$: Observable<number | undefined>;
+  readonly reportType$: Observable<ReportType>;
+
+  get selectedTeamId(): string;
+  get startFromSeason(): number | undefined;
+  get topControlsExpanded(): boolean;
+  get season(): number | undefined;
+  get reportType(): ReportType;
+
+  setSelectedTeamId(teamId: string): void;
+  setStartFromSeason(season: number | undefined): void;
+  setTopControlsExpanded(expanded: boolean): void;
+  setSeason(season: number | null): void;
+  setReportType(reportType: ReportType): void;
+}
+```
+
+**AppSettings type**:
+```typescript
+export type AppSettings = {
+  selectedTeamId: string;
+  startFromSeason: number | null;
+  topControlsExpanded: boolean;
+  season: number | null;
+  reportType: ReportType;
+};
+```
 
 ### TeamService
 **Location**: `src/app/services/team.service.ts`
@@ -166,6 +201,11 @@ class StatsService {
 - Expose filter state as observables for components
 - Keep `season` and `reportType` in sync globally between players and goalies
 - Provide reset helpers (including a global reset)
+
+**Persistence**:
+- Injects `SettingsService` to seed initial `season` and `reportType` from persisted settings on startup
+- Persists `season` and `reportType` back to `SettingsService` on every global filter change (these two fields are global — shared between player and goalie contexts)
+- Non-global fields (`statsPerGame`, `minGames`, `positionFilter`) are never persisted
 
 **Type Definitions**:
 ```typescript

--- a/src/app/goalie-stats/goalie-stats.component.spec.ts
+++ b/src/app/goalie-stats/goalie-stats.component.spec.ts
@@ -56,7 +56,13 @@ describe('GoalieStatsComponent', () => {
         { provide: TeamService, useClass: TeamServiceMock },
         {
           provide: SettingsService,
-          useValue: { startFromSeason$: startFromSeasonSubject.asObservable() },
+          useValue: {
+            startFromSeason$: startFromSeasonSubject.asObservable(),
+            reportType: 'regular',
+            season: undefined,
+            setSeason: jasmine.createSpy('setSeason'),
+            setReportType: jasmine.createSpy('setReportType'),
+          },
         },
       ],
     }).compileComponents();

--- a/src/app/player-stats/player-stats.component.spec.ts
+++ b/src/app/player-stats/player-stats.component.spec.ts
@@ -55,7 +55,13 @@ describe('PlayerStatsComponent', () => {
         { provide: TeamService, useClass: TeamServiceMock },
         {
           provide: SettingsService,
-          useValue: { startFromSeason$: startFromSeasonSubject.asObservable() },
+          useValue: {
+            startFromSeason$: startFromSeasonSubject.asObservable(),
+            reportType: 'regular',
+            season: undefined,
+            setSeason: jasmine.createSpy('setSeason'),
+            setReportType: jasmine.createSpy('setReportType'),
+          },
         },
         { provide: ViewportService, useValue: { isMobile$: of(false) } },
       ],

--- a/src/app/services/filter.service.ts
+++ b/src/app/services/filter.service.ts
@@ -1,6 +1,7 @@
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { BehaviorSubject } from 'rxjs';
 import { ReportType } from './api.service';
+import { SettingsService } from './settings.service';
 
 export type PositionFilter = 'all' | 'F' | 'D';
 
@@ -16,17 +17,19 @@ export interface FilterState {
   providedIn: 'root',
 })
 export class FilterService {
+  private readonly settingsService = inject(SettingsService);
+
   private filters = {
     players: new BehaviorSubject<FilterState>({
-      reportType: 'regular',
-      season: undefined,
+      reportType: this.settingsService.reportType,
+      season: this.settingsService.season,
       statsPerGame: false,
       minGames: 0,
       positionFilter: 'all',
     }),
     goalies: new BehaviorSubject<FilterState>({
-      reportType: 'regular',
-      season: undefined,
+      reportType: this.settingsService.reportType,
+      season: this.settingsService.season,
       statsPerGame: false,
       minGames: 0,
       positionFilter: 'all',
@@ -39,14 +42,12 @@ export class FilterService {
   updatePlayerFilters(change: Partial<FilterState>) {
     const current = this.filters.players.value;
     this.filters.players.next({ ...current, ...change });
-
     this.syncGlobalFilters('players', change);
   }
 
   updateGoalieFilters(change: Partial<FilterState>) {
     const current = this.filters.goalies.value;
     this.filters.goalies.next({ ...current, ...change });
-
     this.syncGlobalFilters('goalies', change);
   }
 
@@ -57,6 +58,9 @@ export class FilterService {
     const hasSeason = Object.prototype.hasOwnProperty.call(change, 'season');
     const hasReportType = Object.prototype.hasOwnProperty.call(change, 'reportType');
     if (!hasSeason && !hasReportType) return;
+
+    if (hasSeason) this.settingsService.setSeason(change.season ?? null);
+    if (hasReportType) this.settingsService.setReportType(change.reportType!);
 
     const globalChange: Partial<FilterState> = {};
     if (hasSeason) globalChange.season = change.season;
@@ -87,7 +91,6 @@ export class FilterService {
   }
 
   resetAll() {
-    // Reset global filters first so both contexts are aligned.
     this.updatePlayerFilters({ reportType: 'regular', season: undefined });
     this.resetPlayerFilters();
     this.resetGoalieFilters();

--- a/src/app/services/settings.service.ts
+++ b/src/app/services/settings.service.ts
@@ -107,9 +107,6 @@ export class SettingsService {
   }
 
   private loadInitialSettings(): AppSettings {
-    // Clean up legacy keys regardless of whether they exist.
-    this.removeLegacyKeys();
-
     try {
       const stored = localStorage.getItem(this.storageKey);
       if (stored) {
@@ -157,15 +154,6 @@ export class SettingsService {
   private parseReportType(value: unknown): ReportType {
     if (value === 'regular' || value === 'playoffs' || value === 'both') return value;
     return 'regular';
-  }
-
-  private removeLegacyKeys(): void {
-    try {
-      localStorage.removeItem('fantrax.selectedTeamId');
-      localStorage.removeItem('fantrax.topControls.expanded');
-    } catch {
-      // ignore
-    }
   }
 
   private persist(settings: AppSettings): void {

--- a/src/app/services/settings.service.ts
+++ b/src/app/services/settings.service.ts
@@ -1,23 +1,20 @@
 import { Injectable } from '@angular/core';
 import { BehaviorSubject, distinctUntilChanged, map } from 'rxjs';
+import { ReportType } from './api.service';
 
-export type AppSettingsV1 = {
-  version: 1;
+export type AppSettings = {
   selectedTeamId: string;
   startFromSeason: number | null;
   topControlsExpanded: boolean;
+  season: number | null;
+  reportType: ReportType;
 };
-
-export type AppSettings = AppSettingsV1;
 
 @Injectable({
   providedIn: 'root',
 })
 export class SettingsService {
   private readonly storageKey = 'fantrax.settings';
-
-  private readonly legacySelectedTeamIdKey = 'fantrax.selectedTeamId';
-  private readonly legacyTopControlsExpandedKey = 'fantrax.topControls.expanded';
 
   private readonly defaultTeamId = '1';
   private readonly defaultTopControlsExpanded = true;
@@ -43,6 +40,16 @@ export class SettingsService {
     distinctUntilChanged()
   );
 
+  readonly season$ = this.settings$.pipe(
+    map((s) => (s.season === null ? undefined : s.season)),
+    distinctUntilChanged()
+  );
+
+  readonly reportType$ = this.settings$.pipe(
+    map((s) => s.reportType),
+    distinctUntilChanged()
+  );
+
   get selectedTeamId(): string {
     return this.settingsSubject.value.selectedTeamId;
   }
@@ -57,105 +64,107 @@ export class SettingsService {
     return this.settingsSubject.value.topControlsExpanded;
   }
 
+  get season(): number | undefined {
+    return this.settingsSubject.value.season === null
+      ? undefined
+      : this.settingsSubject.value.season;
+  }
+
+  get reportType(): ReportType {
+    return this.settingsSubject.value.reportType;
+  }
+
   setSelectedTeamId(teamId: string): void {
     if (!teamId || teamId === this.selectedTeamId) return;
-
     this.updateSettings({ selectedTeamId: teamId });
   }
 
   setStartFromSeason(season: number | undefined): void {
     const normalized = season === undefined ? null : season;
     if (normalized === this.settingsSubject.value.startFromSeason) return;
-
     this.updateSettings({ startFromSeason: normalized });
   }
 
   setTopControlsExpanded(expanded: boolean): void {
     if (expanded === this.topControlsExpanded) return;
-
     this.updateSettings({ topControlsExpanded: expanded });
   }
 
-  private updateSettings(patch: Partial<Omit<AppSettingsV1, 'version'>>): void {
-    const next: AppSettings = {
-      ...this.settingsSubject.value,
-      ...patch,
-      version: 1,
-    };
+  setSeason(season: number | null): void {
+    if (season === this.settingsSubject.value.season) return;
+    this.updateSettings({ season });
+  }
 
+  setReportType(reportType: ReportType): void {
+    if (reportType === this.settingsSubject.value.reportType) return;
+    this.updateSettings({ reportType });
+  }
+
+  private updateSettings(patch: Partial<AppSettings>): void {
+    const next: AppSettings = { ...this.settingsSubject.value, ...patch };
     this.settingsSubject.next(next);
     this.persist(next);
   }
 
   private loadInitialSettings(): AppSettings {
-    const fromNew = this.tryLoadFromNewKey();
-    if (fromNew) return fromNew;
+    // Clean up legacy keys regardless of whether they exist.
+    this.removeLegacyKeys();
 
-    const selectedTeamId = this.loadLegacySelectedTeamId();
-    const topControlsExpanded = this.loadLegacyTopControlsExpanded();
-
-    // Persist migrated settings so future loads use the unified key.
-    const migrated: AppSettings = {
-      version: 1,
-      selectedTeamId,
-      startFromSeason: null,
-      topControlsExpanded,
-    };
-
-    this.persist(migrated);
-    return migrated;
-  }
-
-  private tryLoadFromNewKey(): AppSettings | null {
     try {
       const stored = localStorage.getItem(this.storageKey);
-      if (!stored) return null;
+      if (stored) {
+        const parsed = JSON.parse(stored) as Partial<AppSettings & { version?: unknown }>;
 
-      const parsed = JSON.parse(stored) as Partial<AppSettingsV1> | null;
-      if (!parsed || parsed.version !== 1) return null;
+        const selectedTeamId =
+          typeof parsed.selectedTeamId === 'string' && parsed.selectedTeamId.trim().length > 0
+            ? parsed.selectedTeamId
+            : this.defaultTeamId;
 
-      const selectedTeamId =
-        typeof parsed.selectedTeamId === 'string' && parsed.selectedTeamId.trim().length > 0
-          ? parsed.selectedTeamId
-          : this.defaultTeamId;
+        const startFromSeason =
+          typeof parsed.startFromSeason === 'number' && Number.isFinite(parsed.startFromSeason)
+            ? parsed.startFromSeason
+            : null;
 
-      const startFromSeason =
-        typeof parsed.startFromSeason === 'number' && Number.isFinite(parsed.startFromSeason)
-          ? parsed.startFromSeason
-          : null;
+        const topControlsExpanded =
+          typeof parsed.topControlsExpanded === 'boolean'
+            ? parsed.topControlsExpanded
+            : this.defaultTopControlsExpanded;
 
-      const topControlsExpanded =
-        typeof parsed.topControlsExpanded === 'boolean'
-          ? parsed.topControlsExpanded
-          : this.defaultTopControlsExpanded;
+        const season =
+          typeof parsed.season === 'number' && Number.isFinite(parsed.season)
+            ? parsed.season
+            : null;
 
-      return {
-        version: 1,
-        selectedTeamId,
-        startFromSeason,
-        topControlsExpanded,
-      };
+        const reportType = this.parseReportType(parsed.reportType);
+
+        return { selectedTeamId, startFromSeason, topControlsExpanded, season, reportType };
+      }
     } catch {
-      return null;
+      // ignore parse errors
     }
+
+    const defaults: AppSettings = {
+      selectedTeamId: this.defaultTeamId,
+      startFromSeason: null,
+      topControlsExpanded: this.defaultTopControlsExpanded,
+      season: null,
+      reportType: 'regular',
+    };
+    this.persist(defaults);
+    return defaults;
   }
 
-  private loadLegacySelectedTeamId(): string {
-    try {
-      const stored = localStorage.getItem(this.legacySelectedTeamIdKey);
-      return stored && stored.trim().length > 0 ? stored : this.defaultTeamId;
-    } catch {
-      return this.defaultTeamId;
-    }
+  private parseReportType(value: unknown): ReportType {
+    if (value === 'regular' || value === 'playoffs' || value === 'both') return value;
+    return 'regular';
   }
 
-  private loadLegacyTopControlsExpanded(): boolean {
+  private removeLegacyKeys(): void {
     try {
-      const stored = localStorage.getItem(this.legacyTopControlsExpandedKey);
-      if (stored === null) return this.defaultTopControlsExpanded;
-      return stored === 'true';
+      localStorage.removeItem('fantrax.selectedTeamId');
+      localStorage.removeItem('fantrax.topControls.expanded');
     } catch {
-      return this.defaultTopControlsExpanded;
+      // ignore
     }
   }
 

--- a/src/app/services/tests/comparison.service.spec.ts
+++ b/src/app/services/tests/comparison.service.spec.ts
@@ -97,6 +97,7 @@ describe('ComparisonService', () => {
   let service: ComparisonService;
 
   beforeEach(() => {
+    localStorage.clear();
     TestBed.configureTestingModule({});
     service = TestBed.inject(ComparisonService);
   });

--- a/src/app/services/tests/filter.service.spec.ts
+++ b/src/app/services/tests/filter.service.spec.ts
@@ -6,6 +6,7 @@ describe('FilterService', () => {
   let service: FilterService;
 
   beforeEach(() => {
+    localStorage.clear();
     TestBed.configureTestingModule({
       providers: [FilterService],
     });
@@ -38,6 +39,129 @@ describe('FilterService', () => {
         expect(filters.positionFilter).toBe('all');
         done();
       });
+    });
+  });
+
+  describe('initialization from persisted settings', () => {
+    it('should init season from settings when stored', (done) => {
+      localStorage.setItem(
+        'fantrax.settings',
+        JSON.stringify({
+          selectedTeamId: '1',
+          startFromSeason: null,
+          topControlsExpanded: true,
+          season: 2024,
+          reportType: 'regular',
+        })
+      );
+      TestBed.resetTestingModule();
+      TestBed.configureTestingModule({ providers: [FilterService] });
+      const freshService = TestBed.inject(FilterService);
+
+      freshService.playerFilters$.pipe(take(1)).subscribe((filters) => {
+        expect(filters.season).toBe(2024);
+        done();
+      });
+    });
+
+    it('should init reportType from settings when stored', (done) => {
+      localStorage.setItem(
+        'fantrax.settings',
+        JSON.stringify({
+          selectedTeamId: '1',
+          startFromSeason: null,
+          topControlsExpanded: true,
+          season: null,
+          reportType: 'playoffs',
+        })
+      );
+      TestBed.resetTestingModule();
+      TestBed.configureTestingModule({ providers: [FilterService] });
+      const freshService = TestBed.inject(FilterService);
+
+      freshService.playerFilters$.pipe(take(1)).subscribe((filters) => {
+        expect(filters.reportType).toBe('playoffs');
+        done();
+      });
+    });
+
+    it('should init both player and goalie filters from settings', (done) => {
+      localStorage.setItem(
+        'fantrax.settings',
+        JSON.stringify({
+          selectedTeamId: '1',
+          startFromSeason: null,
+          topControlsExpanded: true,
+          season: 2023,
+          reportType: 'playoffs',
+        })
+      );
+      TestBed.resetTestingModule();
+      TestBed.configureTestingModule({ providers: [FilterService] });
+      const freshService = TestBed.inject(FilterService);
+
+      freshService.goalieFilters$.pipe(take(1)).subscribe((filters) => {
+        expect(filters.season).toBe(2023);
+        expect(filters.reportType).toBe('playoffs');
+        done();
+      });
+    });
+  });
+
+  describe('persistence on filter change', () => {
+    it('should persist season to settings when updatePlayerFilters changes season', () => {
+      service.updatePlayerFilters({ season: 2023 });
+
+      const stored = JSON.parse(localStorage.getItem('fantrax.settings') ?? '{}');
+      expect(stored.season).toBe(2023);
+    });
+
+    it('should persist null season to settings when season is cleared', () => {
+      service.updatePlayerFilters({ season: 2023 });
+      service.updatePlayerFilters({ season: undefined });
+
+      const stored = JSON.parse(localStorage.getItem('fantrax.settings') ?? '{}');
+      expect(stored.season).toBeNull();
+    });
+
+    it('should persist reportType to settings when updatePlayerFilters changes reportType', () => {
+      service.updatePlayerFilters({ reportType: 'playoffs' });
+
+      const stored = JSON.parse(localStorage.getItem('fantrax.settings') ?? '{}');
+      expect(stored.reportType).toBe('playoffs');
+    });
+
+    it('should persist season to settings when updateGoalieFilters changes season', () => {
+      service.updateGoalieFilters({ season: 2022 });
+
+      const stored = JSON.parse(localStorage.getItem('fantrax.settings') ?? '{}');
+      expect(stored.season).toBe(2022);
+    });
+
+    it('should persist reportType to settings when updateGoalieFilters changes reportType', () => {
+      service.updateGoalieFilters({ reportType: 'both' });
+
+      const stored = JSON.parse(localStorage.getItem('fantrax.settings') ?? '{}');
+      expect(stored.reportType).toBe('both');
+    });
+
+    it('should not persist statsPerGame or minGames changes to settings', () => {
+      service.updatePlayerFilters({ statsPerGame: true, minGames: 10 });
+
+      const stored = JSON.parse(localStorage.getItem('fantrax.settings') ?? '{}');
+      expect(stored.season).toBeNull();
+      expect(stored.reportType).toBe('regular');
+      expect(stored['statsPerGame']).toBeUndefined();
+      expect(stored['minGames']).toBeUndefined();
+    });
+
+    it('should persist season=null and reportType=regular after resetAll', () => {
+      service.updatePlayerFilters({ season: 2024, reportType: 'playoffs' });
+      service.resetAll();
+
+      const stored = JSON.parse(localStorage.getItem('fantrax.settings') ?? '{}');
+      expect(stored.season).toBeNull();
+      expect(stored.reportType).toBe('regular');
     });
   });
 

--- a/src/app/services/tests/settings.service.spec.ts
+++ b/src/app/services/tests/settings.service.spec.ts
@@ -224,4 +224,23 @@ describe('SettingsService', () => {
     seasonSub.unsubscribe();
     reportTypeSub.unsubscribe();
   });
+
+  it('should emit topControlsExpanded$ and suppress duplicate values', () => {
+    const service = TestBed.inject(SettingsService);
+
+    const values: boolean[] = [];
+    const sub = service.topControlsExpanded$.subscribe((v) => values.push(v));
+
+    expect(values[values.length - 1]).toBe(true);
+
+    service.setTopControlsExpanded(false);
+    expect(values[values.length - 1]).toBe(false);
+
+    // DistinctUntilChanged should prevent no-op emissions.
+    const count = values.length;
+    service.setTopControlsExpanded(false);
+    expect(values.length).toBe(count);
+
+    sub.unsubscribe();
+  });
 });

--- a/src/app/services/tests/settings.service.spec.ts
+++ b/src/app/services/tests/settings.service.spec.ts
@@ -7,32 +7,36 @@ describe('SettingsService', () => {
     localStorage.clear();
   });
 
-  it('should default and persist migrated settings when no keys exist', () => {
+  it('should default and persist settings when no key exists', () => {
     const setItemSpy = spyOn(localStorage, 'setItem').and.callThrough();
     const service = TestBed.inject(SettingsService);
 
     expect(service.selectedTeamId).toBe('1');
     expect(service.startFromSeason).toBeUndefined();
     expect(service.topControlsExpanded).toBe(true);
+    expect(service.season).toBeUndefined();
+    expect(service.reportType).toBe('regular');
 
     expect(setItemSpy).toHaveBeenCalled();
     const persisted = JSON.parse(localStorage.getItem('fantrax.settings') ?? '{}');
     expect(persisted).toEqual({
-      version: 1,
       selectedTeamId: '1',
       startFromSeason: null,
       topControlsExpanded: true,
+      season: null,
+      reportType: 'regular',
     });
   });
 
-  it('should load from the unified key when valid and avoid migration write', () => {
+  it('should load all fields from stored settings', () => {
     localStorage.setItem(
       'fantrax.settings',
       JSON.stringify({
-        version: 1,
         selectedTeamId: '7',
         startFromSeason: 2023,
         topControlsExpanded: false,
+        season: 2024,
+        reportType: 'playoffs',
       })
     );
 
@@ -42,16 +46,35 @@ describe('SettingsService', () => {
     expect(service.selectedTeamId).toBe('7');
     expect(service.startFromSeason).toBe(2023);
     expect(service.topControlsExpanded).toBe(false);
+    expect(service.season).toBe(2024);
+    expect(service.reportType).toBe('playoffs');
     expect(setItemSpy).not.toHaveBeenCalled();
+  });
+
+  it('should default new fields when loading old settings without them', () => {
+    localStorage.setItem(
+      'fantrax.settings',
+      JSON.stringify({
+        selectedTeamId: '3',
+        startFromSeason: null,
+        topControlsExpanded: true,
+      })
+    );
+
+    const service = TestBed.inject(SettingsService);
+
+    expect(service.season).toBeUndefined();
+    expect(service.reportType).toBe('regular');
   });
 
   it('should validate fields when unified key is present but partially invalid', () => {
     localStorage.setItem(
       'fantrax.settings',
       JSON.stringify({
-        version: 1,
         selectedTeamId: '   ',
         startFromSeason: 'not-a-number',
+        season: 'bad',
+        reportType: 'unknown',
       })
     );
 
@@ -59,38 +82,27 @@ describe('SettingsService', () => {
 
     expect(service.selectedTeamId).toBe('1');
     expect(service.startFromSeason).toBeUndefined();
-    expect(service.topControlsExpanded).toBe(true);
+    expect(service.season).toBeUndefined();
+    expect(service.reportType).toBe('regular');
   });
 
-  it('should fall back to legacy keys when unified key has wrong version', () => {
-    localStorage.setItem(
-      'fantrax.settings',
-      JSON.stringify({ version: 2, selectedTeamId: '99' })
-    );
-    localStorage.setItem('fantrax.selectedTeamId', '8');
+  it('should use defaults when stored JSON is broken', () => {
+    localStorage.setItem('fantrax.settings', '{broken-json');
+    const service = TestBed.inject(SettingsService);
+
+    expect(service.selectedTeamId).toBe('1');
+    expect(service.season).toBeUndefined();
+    expect(service.reportType).toBe('regular');
+  });
+
+  it('should remove legacy keys on load', () => {
+    localStorage.setItem('fantrax.selectedTeamId', '5');
     localStorage.setItem('fantrax.topControls.expanded', 'false');
 
-    const service = TestBed.inject(SettingsService);
+    TestBed.inject(SettingsService);
 
-    expect(service.selectedTeamId).toBe('8');
-    expect(service.topControlsExpanded).toBe(false);
-    expect(service.startFromSeason).toBeUndefined();
-
-    const persisted = JSON.parse(localStorage.getItem('fantrax.settings') ?? '{}');
-    expect(persisted.selectedTeamId).toBe('8');
-    expect(persisted.topControlsExpanded).toBe(false);
-    expect(persisted.startFromSeason).toBeNull();
-  });
-
-  it('should fall back to legacy keys when unified key is invalid JSON', () => {
-    localStorage.setItem('fantrax.settings', '{broken-json');
-    localStorage.setItem('fantrax.selectedTeamId', '10');
-    localStorage.setItem('fantrax.topControls.expanded', 'true');
-
-    const service = TestBed.inject(SettingsService);
-
-    expect(service.selectedTeamId).toBe('10');
-    expect(service.topControlsExpanded).toBe(true);
+    expect(localStorage.getItem('fantrax.selectedTeamId')).toBeNull();
+    expect(localStorage.getItem('fantrax.topControls.expanded')).toBeNull();
   });
 
   it('should normalize startFromSeason and avoid persisting unchanged values', () => {
@@ -113,6 +125,43 @@ describe('SettingsService', () => {
     expect(service.startFromSeason).toBeUndefined();
   });
 
+  it('should persist setSeason and avoid persisting unchanged values', () => {
+    const service = TestBed.inject(SettingsService);
+    const setItemSpy = spyOn(localStorage, 'setItem').and.callThrough();
+    setItemSpy.calls.reset();
+
+    service.setSeason(null);
+    expect(setItemSpy).not.toHaveBeenCalled();
+
+    service.setSeason(2024);
+    expect(service.season).toBe(2024);
+    expect(setItemSpy).toHaveBeenCalled();
+
+    setItemSpy.calls.reset();
+    service.setSeason(2024);
+    expect(setItemSpy).not.toHaveBeenCalled();
+
+    service.setSeason(null);
+    expect(service.season).toBeUndefined();
+  });
+
+  it('should persist setReportType and avoid persisting unchanged values', () => {
+    const service = TestBed.inject(SettingsService);
+    const setItemSpy = spyOn(localStorage, 'setItem').and.callThrough();
+    setItemSpy.calls.reset();
+
+    service.setReportType('regular');
+    expect(setItemSpy).not.toHaveBeenCalled();
+
+    service.setReportType('playoffs');
+    expect(service.reportType).toBe('playoffs');
+    expect(setItemSpy).toHaveBeenCalled();
+
+    setItemSpy.calls.reset();
+    service.setReportType('playoffs');
+    expect(setItemSpy).not.toHaveBeenCalled();
+  });
+
   it('should still update in-memory state if persist throws', () => {
     const service = TestBed.inject(SettingsService);
     spyOn(localStorage, 'setItem').and.throwError('quota exceeded');
@@ -120,13 +169,17 @@ describe('SettingsService', () => {
     service.setSelectedTeamId('12');
     service.setTopControlsExpanded(false);
     service.setStartFromSeason(2020);
+    service.setSeason(2024);
+    service.setReportType('playoffs');
 
     expect(service.selectedTeamId).toBe('12');
     expect(service.topControlsExpanded).toBe(false);
     expect(service.startFromSeason).toBe(2020);
+    expect(service.season).toBe(2024);
+    expect(service.reportType).toBe('playoffs');
   });
 
-  it('should ignore no-op updates (empty teamId and unchanged expanded)', () => {
+  it('should ignore no-op updates', () => {
     const service = TestBed.inject(SettingsService);
     const setItemSpy = spyOn(localStorage, 'setItem').and.callThrough();
     setItemSpy.calls.reset();
@@ -134,54 +187,41 @@ describe('SettingsService', () => {
     service.setSelectedTeamId('');
     service.setSelectedTeamId(service.selectedTeamId);
     service.setTopControlsExpanded(service.topControlsExpanded);
+    service.setSeason(null);
+    service.setReportType('regular');
 
     expect(setItemSpy).not.toHaveBeenCalled();
   });
 
-  it('should emit derived observable values and map startFromSeason null to undefined', () => {
+  it('should emit derived observable values', () => {
     const service = TestBed.inject(SettingsService);
 
-    const selectedTeamIds: string[] = [];
-    const startFromSeasons: Array<number | undefined> = [];
-    const topControlsExpandedValues: boolean[] = [];
+    const seasons: Array<number | undefined> = [];
+    const reportTypes: string[] = [];
 
-    const selectedSub = service.selectedTeamId$.subscribe((v) => selectedTeamIds.push(v));
-    const seasonSub = service.startFromSeason$.subscribe((v) => startFromSeasons.push(v));
-    const expandedSub = service.topControlsExpanded$.subscribe((v) => topControlsExpandedValues.push(v));
+    const seasonSub = service.season$.subscribe((v) => seasons.push(v));
+    const reportTypeSub = service.reportType$.subscribe((v) => reportTypes.push(v));
 
-    // Initial emissions from BehaviorSubject.
-    expect(selectedTeamIds[selectedTeamIds.length - 1]).toBe('1');
-    expect(startFromSeasons[startFromSeasons.length - 1]).toBeUndefined();
-    expect(topControlsExpandedValues[topControlsExpandedValues.length - 1]).toBeTrue();
+    expect(seasons[seasons.length - 1]).toBeUndefined();
+    expect(reportTypes[reportTypes.length - 1]).toBe('regular');
 
-    // Updates should emit new mapped values.
-    service.setSelectedTeamId('2');
-    service.setStartFromSeason(2022);
-    service.setTopControlsExpanded(false);
+    service.setSeason(2024);
+    service.setReportType('playoffs');
 
-    expect(selectedTeamIds[selectedTeamIds.length - 1]).toBe('2');
-    expect(startFromSeasons[startFromSeasons.length - 1]).toBe(2022);
-    expect(topControlsExpandedValues[topControlsExpandedValues.length - 1]).toBeFalse();
-
-    // Setting startFromSeason back to undefined should map to null internally but emit undefined.
-    service.setStartFromSeason(undefined);
-    expect(startFromSeasons[startFromSeasons.length - 1]).toBeUndefined();
+    expect(seasons[seasons.length - 1]).toBe(2024);
+    expect(reportTypes[reportTypes.length - 1]).toBe('playoffs');
 
     // DistinctUntilChanged should prevent no-op emissions.
-    const selectedCount = selectedTeamIds.length;
-    const seasonCount = startFromSeasons.length;
-    const expandedCount = topControlsExpandedValues.length;
+    const seasonCount = seasons.length;
+    const reportTypeCount = reportTypes.length;
 
-    service.setSelectedTeamId('2');
-    service.setStartFromSeason(undefined);
-    service.setTopControlsExpanded(false);
+    service.setSeason(2024);
+    service.setReportType('playoffs');
 
-    expect(selectedTeamIds.length).toBe(selectedCount);
-    expect(startFromSeasons.length).toBe(seasonCount);
-    expect(topControlsExpandedValues.length).toBe(expandedCount);
+    expect(seasons.length).toBe(seasonCount);
+    expect(reportTypes.length).toBe(reportTypeCount);
 
-    selectedSub.unsubscribe();
     seasonSub.unsubscribe();
-    expandedSub.unsubscribe();
+    reportTypeSub.unsubscribe();
   });
 });

--- a/src/app/services/tests/settings.service.spec.ts
+++ b/src/app/services/tests/settings.service.spec.ts
@@ -95,16 +95,6 @@ describe('SettingsService', () => {
     expect(service.reportType).toBe('regular');
   });
 
-  it('should remove legacy keys on load', () => {
-    localStorage.setItem('fantrax.selectedTeamId', '5');
-    localStorage.setItem('fantrax.topControls.expanded', 'false');
-
-    TestBed.inject(SettingsService);
-
-    expect(localStorage.getItem('fantrax.selectedTeamId')).toBeNull();
-    expect(localStorage.getItem('fantrax.topControls.expanded')).toBeNull();
-  });
-
   it('should normalize startFromSeason and avoid persisting unchanged values', () => {
     const service = TestBed.inject(SettingsService);
     const setItemSpy = spyOn(localStorage, 'setItem').and.callThrough();

--- a/src/app/services/tests/team.service.spec.ts
+++ b/src/app/services/tests/team.service.spec.ts
@@ -11,10 +11,11 @@ describe('TeamService', () => {
     localStorage.setItem(
       'fantrax.settings',
       JSON.stringify({
-        version: 1,
         selectedTeamId: '7',
         startFromSeason: null,
         topControlsExpanded: true,
+        season: null,
+        reportType: 'regular',
       })
     );
     const service = TestBed.inject(TeamService);
@@ -22,24 +23,15 @@ describe('TeamService', () => {
     expect(service.selectedTeamId).toBe('7');
   });
 
-  it('should migrate legacy selectedTeamId when fantrax.settings is missing', () => {
-    localStorage.setItem('fantrax.selectedTeamId', '7');
-    const service = TestBed.inject(TeamService);
-
-    expect(service.selectedTeamId).toBe('7');
-
-    const persisted = JSON.parse(localStorage.getItem('fantrax.settings') ?? '{}');
-    expect(persisted.selectedTeamId).toBe('7');
-  });
-
   it('should fall back to default team id when stored value is blank', () => {
     localStorage.setItem(
       'fantrax.settings',
       JSON.stringify({
-        version: 1,
         selectedTeamId: '   ',
         startFromSeason: null,
         topControlsExpanded: true,
+        season: null,
+        reportType: 'regular',
       })
     );
     const service = TestBed.inject(TeamService);
@@ -70,10 +62,11 @@ describe('TeamService', () => {
     localStorage.setItem(
       'fantrax.settings',
       JSON.stringify({
-        version: 1,
         selectedTeamId: '3',
         startFromSeason: null,
         topControlsExpanded: true,
+        season: null,
+        reportType: 'regular',
       })
     );
     const service = TestBed.inject(TeamService);
@@ -120,10 +113,11 @@ describe('TeamService', () => {
     localStorage.setItem(
       'fantrax.settings',
       JSON.stringify({
-        version: 1,
         selectedTeamId: '1',
         startFromSeason: 2012,
         topControlsExpanded: true,
+        season: null,
+        reportType: 'regular',
       })
     );
 

--- a/src/app/shared/top-controls/report-switcher/report-switcher.component.spec.ts
+++ b/src/app/shared/top-controls/report-switcher/report-switcher.component.spec.ts
@@ -10,6 +10,7 @@ describe('ReportSwitcherComponent', () => {
   let filterService: FilterService;
 
   beforeEach(async () => {
+    localStorage.clear();
     await TestBed.configureTestingModule({
       imports: [
         ReportSwitcherComponent,

--- a/src/app/shared/top-controls/season-switcher/season-switcher.component.spec.ts
+++ b/src/app/shared/top-controls/season-switcher/season-switcher.component.spec.ts
@@ -56,7 +56,16 @@ describe('SeasonSwitcherComponent', () => {
         { provide: ApiService, useValue: apiServiceMock },
         FilterService,
         { provide: TeamService, useClass: TeamServiceMock },
-        { provide: SettingsService, useValue: { startFromSeason$: startFromSeasonSubject.asObservable() } },
+        {
+          provide: SettingsService,
+          useValue: {
+            startFromSeason$: startFromSeasonSubject.asObservable(),
+            reportType: 'regular',
+            season: undefined,
+            setSeason: jasmine.createSpy('setSeason'),
+            setReportType: jasmine.createSpy('setReportType'),
+          },
+        },
       ],
     }).compileComponents();
 

--- a/src/app/shared/top-controls/top-controls.component.spec.ts
+++ b/src/app/shared/top-controls/top-controls.component.spec.ts
@@ -9,8 +9,6 @@ describe("TopControlsComponent", () => {
 
   const clearSettingsStorage = (): void => {
     localStorage.removeItem("fantrax.settings");
-    localStorage.removeItem("fantrax.selectedTeamId");
-    localStorage.removeItem("fantrax.topControls.expanded");
   };
 
   beforeEach(async () => {
@@ -69,10 +67,11 @@ describe("TopControlsComponent", () => {
     localStorage.setItem(
       "fantrax.settings",
       JSON.stringify({
-        version: 1,
         selectedTeamId: "1",
         startFromSeason: null,
         topControlsExpanded: false,
+        season: null,
+        reportType: "regular",
       }),
     );
 
@@ -106,10 +105,11 @@ describe("TopControlsComponent", () => {
     localStorage.setItem(
       "fantrax.settings",
       JSON.stringify({
-        version: 1,
         selectedTeamId: "1",
         startFromSeason: null,
         topControlsExpanded: false,
+        season: null,
+        reportType: "regular",
       }),
     );
 


### PR DESCRIPTION
## Summary

- `AppSettings` simplified to a flat type — no versioning, no legacy migration code
- Season selection (`Kausivalitsin`) and report type (`Raportti`) are now persisted to `localStorage` and restored on page reload
- Season resets to "all" on team change (via existing `resetAll()` flow)
- `FilterService` seeds initial state from `SettingsService` and writes back on every global filter change
- All legacy localStorage key references (`fantrax.selectedTeamId`, `fantrax.topControls.expanded`) removed from code, tests, and docs