### PR TITLE
Add playoffs appearances column to leaderboards

### DIFF
--- a/docs/project-overview.md
+++ b/docs/project-overview.md
@@ -59,7 +59,7 @@ Accessibility is a core requirement: the UI is designed to remain usable via key
 
 5. **Team Leaderboards** (`/leaderboards`)
    - All-time regular season ranking table: position, wins, points, win percentage, regular season titles
-   - All-time playoffs ranking table: position, championships, finals, conference finals, round results
+   - All-time playoffs ranking table: position, championships, finals, conference finals, round results, appearances
    - Tab navigation between Runkosarja and Playoffs views (default: Playoffs)
    - Column sorting via `mat-sort`; position ties handled correctly (first tied team shows number, subsequent show blank)
 

--- a/public/i18n/fi.json
+++ b/public/i18n/fi.json
@@ -228,7 +228,8 @@
     "finals": "Finaalit",
     "conferenceFinals": "Konf. finaalit",
     "secondRound": "2. kierros",
-    "firstRound": "1. kierros"
+    "firstRound": "1. kierros",
+    "appearances": "Mukana playoffseissa"
   },
   "tableColumnShort": {
     "position": "#",
@@ -264,7 +265,8 @@
     "finals": "F",
     "conferenceFinals": "KF",
     "secondRound": "2K",
-    "firstRound": "1K"
+    "firstRound": "1K",
+    "appearances": "PO"
   },
   "season": {
     "selector": "Kausivalitsin",

--- a/src/app/leaderboards/playoffs/leaderboard-playoffs.component.ts
+++ b/src/app/leaderboards/playoffs/leaderboard-playoffs.component.ts
@@ -21,5 +21,6 @@ export class LeaderboardPlayoffsComponent {
     { field: 'conferenceFinals' },
     { field: 'secondRound' },
     { field: 'firstRound' },
+    { field: 'appearances' },
   ];
 }

--- a/src/app/services/api.types.generated.ts
+++ b/src/app/services/api.types.generated.ts
@@ -983,6 +983,8 @@ export interface components {
         PlayoffLeaderboardEntry: {
             teamId: string;
             teamName: string;
+            /** @description Total playoff appearances (sum of championships, finals, conferenceFinals, secondRound, and firstRound). */
+            appearances: number;
             championships: number;
             finals: number;
             conferenceFinals: number;
@@ -999,12 +1001,13 @@ export interface components {
             losses: number;
             ties: number;
             points: number;
-            pointsPercent: number;
             divWins: number;
             divLosses: number;
             divTies: number;
             winPercent: number;
             divWinPercent: number;
+            /** @description Achieved points as a fraction of the maximum possible points (wins×2 + ties) / (games×2). */
+            pointsPercent: number;
             /** @description Number of seasons the team finished rank 1 in regular standings. */
             regularTrophies: number;
             /** @description True when this entry's record matches the previous entry's record. */


### PR DESCRIPTION
## Summary
Adds the new playoffs leaderboard API field appearances to the leaderboards table UI.

## What changed
- Added appearances as the last column in playoffs leaderboard table
- Added Finnish column labels:
  - Short: PO
  - Tooltip/full label: Mukana playoffseissa
- Regenerated OpenAPI-derived frontend types to include PlayoffLeaderboardEntry.appearances
- Updated project overview docs to mention playoffs appearances in leaderboard columns

## Files changed
- docs/project-overview.md
- public/i18n/fi.json
- src/app/leaderboards/playoffs/leaderboard-playoffs.component.ts
- src/app/services/api.types.generated.ts

## Validation
- npm run verify

## Notes
- Build completed with existing bundle budget warnings (non-blocking, pre-existing pattern).