### PR TITLE
Refactor: Modernize components - part 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ Local Playwright runs against `http://localhost:4200` and starts `npm start` via
 
 ### Test Coverage Summary
 
-Coverage is tracked via `npm run test:coverage` and as part of `npm run verify` (tests with coverage + production build). Vitest coverage now uses the **Istanbul** provider, and CI enforces minimum thresholds of **92% statements**, **75% branches**, **94% functions**, and **95% lines** via `angular.json` (`architect.test.options.coverageThresholds`). The lower temporary branch threshold reflects current Angular signal-input coverage noise; every contribution must still include tests for all new/changed logic (aim for **100% coverage for touched code paths**, including error/edge cases).
+Coverage is tracked via `npm run test:coverage` and as part of `npm run verify` (tests with coverage + production build). Vitest coverage now uses the **Istanbul** provider, and CI enforces minimum thresholds of **93% statements**, **75% branches**, **94% functions**, and **95% lines** via `angular.json` (`architect.test.options.coverageThresholds`). The lower temporary branch threshold reflects current Angular signal-input coverage noise; every contribution must still include tests for all new/changed logic (aim for **100% coverage for touched code paths**, including error/edge cases).
 
 See [docs/project-testing.md](docs/project-testing.md) for detailed information about test patterns, best practices, and coverage.
 

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ Local Playwright runs against `http://localhost:4200` and starts `npm start` via
 
 ### Test Coverage Summary
 
-Coverage is tracked via `npm run test:coverage` and as part of `npm run verify` (tests with coverage + production build). Vitest coverage now uses the **Istanbul** provider, and CI enforces minimum thresholds of **92% statements**, **75% branches**, **93% functions**, and **95% lines** via `angular.json` (`architect.test.options.coverageThresholds`). The lower temporary branch threshold reflects current Angular signal-input coverage noise; every contribution must still include tests for all new/changed logic (aim for **100% coverage for touched code paths**, including error/edge cases).
+Coverage is tracked via `npm run test:coverage` and as part of `npm run verify` (tests with coverage + production build). Vitest coverage now uses the **Istanbul** provider, and CI enforces minimum thresholds of **92% statements**, **75% branches**, **94% functions**, and **95% lines** via `angular.json` (`architect.test.options.coverageThresholds`). The lower temporary branch threshold reflects current Angular signal-input coverage noise; every contribution must still include tests for all new/changed logic (aim for **100% coverage for touched code paths**, including error/edge cases).
 
 See [docs/project-testing.md](docs/project-testing.md) for detailed information about test patterns, best practices, and coverage.
 
@@ -194,7 +194,7 @@ Accessibility is a core requirement of this project (not optional).
 - **Framework**: Angular 21
 - **UI Library**: Angular Material 21
 - **Language**: TypeScript 5.9
-- **State Management**: RxJS 7.8 (BehaviorSubjects)
+- **State Management**: Angular signals for synchronous UI state reads, RxJS 7.8 for async flows and compatibility streams
 - **HTTP Client**: Angular HttpClient with caching
 - **Testing**: Vitest + Testing Library (`@testing-library/angular`), Playwright (E2E)
 - **i18n**: ngx-translate 17
@@ -206,6 +206,8 @@ For Angular 21 component work in this repo:
 - Standalone components are the default. Do not add redundant `standalone: true`.
 - Prefer signal inputs for component APIs. Use `input.required()` whenever the parent must always provide the value; do not keep inputs optional "just in case".
 - Prefer the `host` object in `@Component` metadata over `@HostListener` and `@HostBinding`.
+- For app state services, prefer signal-facing read APIs in component code and keep observable APIs for async composition or compatibility only.
+- After refactors, investigate the replaced implementation paths and delete leftovers that are proven unused. Do not keep dormant fallback code "just in case".
 - Use `ChangeDetectionStrategy.OnPush` when the component is already safe for it through signal inputs, `async`-pipe flows, or local event-driven state. Do not apply it as a blanket rule to subscription-heavy components.
 
 ## Project Structure
@@ -248,7 +250,7 @@ This project was originally generated using [Angular CLI](https://github.com/ang
 ### Key Architectural Decisions
 
 1. **Standalone Components**: All components use Angular's standalone API (no modules)
-2. **Reactive Patterns**: RxJS observables for state management
+2. **Reactive Patterns**: Angular signals for synchronous UI reads, with RxJS retained for async composition and compatibility
 3. **Type Safety**: Strict TypeScript configuration enforced
 4. **Immutable State**: Filter state updates create new objects
 5. **Path Aliases**: `@base/*`, `@services/*`, `@shared/*` for clean imports

--- a/angular.json
+++ b/angular.json
@@ -93,7 +93,7 @@
             ],
             "coverageThresholds": {
               "branches": 75,
-              "statements": 92,
+              "statements": 93,
               "functions": 94,
               "lines": 95
             },

--- a/angular.json
+++ b/angular.json
@@ -94,7 +94,7 @@
             "coverageThresholds": {
               "branches": 75,
               "statements": 92,
-              "functions": 93,
+              "functions": 94,
               "lines": 95
             },
             "coverageExclude": [

--- a/docs/coding-standards.md
+++ b/docs/coding-standards.md
@@ -36,6 +36,18 @@ export class ExampleComponent {
 }
 ```
 
+For state services, prefer signal-facing read APIs in component code and reserve observable APIs for async composition, interop, or compatibility:
+
+```typescript
+export class ExampleComponent {
+  private readonly filterService = inject(FilterService);
+
+  readonly filterState = computed(() => this.filterService.playerFiltersSignal());
+}
+```
+
+After refactors, investigate the replaced implementation paths and remove old code that is now unused. Do not keep dormant compatibility branches or leftover APIs without a real consumer.
+
 Use `input.required()` whenever an input is not truly optional in real usage:
 
 - required inputs preserve the real parent/child contract in TypeScript
@@ -362,6 +374,7 @@ All tests use **Testing Library** (`@testing-library/angular`) with **Vitest**.
 - **Mock only approved external boundaries in UI tests**: `ApiService`, `ViewportService`, and `PwaUpdateService` are normal mock points; do not mock stateful UI services like `FilterService`, `SettingsService`, or `TeamService` just to isolate a control
 - **Delete impossible-state branches**: If a branch cannot happen in any real usage path, remove it instead of keeping defensive context checks or dead fallback code
 - **Simplify before adding tests**: For behavior-neutral refactors, prefer deleting unreachable logic over adding narrow tests whose only purpose is to preserve coverage for code the UI can never hit
+- **Clean up after refactors**: When a refactor replaces an implementation, verify whether the old path still has consumers and delete it if it does not
 
 ```typescript
 import { render, screen } from '@testing-library/angular';

--- a/docs/component-guide.md
+++ b/docs/component-guide.md
@@ -333,6 +333,7 @@ readonly contentOnly = input(false);
 
 - Default mode renders a collapsible panel (toggle button + collapsible content).
 - In the mobile settings drawer, it is rendered with `contentOnly=true` to show only the controls (no toggle UI).
+- Reads the persisted expand/collapse preference from `SettingsService.topControlsExpandedSignal`.
 
 ---
 
@@ -399,7 +400,8 @@ readonly context = input<'player' | 'goalie'>('player');
 
 - Loads seasons from `ApiService`
 - Displays seasons in reverse order (newest first)
-- Updates the appropriate filter stream in `FilterService` when the selection changes
+- Reads the active filter state through `FilterService` signal APIs
+- Updates the appropriate filter state in `FilterService` when the selection changes
 
 ---
 
@@ -419,7 +421,7 @@ readonly context = input<'player' | 'goalie'>('player');
 **Behavior**:
 
 - Uses `MatSelect` to let the user pick `regular`, `playoffs`, or `both`
-- Subscribes to `FilterService` (`playerFilters$`/`goalieFilters$`) to expose `reportType$`
+- Reads the active `reportType` through `FilterService` signal APIs
 - Calls `updatePlayerFilters` / `updateGoalieFilters` when the toggle changes
 
 ---
@@ -434,7 +436,8 @@ readonly context = input<'player' | 'goalie'>('player');
 
 - Only renders for player context (not goalies)
 - Uses `MatButtonToggle` for Kaikki/H/P selection (All/Forwards/Defensemen)
-- Updates `FilterService.playerFilters$` with `positionFilter` value
+- Reads `positionFilter` through `FilterService.playerFiltersSignal`
+- Updates `FilterService` with the selected `positionFilter` value
 - When position filter is active (H or P):
   - Stats table shows only players of that position
   - Score columns display position-relative values (`scoreByPosition`, `scoreByPositionAdjustedByGames`)
@@ -456,6 +459,7 @@ readonly context = input<'player' | 'goalie'>('player');
 
 **Behavior**:
 
+- Reads the active filter state through `FilterService` signal APIs
 - Uses a `MatSlideToggle` to manipulate the `statsPerGame` flag in `FilterService`
 - Keeps its visual state in sync with the current filter state for the given context
 
@@ -476,6 +480,7 @@ readonly maxGames = input(0);
 
 **Behavior**:
 
+- Reads the active filter state through `FilterService` signal APIs
 - Uses `MatSlider` to choose `minGames`
 - Constrains the slider range based on `maxGames`
 - Pushes changes into `FilterService` for the active context

--- a/docs/component-guide.md
+++ b/docs/component-guide.md
@@ -34,10 +34,20 @@ Some sections below describe current public inputs for existing components. Thos
 **Usage**:
 
 ```html
-<app-navigation></app-navigation>
+<app-navigation [tabPanel]="tabPanel"></app-navigation>
 ```
 
-**Inputs/Outputs**: None (uses router for navigation)
+**Inputs**:
+
+```typescript
+readonly tabPanel = input.required<MatTabNavPanel>();
+```
+
+**Behavior**:
+
+- `tabPanel` is required because every real app-shell usage pairs the nav bar with a Material `mat-tab-nav-panel`
+- Reads the current router URL to keep the active tab highlight in sync
+- Normalizes `/` to `/player-stats` so the default route highlights the player tab
 
 ---
 
@@ -189,6 +199,39 @@ TeamService → PlayerStatsComponent (triggers refetch + adds teamId)
 - Fetch career rows from the dedicated API endpoints
 - Pass column definitions and formatters into the shared virtualized table
 - Keep the player career table sorted by plain `name` while rendering position inline with the displayed player name
+
+### LeaderboardComponent
+
+**Location**: `src/app/leaderboards/leaderboard/`
+
+**Type**: Feature Wrapper Component
+
+**Purpose**: Reusable leaderboard shell that fetches leaderboard rows and feeds the read-only expandable stats table used by the regular-season and playoffs leaderboard views.
+
+**Inputs**:
+
+```typescript
+readonly fetchFn = input.required<() => Observable<LeaderboardEntry[]>>();
+readonly columns = input.required<Column[]>();
+readonly formatCell = input<((column: string, value: number | string | undefined) => string) | undefined>();
+readonly rowKey = input.required<(row: LeaderboardRow, index: number) => string>();
+readonly isRowExpandable = input.required<(row: LeaderboardRow) => boolean>();
+readonly expandedRowsFor = input.required<(row: LeaderboardRow) => ExpandedRowViewModel[]>();
+readonly expandToggleAriaLabel = input.required<
+  (row: LeaderboardRow, expanded: boolean) => string
+>();
+readonly expandedHeaderLabels = input.required<{
+  season: string;
+  primary: string;
+  secondary?: string;
+}>();
+```
+
+**Behavior**:
+
+- `formatCell` remains optional because only the regular-season leaderboard currently custom-formats percentage columns
+- All other inputs are required because both concrete leaderboard parents always provide them
+- Fetches rows once on init, derives tied-position display values, and forwards expansion callbacks into `StatsTableComponent`
 
 ---
 
@@ -909,6 +952,15 @@ Supported block types:
 - `ComparisonService` — selection state
 - `MatDialog` — opens comparison dialog
 
+**Input Contract**:
+
+```typescript
+readonly context = input.required<StatsContext>();
+```
+
+- `context` is required because the app shell always provides the active stats context
+- Changing `context` clears any in-progress comparison selection through an effect-driven reset
+
 ---
 
 ### ComparisonDialogComponent
@@ -923,7 +975,9 @@ Supported block types:
 
 ```typescript
 data: {
-  players: [Player | Goalie, Player | Goalie];
+  context: StatsContext;
+  playerA: Player | Goalie;
+  playerB: Player | Goalie;
 }
 ```
 
@@ -951,8 +1005,10 @@ data: {
 **Inputs**:
 
 ```typescript
+readonly context = input.required<StatsContext>();
 readonly playerA = input.required<Player | Goalie>();
 readonly playerB = input.required<Player | Goalie>();
+readonly isMobile = input.required<boolean>();
 ```
 
 **Key Features**:
@@ -975,6 +1031,7 @@ readonly playerB = input.required<Player | Goalie>();
 **Inputs**:
 
 ```typescript
+readonly context = input.required<StatsContext>();
 readonly playerA = input.required<Player | Goalie>();
 readonly playerB = input.required<Player | Goalie>();
 ```

--- a/docs/component-guide.md
+++ b/docs/component-guide.md
@@ -234,26 +234,46 @@ TeamService → PlayerStatsComponent (triggers refetch + adds teamId)
 **Inputs**:
 
 ```typescript
-readonly data = input<any[]>([]);
-readonly columns = input<Column[]>([]);   // optional icon support for emoji/material headers
-readonly defaultSortColumn = input('score');
-readonly loading = input(false);
-readonly apiError = input(false);
-readonly tableId = input('stats-table');
-readonly showSearch = input(true);
-readonly showPositionColumn = input(true);
-readonly positionValue = input<(row: any, index: number) => string>();
-readonly clickable = input(true);
-readonly selectRow = input(false);
-readonly isRowSelected = input<(row: any) => boolean>(() => false);
-readonly canSelectRow$ = input<Observable<boolean>>(of(true));
-readonly onRowSelect = input<(row: any) => void>();
-readonly formatCell = input<(column: string, value: any) => string>();
-readonly expandable = input(false);
-readonly rowKey = input<(row: any, index: number) => string>();
-readonly isRowExpandable = input<(row: any) => boolean>(() => false);
-readonly expandedRowsFor = input<(row: any) => ExpandedRowViewModel[]>(() => []);
-readonly expandToggleAriaLabel = input<(row: any, expanded: boolean) => string>();
+readonly dataInput = input.required<any[]>({ alias: 'data' });
+readonly columnsInput = input.required<Column[]>({ alias: 'columns' });
+readonly defaultSortColumnInput = input('score', { alias: 'defaultSortColumn' });
+readonly loadingInput = input(false, { alias: 'loading' });
+readonly apiErrorInput = input(false, { alias: 'apiError' });
+readonly tableIdInput = input('stats-table', { alias: 'tableId' });
+readonly showSearchInput = input(true, { alias: 'showSearch' });
+readonly showPositionColumnInput = input(true, { alias: 'showPositionColumn' });
+readonly positionValueInput = input<((row: any, index: number) => string) | undefined>(
+  undefined,
+  { alias: 'positionValue' },
+);
+readonly clickableInput = input(true, { alias: 'clickable' });
+readonly selectRowInput = input(false, { alias: 'selectRow' });
+readonly isRowSelectedInput = input<((row: any) => boolean) | undefined>(
+  undefined,
+  { alias: 'isRowSelected' },
+);
+readonly canSelectRowInput = input<Observable<boolean>>(of(true), { alias: 'canSelectRow$' });
+readonly onRowSelectInput = input<((row: any) => void) | undefined>(undefined, {
+  alias: 'onRowSelect',
+});
+readonly formatCellInput = input<
+  ((column: string, value: any) => string) | undefined
+>(undefined, { alias: 'formatCell' });
+readonly expandableInput = input(false, { alias: 'expandable' });
+readonly rowKeyInput = input<((row: any, index: number) => string) | undefined>(undefined, {
+  alias: 'rowKey',
+});
+readonly isRowExpandableInput = input<((row: any) => boolean) | undefined>(undefined, {
+  alias: 'isRowExpandable',
+});
+readonly expandedRowsForInput = input<
+  ((row: any) => ExpandedRowViewModel[]) | undefined
+>(undefined, { alias: 'expandedRowsFor' });
+readonly expandToggleAriaLabelInput = input<
+  ((row: any, expanded: boolean) => string) | undefined
+>(undefined, {
+  alias: 'expandToggleAriaLabel',
+});
 ```
 
 `ExpandedRowViewModel`:
@@ -276,6 +296,7 @@ type ExpandedRowViewModel = {
 - Column configuration driven by `Column[]` objects from `column.types.ts`; column headers support emoji and Material icons via the `icon` property
 - Optional auto-numbered `position` column (`showPositionColumn`) with optional comparison checkboxes (`selectRow`)
 - Optional expandable detail rows (used by leaderboards season breakdown)
+- Signal-input front with effect-driven synchronization of sorting, loading state, focus reset, and expansion bookkeeping
 - Compact stat headers from `tableColumnShort.*` with tooltips using full labels from `tableColumn.*`
 - Center-aligned numeric/stat headers and cells, with the name column left-aligned for readability
 - Responsive layout with horizontal scrolling on narrow viewports
@@ -287,6 +308,36 @@ type ExpandedRowViewModel = {
   [selectRow]="true" [isRowSelected]="isRowSelected" [onRowSelect]="onRowSelect">
 </app-stats-table>
 ```
+
+### VirtualTableComponent
+
+**Location**: `src/app/shared/stats-table/`
+
+**Type**: Presentational Component (read-only virtualized table)
+
+**Purpose**: Lightweight virtual-scroll table for the career player and goalie listings.
+
+**Inputs**:
+
+```typescript
+readonly dataInput = input.required<any[]>({ alias: 'data' });
+readonly columnsInput = input.required<Column[]>({ alias: 'columns' });
+readonly defaultSortColumnInput = input('name', { alias: 'defaultSortColumn' });
+readonly loadingInput = input(false, { alias: 'loading' });
+readonly apiErrorInput = input(false, { alias: 'apiError' });
+readonly searchLabelKeyInput = input('table.playerSearch', { alias: 'searchLabelKey' });
+readonly formatCellInput = input<
+  ((row: any, column: string, value: any) => string) | undefined
+>(undefined, { alias: 'formatCell' });
+```
+
+**Features**:
+
+- Read-only career table optimized for large result sets with `CdkVirtualScrollViewport`
+- Signal-input synchronization replaces the former `ngOnChanges` path for data and default-sort updates
+- Keeps the running-number column and search field always on, because those are the only real app contexts
+- Uses `MatSort` for keyboard-accessible sorting and destroy-aware subscription cleanup
+- Maintains row-focus keyboard navigation across filtering, scrolling, and resize updates
 
 **Usage** (leaderboard — read-only, no search, icon headers, custom cell format):
 
@@ -583,6 +634,7 @@ For **Goalie Stats**, columns are intelligently reordered:
 **Implementation Details**:
 
 - Uses Material Dialog service with custom panel class
+- Internal player state, selected team, filter snapshot, and graphs inputs are signal-backed so navigation swaps keep derived labels/tabs in sync
 - Tracks active tab index to toggle `season-mode` class for dynamic width
 - `formatSeasonDisplay()` method converts year to "YYYY-YY" format
 - `reorderStatsForDisplay()` method handles:
@@ -699,7 +751,7 @@ readonly requestFocusTabHeader = input<() => void>();
 When `positionFilter` is not `'all'` (i.e., filtering by position):
 - **Radar Chart**: Uses `scoresByPosition` instead of `scores` for position-relative comparisons
 - **Line Chart**: Uses `scoreByPosition` and `scoreByPositionAdjustedByGames` for score trend lines
-- Charts automatically rebuild when `positionFilter` input changes via `ngOnChanges`
+- Charts automatically rebuild when signal inputs change via component effects
 
 **Chart Types**:
 
@@ -983,26 +1035,31 @@ this.sharedService.value$.subscribe((value) => {
 
 ## Component Lifecycle
 
-Common hooks used in this project:
+Preferred lifecycle patterns in this project:
 
-1. **ngOnInit**: Component initialization, data fetching
-2. **ngOnDestroy**: Cleanup, unsubscribe observables
-3. **ngOnChanges**: React to input changes (for presentational components)
+1. **constructor + `effect()` / `computed()`**: React to signal inputs and internal signal state
+2. **ngAfterViewInit**: View/query-dependent setup such as focus targets or chart sizing
+3. **ngOnDestroy**: Cleanup timers, DOM listeners, and non-RxJS resources
+4. **ngOnInit**: Only when initialization does not fit the signal/effect flow cleanly
 
 ```typescript
-export class MyComponent implements OnInit, OnDestroy, OnChanges {
-  ngOnChanges(changes: SimpleChanges): void {
-    if (changes["data"]) {
-      // React to data input changes
-    }
+export class MyComponent implements AfterViewInit, OnDestroy {
+  readonly dataInput = input.required<Item[]>({ alias: 'data' });
+  readonly selectedId = signal<string | null>(null);
+
+  constructor() {
+    effect(() => {
+      const data = this.dataInput();
+      this.selectedId.set(data[0]?.id ?? null);
+    });
   }
 
-  ngOnInit(): void {
-    // Initialize component, fetch data
+  ngAfterViewInit(): void {
+    // Handle query-based or DOM-dependent setup
   }
 
   ngOnDestroy(): void {
-    // Cleanup subscriptions
+    // Cleanup timers/listeners
   }
 }
 ```

--- a/docs/project-overview.md
+++ b/docs/project-overview.md
@@ -125,8 +125,9 @@ Backend API → ApiService → Component → Template
          ↓
       CacheService
 
-TeamService → Component
-FilterService → Component → Table Display
+TeamService / FilterService / SettingsService signals → Component → Template
+                                         ↓
+                             observable APIs for async composition
 ```
 
 ## Build & Deployment

--- a/docs/project-requirements.md
+++ b/docs/project-requirements.md
@@ -69,7 +69,7 @@ npm run test:coverage
 ```
 
 - **Scope**: Application implementation under `src/` (test files excluded)
-- **Coverage gate**: `npm run verify` enforces minimum coverage of 92% statements, 75% branches, 94% functions, and 95% lines.
+- **Coverage gate**: `npm run verify` enforces minimum coverage of 93% statements, 75% branches, 94% functions, and 95% lines.
 - **Contribution rule (required)**: every new/changed code path must be covered by tests (aim 100% coverage for the code you touched, including error/edge cases)
 - **Prefer**: Remove unused/dead code rather than writing tests solely to “cover” it
 
@@ -90,7 +90,7 @@ npm run test:coverage
 ### Test Coverage
 
 - New/changed logic must be fully tested (aim 100% coverage for the code you touched, including error/edge cases).
-- `npm run verify` must keep overall coverage at or above 92% statements, 75% branches, 94% functions, and 95% lines.
+- `npm run verify` must keep overall coverage at or above 93% statements, 75% branches, 94% functions, and 95% lines.
 - The reduced branch threshold is a temporary workaround for current Angular signal-input coverage noise, not permission to leave real logic untested.
 - After refactors, investigate the implementation that was replaced and remove it if it no longer has real consumers.
 - Don’t merge changes that add uncovered new behavior.

--- a/docs/project-requirements.md
+++ b/docs/project-requirements.md
@@ -69,7 +69,7 @@ npm run test:coverage
 ```
 
 - **Scope**: Application implementation under `src/` (test files excluded)
-- **Coverage gate**: `npm run verify` enforces minimum coverage of 92% statements, 75% branches, 93% functions, and 95% lines.
+- **Coverage gate**: `npm run verify` enforces minimum coverage of 92% statements, 75% branches, 94% functions, and 95% lines.
 - **Contribution rule (required)**: every new/changed code path must be covered by tests (aim 100% coverage for the code you touched, including error/edge cases)
 - **Prefer**: Remove unused/dead code rather than writing tests solely to “cover” it
 
@@ -90,8 +90,9 @@ npm run test:coverage
 ### Test Coverage
 
 - New/changed logic must be fully tested (aim 100% coverage for the code you touched, including error/edge cases).
-- `npm run verify` must keep overall coverage at or above 92% statements, 75% branches, 93% functions, and 95% lines.
+- `npm run verify` must keep overall coverage at or above 92% statements, 75% branches, 94% functions, and 95% lines.
 - The reduced branch threshold is a temporary workaround for current Angular signal-input coverage noise, not permission to leave real logic untested.
+- After refactors, investigate the implementation that was replaced and remove it if it no longer has real consumers.
 - Don’t merge changes that add uncovered new behavior.
 
 ### Testing Best Practices

--- a/docs/project-testing.md
+++ b/docs/project-testing.md
@@ -19,7 +19,7 @@ Every contribution must include tests for all new/changed behavior.
 
 - **Rule**: new/changed logic should be tested (include error and edge cases)
 - **CI Gate**: `npm run verify` must pass (tests + production build)
-- **Coverage thresholds**: `npm run verify` enforces minimum coverage of 92% statements, 75% branches, 94% functions, and 95% lines via `angular.json` (`architect.test.options.coverageThresholds`)
+- **Coverage thresholds**: `npm run verify` enforces minimum coverage of 93% statements, 75% branches, 94% functions, and 95% lines via `angular.json` (`architect.test.options.coverageThresholds`)
 - **Temporary note**: the branch threshold is intentionally lower while Angular signal-input coverage is still over-counting framework branches; do not use that as a reason to skip meaningful behavior coverage
 - **Planning-heavy changes**: save the approved implementation plan locally under gitignored `docs/plans/YYYY-MM-DD-*.md` before editing code so behavior-test work can resume cleanly in a later session
 

--- a/docs/project-testing.md
+++ b/docs/project-testing.md
@@ -19,7 +19,7 @@ Every contribution must include tests for all new/changed behavior.
 
 - **Rule**: new/changed logic should be tested (include error and edge cases)
 - **CI Gate**: `npm run verify` must pass (tests + production build)
-- **Coverage thresholds**: `npm run verify` enforces minimum coverage of 92% statements, 75% branches, 93% functions, and 95% lines via `angular.json` (`architect.test.options.coverageThresholds`)
+- **Coverage thresholds**: `npm run verify` enforces minimum coverage of 92% statements, 75% branches, 94% functions, and 95% lines via `angular.json` (`architect.test.options.coverageThresholds`)
 - **Temporary note**: the branch threshold is intentionally lower while Angular signal-input coverage is still over-counting framework branches; do not use that as a reason to skip meaningful behavior coverage
 - **Planning-heavy changes**: save the approved implementation plan locally under gitignored `docs/plans/YYYY-MM-DD-*.md` before editing code so behavior-test work can resume cleanly in a later session
 
@@ -66,6 +66,7 @@ The coverage gate used by `npm run test:coverage` and `npm run verify` is config
 - **Do not mock stateful UI services just to isolate controls**: Avoid mocking services like `FilterService`, `SettingsService`, or `TeamService` when the control is something the user sees and clicks
 - **Minimize renders**: Full-render tests are expensive. Group all assertions for a given scenario into a single test with one `render()` call. Use comments to separate logical assertion groups. Do NOT create separate `it()` blocks that each call `render()` for the same component state
 - **Prefer removing dead logic to covering it**: If a branch cannot be reached through any real user path, delete it instead of adding isolated tests that only exercise internal implementation details
+- **After refactors, remove proven-unused leftovers**: Once the new path is in place, investigate the replaced implementation and delete unused old code instead of preserving it "for safety"
 
 ### Service-Layer Tests
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -32,7 +32,6 @@ Persist the user's last sort column and direction per table (players/goalies) in
 
 ### Remaining modernization work
 
-- Modernize the remaining decorator-era, stateful table and card components where it is behavior-safe: `stats-table.component.ts`, `virtual-table.component.ts`, `player-card.component.ts`, and `player-card-graphs.component.ts`.
 - Audit the remaining `@Input`-based shared components and convert only the inputs that are truly required/optional instead of preserving defensive flexibility by default.
 - Revisit the temporary branch-coverage workaround after Angular fixes signal-input coverage accounting, then raise the branch threshold back up.
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -32,7 +32,6 @@ Persist the user's last sort column and direction per table (players/goalies) in
 
 ### Remaining modernization work
 
-- Audit the remaining `@Input`-based shared components and convert only the inputs that are truly required/optional instead of preserving defensive flexibility by default.
 - Revisit the temporary branch-coverage workaround after Angular fixes signal-input coverage accounting, then raise the branch threshold back up.
 
 ## E2E Testing

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -34,6 +34,16 @@ Persist the user's last sort column and direction per table (players/goalies) in
 
 - Revisit the temporary branch-coverage workaround after Angular fixes signal-input coverage accounting, then raise the branch threshold back up.
 
+#### Retire Deprecated Angular Animation Providers (~2-4h)
+
+Angular 21.2.1 still builds cleanly, but the current animation provider APIs used in this repo were deprecated in Angular 20.2 and are marked with intent to remove in v23.
+
+Refactor steps:
+
+1. Verify whether runtime `provideAnimationsAsync()` is still required in `src/app/app.config.ts` for the current Angular Material usage, and remove it if the app behavior stays correct without it.
+2. Replace deprecated `provideNoopAnimations()` usage in `src/app/testing/behavior-test-utils.ts` and the remaining table / leaderboard specs with a non-deprecated test setup that matches the chosen runtime animation strategy.
+3. Re-run behavior coverage around animation-sensitive flows after the migration, especially the navigation sheet, settings drawer, player card dialog, comparison dialog, and expandable tables.
+
 ## E2E Testing
 
 ### Test data management

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -32,7 +32,6 @@ Persist the user's last sort column and direction per table (players/goalies) in
 
 ### Remaining modernization work
 
-- Add signal-facing read APIs to `filter.service.ts`, `settings.service.ts`, and `team.service.ts` while keeping the current observable APIs for compatibility.
 - Modernize the remaining decorator-era, stateful table and card components where it is behavior-safe: `stats-table.component.ts`, `virtual-table.component.ts`, `player-card.component.ts`, and `player-card-graphs.component.ts`.
 - Audit the remaining `@Input`-based shared components and convert only the inputs that are truly required/optional instead of preserving defensive flexibility by default.
 - Revisit the temporary branch-coverage workaround after Angular fixes signal-input coverage accounting, then raise the branch threshold back up.

--- a/docs/service-guide.md
+++ b/docs/service-guide.md
@@ -13,7 +13,7 @@ Services in this application handle data fetching, business logic, state managem
 
 **Responsibilities**:
 - Store user settings in a single `localStorage` key: `fantrax.settings`
-- Provide reactive settings slices as observables (team id, start-from season, top-controls expanded, season, report type)
+- Provide the currently used reactive settings reads for team id, start-from season, and top-controls expand/collapse state
 - Validate all fields on load; invalid or missing fields fall back to defaults
 
 **Notes**:
@@ -26,16 +26,13 @@ Services in this application handle data fetching, business logic, state managem
 **Key API**:
 ```typescript
 class SettingsService {
-  readonly settings$: Observable<AppSettings>;
   readonly selectedTeamId$: Observable<string>;
+  readonly selectedTeamIdSignal: Signal<string>;
   readonly startFromSeason$: Observable<number | undefined>;
-  readonly topControlsExpanded$: Observable<boolean>;
-  readonly season$: Observable<number | undefined>;
-  readonly reportType$: Observable<ReportType>;
+  readonly topControlsExpandedSignal: Signal<boolean>;
 
   get selectedTeamId(): string;
   get startFromSeason(): number | undefined;
-  get topControlsExpanded(): boolean;
   get season(): number | undefined;
   get reportType(): ReportType;
 
@@ -64,7 +61,7 @@ export type AppSettings = {
 **Purpose**: Global selected-team state with persistence
 
 **Responsibilities**:
-- Provide current team id as an observable (`selectedTeamId$`)
+- Provide current team id as both a signal (`selectedTeamIdSignal`) and an observable (`selectedTeamId$`)
 - Persist selection via `SettingsService` (`fantrax.settings` → `selectedTeamId`)
 - Default to Colorado (team id `"1"`) — there is no "no team" state
 
@@ -72,6 +69,7 @@ export type AppSettings = {
 ```typescript
 class TeamService {
   readonly selectedTeamId$: Observable<string>;
+  readonly selectedTeamIdSignal: Signal<string>;
   get selectedTeamId(): string;
   setTeamId(teamId: string): void;
 }
@@ -202,7 +200,7 @@ class StatsService {
 
 **Responsibilities**:
 - Maintain independent filter state for players and goalies
-- Expose filter state as observables for components
+- Expose filter state as both signals and observables for components
 - Keep `season` and `reportType` in sync globally between players and goalies
 - Provide reset helpers (including a global reset)
 
@@ -229,6 +227,8 @@ export interface FilterState {
 class FilterService {
   playerFilters$: Observable<FilterState>;
   goalieFilters$: Observable<FilterState>;
+  playerFiltersSignal: Signal<FilterState>;
+  goalieFiltersSignal: Signal<FilterState>;
 
   updatePlayerFilters(change: Partial<FilterState>): void;
   updateGoalieFilters(change: Partial<FilterState>): void;

--- a/src/app/base/navigation/navigation.component.html
+++ b/src/app/base/navigation/navigation.component.html
@@ -1,4 +1,4 @@
-<nav mat-tab-nav-bar [tabPanel]="tabPanel">
+<nav mat-tab-nav-bar [tabPanel]="tabPanel()">
   @for (item of navItems; track item) {
   <a
     mat-tab-link

--- a/src/app/base/navigation/navigation.component.ts
+++ b/src/app/base/navigation/navigation.component.ts
@@ -1,10 +1,12 @@
 import {
+  DestroyRef,
   Component,
-  Input,
-  inject,
   ChangeDetectorRef,
   OnInit,
+  inject,
+  input,
 } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { RouterLink, Router } from '@angular/router';
 import { TranslateModule } from '@ngx-translate/core';
 import { MatTabNavPanel, MatTabsModule } from '@angular/material/tabs';
@@ -16,9 +18,10 @@ import { MatTabNavPanel, MatTabsModule } from '@angular/material/tabs';
   styleUrl: './navigation.component.scss',
 })
 export class NavigationComponent implements OnInit {
-  @Input() tabPanel!: MatTabNavPanel;
+  readonly tabPanel = input.required<MatTabNavPanel>();
   private cdr = inject(ChangeDetectorRef);
   private router = inject(Router);
+  private destroyRef = inject(DestroyRef);
 
   navItems = [
     { label: 'link.playerStats', path: '/player-stats' },
@@ -27,10 +30,12 @@ export class NavigationComponent implements OnInit {
   activeLink = '';
 
   ngOnInit(): void {
-    this.router.events.subscribe(() => {
-      this.activeLink = this.normalizeActiveLink(this.router.url);
-      this.cdr.detectChanges();
-    });
+    this.router.events
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(() => {
+        this.activeLink = this.normalizeActiveLink(this.router.url);
+        this.cdr.detectChanges();
+      });
   }
 
   private normalizeActiveLink(url: string): string {

--- a/src/app/leaderboards/leaderboard/leaderboard.component.ts
+++ b/src/app/leaderboards/leaderboard/leaderboard.component.ts
@@ -1,5 +1,6 @@
-import { Component, Input, OnInit, OnDestroy } from '@angular/core';
-import { Subject, Observable, takeUntil } from 'rxjs';
+import { Component, DestroyRef, OnInit, inject, input } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { Observable } from 'rxjs';
 import { StatsTableComponent, TableRow } from '@shared/stats-table/stats-table.component';
 import { Column } from '@shared/column.types';
 import { ExpandedRowViewModel } from '@shared/table-row-expansion.types';
@@ -15,44 +16,52 @@ type LeaderboardRow = LeaderboardEntry & { displayPosition: string };
   template: `
     <app-stats-table
       [data]="data"
-      [columns]="columns"
+      [columns]="columns()"
       [loading]="loading"
       [apiError]="apiError"
       [showSearch]="false"
       [showPositionColumn]="false"
       [clickable]="false"
       [selectRow]="false"
-      [formatCell]="formatCell"
+      [formatCell]="formatCell()"
       [expandable]="true"
       [rowKey]="rowKeyForTable"
       [isRowExpandable]="isRowExpandableForTable"
       [expandedRowsFor]="expandedRowsForTable"
       [expandToggleAriaLabel]="expandToggleAriaLabelForTable"
-      [expandedHeaderLabels]="expandedHeaderLabels"
+      [expandedHeaderLabels]="expandedHeaderLabels()"
       defaultSortColumn=""
       tableId="leaderboard-table"
     />
   `,
 })
-export class LeaderboardComponent implements OnInit, OnDestroy {
-  @Input() fetchFn!: () => Observable<LeaderboardEntry[]>;
-  @Input() columns: Column[] = [];
-  @Input() formatCell?: (column: string, value: number | string | undefined) => string;
-  @Input() rowKey?: (row: LeaderboardRow, index: number) => string;
-  @Input({ required: true }) isRowExpandable!: (row: LeaderboardRow) => boolean;
-  @Input({ required: true }) expandedRowsFor!: (row: LeaderboardRow) => ExpandedRowViewModel[];
-  @Input() expandToggleAriaLabel?: (row: LeaderboardRow, expanded: boolean) => string;
-  @Input() expandedHeaderLabels?: { season: string; primary: string; secondary?: string };
-  readonly rowKeyForTable = (row: TableRow, index: number): string =>
-    this.rowKey?.(row as LeaderboardRow, index) ?? String(index);
-  readonly isRowExpandableForTable = (row: TableRow): boolean =>
-    this.isRowExpandable(row as LeaderboardRow);
-  readonly expandedRowsForTable = (row: TableRow): ExpandedRowViewModel[] =>
-    this.expandedRowsFor(row as LeaderboardRow);
-  readonly expandToggleAriaLabelForTable = (row: TableRow, expanded: boolean): string =>
-    this.expandToggleAriaLabel?.(row as LeaderboardRow, expanded) ?? '';
+export class LeaderboardComponent implements OnInit {
+  readonly fetchFn = input.required<() => Observable<LeaderboardEntry[]>>();
+  readonly columns = input.required<Column[]>();
+  readonly formatCell = input<
+    ((column: string, value: number | string | undefined) => string) | undefined
+  >();
+  readonly rowKey = input.required<(row: LeaderboardRow, index: number) => string>();
+  readonly isRowExpandable = input.required<(row: LeaderboardRow) => boolean>();
+  readonly expandedRowsFor = input.required<(row: LeaderboardRow) => ExpandedRowViewModel[]>();
+  readonly expandToggleAriaLabel = input.required<
+    (row: LeaderboardRow, expanded: boolean) => string
+  >();
+  readonly expandedHeaderLabels = input.required<{
+    season: string;
+    primary: string;
+    secondary?: string;
+  }>();
+  private destroyRef = inject(DestroyRef);
 
-  private destroy$ = new Subject<void>();
+  readonly rowKeyForTable = (row: TableRow, index: number): string =>
+    this.rowKey()(row as LeaderboardRow, index);
+  readonly isRowExpandableForTable = (row: TableRow): boolean =>
+    this.isRowExpandable()(row as LeaderboardRow);
+  readonly expandedRowsForTable = (row: TableRow): ExpandedRowViewModel[] =>
+    this.expandedRowsFor()(row as LeaderboardRow);
+  readonly expandToggleAriaLabelForTable = (row: TableRow, expanded: boolean): string =>
+    this.expandToggleAriaLabel()(row as LeaderboardRow, expanded);
 
   data: LeaderboardRow[] = [];
   loading = true;
@@ -60,8 +69,8 @@ export class LeaderboardComponent implements OnInit, OnDestroy {
 
   ngOnInit(): void {
     this.loading = true;
-    this.fetchFn()
-      .pipe(takeUntil(this.destroy$))
+    this.fetchFn()()
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
         next: (data) => {
           this.data = derivePositions(data);
@@ -72,10 +81,5 @@ export class LeaderboardComponent implements OnInit, OnDestroy {
           this.loading = false;
         },
       });
-  }
-
-  ngOnDestroy(): void {
-    this.destroy$.next();
-    this.destroy$.complete();
   }
 }

--- a/src/app/services/filter.service.ts
+++ b/src/app/services/filter.service.ts
@@ -1,4 +1,5 @@
 import { Injectable, inject } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
 import { BehaviorSubject } from 'rxjs';
 import { ReportType } from './api.service';
 import { SettingsService } from './settings.service';
@@ -38,14 +39,8 @@ export class FilterService {
 
   playerFilters$ = this.filters.players.asObservable();
   goalieFilters$ = this.filters.goalies.asObservable();
-
-  get playerFilters(): FilterState {
-    return this.filters.players.value;
-  }
-
-  get goalieFilters(): FilterState {
-    return this.filters.goalies.value;
-  }
+  readonly playerFiltersSignal = toSignal(this.playerFilters$, { requireSync: true });
+  readonly goalieFiltersSignal = toSignal(this.goalieFilters$, { requireSync: true });
 
   updatePlayerFilters(change: Partial<FilterState>): void {
     const current = this.filters.players.value;

--- a/src/app/services/settings.service.ts
+++ b/src/app/services/settings.service.ts
@@ -1,4 +1,5 @@
-import { Injectable } from '@angular/core';
+import { computed, Injectable } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
 import { BehaviorSubject, distinctUntilChanged, map } from 'rxjs';
 import { ReportType } from './api.service';
 
@@ -23,32 +24,20 @@ export class SettingsService {
     this.loadInitialSettings()
   );
 
-  readonly settings$ = this.settingsSubject.asObservable();
+  private readonly settings$ = this.settingsSubject.asObservable();
+  private readonly settingsSignal = toSignal(this.settings$, { requireSync: true });
 
   readonly selectedTeamId$ = this.settings$.pipe(
     map((s) => s.selectedTeamId),
     distinctUntilChanged()
   );
+  readonly selectedTeamIdSignal = computed(() => this.settingsSignal().selectedTeamId);
 
   readonly startFromSeason$ = this.settings$.pipe(
-    map((s) => (s.startFromSeason === null ? undefined : s.startFromSeason)),
+    map((s) => this.normalizeOptionalSeason(s.startFromSeason)),
     distinctUntilChanged()
   );
-
-  readonly topControlsExpanded$ = this.settings$.pipe(
-    map((s) => s.topControlsExpanded),
-    distinctUntilChanged()
-  );
-
-  readonly season$ = this.settings$.pipe(
-    map((s) => (s.season === null ? undefined : s.season)),
-    distinctUntilChanged()
-  );
-
-  readonly reportType$ = this.settings$.pipe(
-    map((s) => s.reportType),
-    distinctUntilChanged()
-  );
+  readonly topControlsExpandedSignal = computed(() => this.settingsSignal().topControlsExpanded);
 
   get selectedTeamId(): string {
     return this.settingsSubject.value.selectedTeamId;
@@ -58,10 +47,6 @@ export class SettingsService {
     return this.settingsSubject.value.startFromSeason === null
       ? undefined
       : this.settingsSubject.value.startFromSeason;
-  }
-
-  get topControlsExpanded(): boolean {
-    return this.settingsSubject.value.topControlsExpanded;
   }
 
   get season(): number | undefined {
@@ -86,7 +71,7 @@ export class SettingsService {
   }
 
   setTopControlsExpanded(expanded: boolean): void {
-    if (expanded === this.topControlsExpanded) return;
+    if (expanded === this.settingsSubject.value.topControlsExpanded) return;
     this.updateSettings({ topControlsExpanded: expanded });
   }
 
@@ -154,6 +139,10 @@ export class SettingsService {
   private parseReportType(value: unknown): ReportType {
     if (value === 'regular' || value === 'playoffs' || value === 'both') return value;
     return 'regular';
+  }
+
+  private normalizeOptionalSeason(season: number | null): number | undefined {
+    return season === null ? undefined : season;
   }
 
   private persist(settings: AppSettings): void {

--- a/src/app/services/team.service.ts
+++ b/src/app/services/team.service.ts
@@ -10,6 +10,7 @@ export class TeamService {
   private readonly settingsService = inject(SettingsService);
 
   readonly selectedTeamId$: Observable<string> = this.settingsService.selectedTeamId$;
+  readonly selectedTeamIdSignal = this.settingsService.selectedTeamIdSignal;
 
   get selectedTeamId(): string {
     return this.settingsService.selectedTeamId;

--- a/src/app/shared/comparison-bar/comparison-bar.component.ts
+++ b/src/app/shared/comparison-bar/comparison-bar.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, inject, Input, OnChanges, SimpleChanges } from '@angular/core';
+import { ChangeDetectionStrategy, Component, effect, inject, input } from '@angular/core';
 import { AsyncPipe } from '@angular/common';
 import { MatButtonModule } from '@angular/material/button';
 import { MatDialog } from '@angular/material/dialog';
@@ -15,11 +15,12 @@ import { StatsContext } from '@shared/types/context.types';
   templateUrl: './comparison-bar.component.html',
   styleUrl: './comparison-bar.component.scss',
 })
-export class ComparisonBarComponent implements OnChanges {
-  @Input() context: StatsContext = 'player';
+export class ComparisonBarComponent {
+  readonly context = input.required<StatsContext>();
   private readonly comparisonService = inject(ComparisonService);
   private readonly translateService = inject(TranslateService);
   private readonly dialog = inject(MatDialog);
+  private previousContext?: StatsContext;
 
   readonly selection$ = this.comparisonService.selection$;
 
@@ -43,11 +44,16 @@ export class ComparisonBarComponent implements OnChanges {
     })
   );
 
-  ngOnChanges(changes: SimpleChanges): void {
-    // Clear comparison when context changes (but not on initial load)
-    if (changes['context'] && !changes['context'].firstChange) {
-      this.comparisonService.clear();
-    }
+  constructor() {
+    effect(() => {
+      const context = this.context();
+
+      if (this.previousContext !== undefined && context !== this.previousContext) {
+        this.comparisonService.clear();
+      }
+
+      this.previousContext = context;
+    });
   }
 
   onClear(): void {
@@ -66,7 +72,7 @@ export class ComparisonBarComponent implements OnChanges {
     );
 
     this.dialog.open(ComparisonDialogComponent, {
-      data: { ...ordered, context: this.context },
+      data: { ...ordered, context: this.context() },
       maxWidth: '95vw',
       width: 'auto',
       panelClass: 'comparison-dialog-panel',

--- a/src/app/shared/comparison-dialog/comparison-radar/comparison-radar.component.ts
+++ b/src/app/shared/comparison-dialog/comparison-radar/comparison-radar.component.ts
@@ -1,5 +1,5 @@
 import { DOCUMENT } from '@angular/common';
-import { Component, Input, OnInit, inject } from '@angular/core';
+import { Component, OnInit, inject, input } from '@angular/core';
 import { BaseChartDirective, provideCharts, withDefaultRegisterables } from 'ng2-charts';
 import type { ChartConfiguration, ChartData, TooltipItem } from 'chart.js';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
@@ -17,9 +17,9 @@ export class ComparisonRadarComponent implements OnInit {
   private document = inject(DOCUMENT);
   private translateService = inject(TranslateService);
 
-  @Input() context: StatsContext = 'player';
-  @Input({ required: true }) playerA!: Player | Goalie;
-  @Input({ required: true }) playerB!: Player | Goalie;
+  readonly context = input.required<StatsContext>();
+  readonly playerA = input.required<Player | Goalie>();
+  readonly playerB = input.required<Player | Goalie>();
 
   radarChartData: ChartData<'radar'> = { labels: [], datasets: [] };
   radarChartOptions: ChartConfiguration<'radar'>['options'] = {};
@@ -91,12 +91,12 @@ export class ComparisonRadarComponent implements OnInit {
   }
 
   private buildRadarChartData(): void {
-    return this.context === 'goalie' ? this.buildGoalieRadarData() : this.buildPlayerRadarData();
+    return this.context() === 'goalie' ? this.buildGoalieRadarData() : this.buildPlayerRadarData();
   }
 
   private buildPlayerRadarData(): void {
-    const playerA = this.playerA as Player;
-    const playerB = this.playerB as Player;
+    const playerA = this.playerA() as Player;
+    const playerB = this.playerB() as Player;
 
     const scoresA = playerA.scores;
     const scoresB = playerB.scores;
@@ -149,8 +149,8 @@ export class ComparisonRadarComponent implements OnInit {
   }
 
   private buildGoalieRadarData(): void {
-    const goalieA = this.playerA as Goalie;
-    const goalieB = this.playerB as Goalie;
+    const goalieA = this.playerA() as Goalie;
+    const goalieB = this.playerB() as Goalie;
 
     if (!goalieA.scores || !goalieB.scores) return;
 

--- a/src/app/shared/comparison-dialog/comparison-stats/comparison-stats.component.html
+++ b/src/app/shared/comparison-dialog/comparison-stats/comparison-stats.component.html
@@ -1,6 +1,6 @@
-<div class="comparison-stats" [class.mobile]="isMobile">
+<div class="comparison-stats" [class.mobile]="isMobile()">
   @for (row of statRows; track row.key) {
-  @if (isMobile) {
+  @if (isMobile()) {
   <div class="stat-row-mobile">
     <div class="stat-label">{{ row.label }}</div>
     <div class="stat-values">

--- a/src/app/shared/comparison-dialog/comparison-stats/comparison-stats.component.ts
+++ b/src/app/shared/comparison-dialog/comparison-stats/comparison-stats.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnInit, inject } from '@angular/core';
+import { Component, OnInit, inject, input } from '@angular/core';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import type { Player, Goalie } from '@services/api.service';
 import { FilterService } from '@services/filter.service';
@@ -28,10 +28,10 @@ export type StatRow = {
 export class ComparisonStatsComponent implements OnInit {
   private translateService = inject(TranslateService);
 
-  @Input() context: StatsContext = 'player';
-  @Input({ required: true }) playerA!: Player | Goalie;
-  @Input({ required: true }) playerB!: Player | Goalie;
-  @Input() isMobile = false;
+  readonly context = input.required<StatsContext>();
+  readonly playerA = input.required<Player | Goalie>();
+  readonly playerB = input.required<Player | Goalie>();
+  readonly isMobile = input.required<boolean>();
 
   private filterService = inject(FilterService);
 
@@ -39,7 +39,7 @@ export class ComparisonStatsComponent implements OnInit {
   statRows: StatRow[] = [];
 
   ngOnInit(): void {
-    const filters$ = this.context === 'goalie'
+    const filters$ = this.context() === 'goalie'
       ? this.filterService.goalieFilters$
       : this.filterService.playerFilters$;
 
@@ -65,8 +65,8 @@ export class ComparisonStatsComponent implements OnInit {
     const nameRow: StatRow = {
       key: 'name',
       label: this.translateService.instant('tableColumn.name'),
-      valueA: this.isMobile ? this.getShortName(this.playerA.name) : this.playerA.name,
-      valueB: this.isMobile ? this.getShortName(this.playerB.name) : this.playerB.name,
+      valueA: this.isMobile() ? this.getShortName(this.playerA().name) : this.playerA().name,
+      valueB: this.isMobile() ? this.getShortName(this.playerB().name) : this.playerB().name,
       boldA: true,
       boldB: false
     };
@@ -74,8 +74,8 @@ export class ComparisonStatsComponent implements OnInit {
     this.statRows = [
       nameRow,
       ...columns.map((key) => {
-        const valueA = this.getStatValue(this.playerA, key);
-        const valueB = this.getStatValue(this.playerB, key);
+        const valueA = this.getStatValue(this.playerA(), key);
+        const valueB = this.getStatValue(this.playerB(), key);
         const label = this.translateService.instant(`tableColumn.${key}`);
         const { boldA, boldB } = this.computeBold(key, valueA, valueB);
 
@@ -84,12 +84,13 @@ export class ComparisonStatsComponent implements OnInit {
   }
 
   private getStatColumns(): string[] {
-    if (this.context === 'player') {
+    if (this.context() === 'player') {
       return PLAYER_STAT_COLUMNS;
     }
 
     // Check if goalie has season-specific stats (gaa, savePercent)
-    const hasSeasonStats = 'gaa' in this.playerA && this.playerA.gaa !== undefined;
+    const playerA = this.playerA();
+    const hasSeasonStats = 'gaa' in playerA && playerA.gaa !== undefined;
     return hasSeasonStats ? GOALIE_SEASON_STAT_COLUMNS : GOALIE_STAT_COLUMNS;
   }
 

--- a/src/app/shared/player-card/player-card-graphs/player-card-graphs.component.ts
+++ b/src/app/shared/player-card/player-card-graphs/player-card-graphs.component.ts
@@ -2,16 +2,12 @@ import { DOCUMENT } from '@angular/common';
 import {
   AfterViewInit,
   Component,
-  Input,
-  OnChanges,
   OnDestroy,
-  OnInit,
-  SimpleChanges,
-  ViewChildren,
-  QueryList,
+  effect,
   inject,
+  input,
+  viewChildren,
 } from '@angular/core';
-import type { Subscription } from 'rxjs';
 import { MatCheckboxChange, MatCheckboxModule } from '@angular/material/checkbox';
 import { BaseChartDirective, provideCharts, withDefaultRegisterables } from 'ng2-charts';
 import type { ChartConfiguration, ChartData, ChartDataset, TooltipItem } from 'chart.js';
@@ -42,49 +38,45 @@ import { MatIconModule } from '@angular/material/icon';
   styleUrl: './player-card-graphs.component.scss',
   providers: [provideCharts(withDefaultRegisterables())],
 })
-export class PlayerCardGraphsComponent implements OnInit, OnChanges, AfterViewInit, OnDestroy {
+export class PlayerCardGraphsComponent implements AfterViewInit, OnDestroy {
   private static readonly RADAR_COMPACT_MAX_WIDTH = 520;
   private static readonly DEFAULT_VIEWPORT_WIDTH = 1024;
 
-  private document = inject(DOCUMENT);
-  private translateService = inject(TranslateService);
+  private readonly document = inject(DOCUMENT);
+  private readonly translateService = inject(TranslateService);
 
-  @ViewChildren(BaseChartDirective) private charts?: QueryList<BaseChartDirective>;
+  readonly dataInput = input.required<Player | Goalie>({ alias: 'data' });
+  readonly closeButtonElInput = input<HTMLButtonElement | undefined>(undefined, {
+    alias: 'closeButtonEl',
+  });
+  readonly requestFocusTabHeaderInput = input<(() => void) | undefined>(undefined, {
+    alias: 'requestFocusTabHeader',
+  });
+  readonly viewContextInput = input<'combined' | 'season'>('combined', { alias: 'viewContext' });
+  readonly positionFilterInput = input<PositionFilter>('all', { alias: 'positionFilter' });
+
+  readonly charts = viewChildren(BaseChartDirective);
 
   private prefersDarkMql?: MediaQueryList;
-  private chartsChangesSub?: Subscription;
-  private onPrefersSchemeChange = () => {
+  private previousData?: Player | Goalie;
+  private previousViewContext?: 'combined' | 'season';
+  private previousPositionFilter?: PositionFilter;
+  private initialized = false;
+  private readonly onPrefersSchemeChange = () => {
     this.applyThemeToChartOptions();
     this.applyThemeToRadarChartOptions();
     this.refreshChartsLayout();
   };
 
-  private refreshChartsLayout(): void {
-    // Run after the DOM has settled so Chart.js measures the correct container size.
-    requestAnimationFrame(() => {
-      requestAnimationFrame(() => {
-        const charts = this.charts?.toArray() ?? [];
-        charts.forEach((c) => {
-          c.chart?.resize();
-          c.update();
-        });
-      });
-    });
-  }
+  data!: Player | Goalie;
+  closeButtonEl?: HTMLButtonElement;
+  requestFocusTabHeader?: () => void;
+  viewContext: 'combined' | 'season' = 'combined';
+  positionFilter: PositionFilter = 'all';
 
-  @Input({ required: true }) data!: Player | Goalie;
-  @Input() closeButtonEl?: HTMLButtonElement;
-  @Input() requestFocusTabHeader?: () => void;
-  @Input() viewContext: 'combined' | 'season' = 'combined';
-  @Input() positionFilter: PositionFilter = 'all';
-
-  // Track graph controls visibility on mobile
   graphControlsExpanded = false;
-
-  // Chart view mode
   chartViewMode: 'line' | 'radar' = 'line';
 
-  // Radar chart data and options
   radarChartData: ChartData<'radar'> = { labels: [], datasets: [] };
   radarChartOptions: ChartConfiguration<'radar'>['options'] = {
     responsive: true,
@@ -115,25 +107,7 @@ export class PlayerCardGraphsComponent implements OnInit, OnChanges, AfterViewIn
     },
   };
 
-  get chartStatKeys(): string[] {
-    return this.isGoalie
-      ? ['score', 'scoreAdjustedByGames', 'games', 'wins', 'saves', 'shutouts']
-      : [
-        'score',
-        'scoreAdjustedByGames',
-        'games',
-        'goals',
-        'assists',
-        'points',
-        'shots',
-        'penalties',
-        'hits',
-        'blocks',
-      ];
-  }
-
   chartSelections: Record<string, boolean> = {};
-
   chartLabels: string[] = [];
   chartYearsRange: number[] = [];
 
@@ -156,6 +130,84 @@ export class PlayerCardGraphsComponent implements OnInit, OnChanges, AfterViewIn
     },
   };
 
+  constructor() {
+    this.applyThemeToChartOptions();
+    this.applyThemeToRadarChartOptions();
+
+    this.prefersDarkMql = this.document.defaultView?.matchMedia?.('(prefers-color-scheme: dark)');
+    this.prefersDarkMql?.addEventListener?.('change', this.onPrefersSchemeChange);
+
+    effect(() => {
+      const charts = this.charts();
+      if (!this.initialized || charts.length === 0) {
+        return;
+      }
+
+      this.refreshChartsLayout();
+    });
+
+    effect(() => {
+      const data = this.dataInput();
+      const closeButtonEl = this.closeButtonElInput();
+      const requestFocusTabHeader = this.requestFocusTabHeaderInput();
+      const viewContext = this.viewContextInput();
+      const positionFilter = this.positionFilterInput();
+
+      const dataChanged = data !== this.previousData;
+      const viewContextChanged = viewContext !== this.previousViewContext;
+      const positionFilterChanged = positionFilter !== this.previousPositionFilter;
+
+      this.data = data;
+      this.closeButtonEl = closeButtonEl;
+      this.requestFocusTabHeader = requestFocusTabHeader;
+      this.viewContext = viewContext;
+      this.positionFilter = positionFilter;
+      this.syncChartSelections();
+
+      if (viewContext === 'season') {
+        this.chartViewMode = 'radar';
+      }
+
+      if (!this.initialized) {
+        this.previousData = data;
+        this.previousViewContext = viewContext;
+        this.previousPositionFilter = positionFilter;
+        return;
+      }
+
+      if (viewContextChanged && viewContext === 'season') {
+        this.chartViewMode = 'radar';
+      }
+
+      if (dataChanged || viewContextChanged) {
+        this.rebuildChartData();
+      } else if (positionFilterChanged) {
+        this.rebuildChartDataForPositionFilterChange();
+      }
+
+      this.previousData = data;
+      this.previousViewContext = viewContext;
+      this.previousPositionFilter = positionFilter;
+    });
+  }
+
+  get chartStatKeys(): string[] {
+    return this.isGoalie
+      ? ['score', 'scoreAdjustedByGames', 'games', 'wins', 'saves', 'shutouts']
+      : [
+        'score',
+        'scoreAdjustedByGames',
+        'games',
+        'goals',
+        'assists',
+        'points',
+        'shots',
+        'penalties',
+        'hits',
+        'blocks',
+      ];
+  }
+
   get isGoalie(): boolean {
     return this.data != null && 'wins' in this.data;
   }
@@ -168,81 +220,138 @@ export class PlayerCardGraphsComponent implements OnInit, OnChanges, AfterViewIn
     return this.viewContext === 'combined' && this.hasSeasons && this.data.seasons!.length > 1;
   }
 
-  ngOnInit(): void {
-    this.applyThemeToChartOptions();
-    this.applyThemeToRadarChartOptions();
+  ngAfterViewInit(): void {
+    this.initialized = true;
+    this.syncChartSelections();
 
-    // Keep chart theme in sync with auto color-scheme.
-    this.prefersDarkMql = this.document.defaultView?.matchMedia?.(
-      '(prefers-color-scheme: dark)'
-    );
-    this.prefersDarkMql?.addEventListener?.('change', this.onPrefersSchemeChange);
-
-    // For season view, start in radar mode
     if (this.viewContext === 'season') {
       this.chartViewMode = 'radar';
     }
 
-    if (Object.keys(this.chartSelections).length === 0) {
-      this.chartSelections = this.chartStatKeys.reduce(
-        (acc, key) => ({
-          ...acc,
-          // Default: only score fields selected; others via toggle
-          [key]: key === 'score' || key === 'scoreAdjustedByGames',
-        }),
-        {} as Record<string, boolean>
-      );
-    }
-
-    if (this.hasSeasons) {
-      this.setupChartData();
-    }
-
-    // Build radar chart data if in radar mode or if season view
-    if (this.chartViewMode === 'radar' || this.viewContext === 'season') {
-      this.buildRadarChartData();
-    }
-  }
-
-  ngOnChanges(changes: SimpleChanges): void {
-    // Rebuild charts when positionFilter changes
-    if (changes['positionFilter'] && !changes['positionFilter'].firstChange) {
-      // Rebuild radar chart if in radar mode or season view
-      if (this.chartViewMode === 'radar' || this.viewContext === 'season') {
-        this.buildRadarChartData();
-      }
-      // Rebuild line chart if has seasons
-      if (this.hasSeasons && this.data.seasons) {
-        this.updateChartData([...this.data.seasons]);
-      }
-      this.refreshChartsLayout();
-    }
-  }
-
-  ngAfterViewInit(): void {
-    // When switching chart view, Angular destroys/recreates the canvas; ensure we resize
-    // *after* the BaseChartDirective QueryList has updated.
-    this.chartsChangesSub = this.charts?.changes.subscribe(() => this.refreshChartsLayout());
-
-    // In dev/HMR, CSS can re-apply slightly after component init; re-resize once.
+    this.rebuildChartData();
     queueMicrotask(() => this.refreshChartsLayout());
   }
 
   ngOnDestroy(): void {
     this.prefersDarkMql?.removeEventListener?.('change', this.onPrefersSchemeChange);
-    this.chartsChangesSub?.unsubscribe();
+  }
+
+  toggleChartView(): void {
+    this.chartViewMode = this.chartViewMode === 'line' ? 'radar' : 'line';
+    if (this.chartViewMode === 'radar') {
+      this.buildRadarChartData();
+    }
+
+    setTimeout(() => this.refreshChartsLayout(), 0);
+  }
+
+  toggleGraphControls(): void {
+    this.graphControlsExpanded = !this.graphControlsExpanded;
+  }
+
+  onStatToggle(key: string, event: MatCheckboxChange): void {
+    this.chartSelections[key] = event.checked;
+
+    if (!this.data.seasons) return;
+
+    const sortedSeasons = [...this.data.seasons].sort((a, b) => b.season - a.season);
+    this.updateChartData(sortedSeasons);
+  }
+
+  onGraphCheckboxKeydown(event: KeyboardEvent): void {
+    switch (event.key) {
+      case 'ArrowUp': {
+        event.preventDefault();
+        this.requestFocusTabHeader?.();
+        return;
+      }
+      case 'ArrowDown': {
+        const btn = this.closeButtonEl;
+        if (!btn) {
+          return;
+        }
+        event.preventDefault();
+        btn.focus();
+        return;
+      }
+      default:
+        return;
+    }
+  }
+
+  private syncChartSelections(): void {
+    const chartKeys = this.chartStatKeys;
+    const currentKeys = Object.keys(this.chartSelections);
+    const matchesCurrentChart =
+      currentKeys.length === chartKeys.length &&
+      chartKeys.every((key) => currentKeys.includes(key));
+
+    if (matchesCurrentChart) {
+      return;
+    }
+
+    this.chartSelections = chartKeys.reduce(
+      (acc, key) => ({
+        ...acc,
+        [key]: key === 'score' || key === 'scoreAdjustedByGames',
+      }),
+      {} as Record<string, boolean>,
+    );
+  }
+
+  private rebuildChartData(): void {
+    if (this.hasSeasons) {
+      this.setupChartData();
+    } else {
+      this.resetLineChartData();
+    }
+
+    if (this.chartViewMode === 'radar' || this.viewContext === 'season') {
+      this.buildRadarChartData();
+    }
+
+    this.refreshChartsLayout();
+  }
+
+  private rebuildChartDataForPositionFilterChange(): void {
+    if (this.chartViewMode === 'radar' || this.viewContext === 'season') {
+      this.buildRadarChartData();
+    }
+
+    if (this.hasSeasons && this.data.seasons) {
+      this.updateChartData([...this.data.seasons]);
+    }
+
+    this.refreshChartsLayout();
+  }
+
+  private resetLineChartData(): void {
+    this.chartLabels = [];
+    this.chartYearsRange = [];
+    this.lineChartData = {
+      labels: [],
+      datasets: [],
+    };
+  }
+
+  private refreshChartsLayout(): void {
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        this.charts().forEach((chart) => {
+          chart.chart?.resize();
+          chart.update();
+        });
+      });
+    });
   }
 
   private applyThemeToChartOptions(): void {
-    // Note: Angular Material v21 can emit token values using CSS `light-dark()`.
-    // Reading a CSS variable directly returns the raw `light-dark(...)` string, which
-    // Chart.js does not understand. Resolve via computed styles instead.
     const textColor = this.resolveCssColorVar('--mat-sys-on-surface', '#1f1f1f');
     const gridColor = this.resolveCssColorVar('--mat-sys-outline-variant', 'rgba(0,0,0,0.2)');
     const tooltipBg = this.resolveCssColorVar(
       '--mat-sys-surface-container-high',
       'rgba(0,0,0,0.8)',
-      'backgroundColor'
+      'backgroundColor',
     );
 
     const plugins = this.lineChartOptions.plugins ?? {};
@@ -300,7 +409,7 @@ export class PlayerCardGraphsComponent implements OnInit, OnChanges, AfterViewIn
   private resolveCssColorVar(
     name: string,
     fallback: string,
-    cssProperty: 'color' | 'backgroundColor' = 'color'
+    cssProperty: 'color' | 'backgroundColor' = 'color',
   ): string {
     try {
       const body = this.document.body;
@@ -308,12 +417,12 @@ export class PlayerCardGraphsComponent implements OnInit, OnChanges, AfterViewIn
         return fallback;
       }
 
-      // Prefer the app's *actual* active scheme (as computed from CSS) over OS preference.
-      // This matters if the app/theme forces a scheme that differs from `prefers-color-scheme`.
       const root = this.document.documentElement;
       const rootStyle = root ? getComputedStyle(root) : undefined;
       const computedSchemeRaw =
-        (rootStyle as CSSStyleDeclaration & { colorScheme?: string })?.colorScheme || rootStyle?.getPropertyValue('color-scheme') || '';
+        (rootStyle as CSSStyleDeclaration & { colorScheme?: string })?.colorScheme ||
+        rootStyle?.getPropertyValue('color-scheme') ||
+        '';
       const schemeTokens = computedSchemeRaw.trim().split(/\s+/).filter(Boolean);
       const schemeToken = schemeTokens.length === 1 ? schemeTokens[0] : undefined;
 
@@ -322,14 +431,9 @@ export class PlayerCardGraphsComponent implements OnInit, OnChanges, AfterViewIn
           ? (schemeToken as 'light' | 'dark')
           : undefined;
 
-      // If CSS reports a non-single token (e.g. "light dark") or nothing, detect the *used*
-      // scheme by evaluating a tiny `light-dark()` expression.
       const usedScheme = this.detectUsedColorScheme(body, scheme);
 
       const probe = this.createHiddenProbeElement();
-      // Force the used color-scheme so CSS `light-dark()` tokens resolve correctly.
-      // If we can't confidently read the active scheme (some browsers report "normal"),
-      // inherit instead of guessing from OS preference.
       if (usedScheme) {
         probe.style.setProperty('color-scheme', usedScheme);
       }
@@ -362,7 +466,7 @@ export class PlayerCardGraphsComponent implements OnInit, OnChanges, AfterViewIn
 
   private detectUsedColorScheme(
     body: HTMLElement,
-    knownScheme: 'light' | 'dark' | undefined
+    knownScheme: 'light' | 'dark' | undefined,
   ): 'light' | 'dark' | undefined {
     if (knownScheme) {
       return knownScheme;
@@ -386,7 +490,7 @@ export class PlayerCardGraphsComponent implements OnInit, OnChanges, AfterViewIn
     const tooltipBg = this.resolveCssColorVar(
       '--mat-sys-surface-container-high',
       'rgba(0,0,0,0.8)',
-      'backgroundColor'
+      'backgroundColor',
     );
 
     const viewportWidth =
@@ -397,7 +501,6 @@ export class PlayerCardGraphsComponent implements OnInit, OnChanges, AfterViewIn
     const pointLabelPadding = compact ? 2 : 6;
     const layoutPadding = compact ? 0 : 8;
 
-    // Use outline token for grid so it stays readable in light mode.
     const gridColor = outlineColor;
 
     this.radarChartOptions = {
@@ -450,16 +553,6 @@ export class PlayerCardGraphsComponent implements OnInit, OnChanges, AfterViewIn
     };
   }
 
-  toggleChartView(): void {
-    this.chartViewMode = this.chartViewMode === 'line' ? 'radar' : 'line';
-    if (this.chartViewMode === 'radar') {
-      this.buildRadarChartData();
-    }
-
-    // When swapping via @if, the canvas is destroyed/recreated; force a resize once it's mounted.
-    setTimeout(() => this.refreshChartsLayout(), 0);
-  }
-
   private buildRadarChartData(): void {
     const isGoalie = 'wins' in this.data;
 
@@ -473,7 +566,6 @@ export class PlayerCardGraphsComponent implements OnInit, OnChanges, AfterViewIn
   private buildPlayerRadarData(): void {
     const player = this.data as Player;
 
-    // Use position-based scores when filter is active
     const scores = (this.positionFilter !== 'all' && player.scoresByPosition)
       ? player.scoresByPosition
       : player.scores;
@@ -482,7 +574,6 @@ export class PlayerCardGraphsComponent implements OnInit, OnChanges, AfterViewIn
       return;
     }
 
-    // Define stat keys and get labels
     const statKeys: (keyof PlayerScores)[] = [
       'goals',
       'assists',
@@ -496,12 +587,10 @@ export class PlayerCardGraphsComponent implements OnInit, OnChanges, AfterViewIn
       'blocks',
     ];
 
-    // Get translated labels
     const labels = statKeys.map((key) =>
-      this.translateService.instant(`tableColumn.${key}`)
+      this.translateService.instant(`tableColumn.${key}`),
     );
 
-    // Get score values
     const data = statKeys.map((key) => scores[key]);
 
     this.radarChartData = {
@@ -533,7 +622,6 @@ export class PlayerCardGraphsComponent implements OnInit, OnChanges, AfterViewIn
 
     const scores = goalie.scores;
 
-    // Check if gaa/savePercent are available (season endpoint)
     const hasExtendedStats = 'gaa' in scores;
 
     const statKeys = hasExtendedStats
@@ -541,7 +629,7 @@ export class PlayerCardGraphsComponent implements OnInit, OnChanges, AfterViewIn
       : ['wins', 'saves', 'shutouts'];
 
     const labels = statKeys.map((key) =>
-      this.translateService.instant(`tableColumn.${key}`)
+      this.translateService.instant(`tableColumn.${key}`),
     );
 
     const data = statKeys.map((key) => (scores as Record<string, number>)[key]);
@@ -566,40 +654,6 @@ export class PlayerCardGraphsComponent implements OnInit, OnChanges, AfterViewIn
     };
   }
 
-  toggleGraphControls(): void {
-    this.graphControlsExpanded = !this.graphControlsExpanded;
-  }
-
-  onStatToggle(key: string, event: MatCheckboxChange): void {
-    this.chartSelections[key] = event.checked;
-
-    if (!this.data.seasons) return;
-
-    const sortedSeasons = [...this.data.seasons].sort((a, b) => b.season - a.season);
-    this.updateChartData(sortedSeasons);
-  }
-
-  onGraphCheckboxKeydown(event: KeyboardEvent): void {
-    switch (event.key) {
-      case 'ArrowUp': {
-        event.preventDefault();
-        this.requestFocusTabHeader?.();
-        return;
-      }
-      case 'ArrowDown': {
-        const btn = this.closeButtonEl;
-        if (!btn) {
-          return;
-        }
-        event.preventDefault();
-        btn.focus();
-        return;
-      }
-      default:
-        return;
-    }
-  }
-
   private setupChartData(): void {
     if (!this.data.seasons) return;
 
@@ -609,7 +663,7 @@ export class PlayerCardGraphsComponent implements OnInit, OnChanges, AfterViewIn
 
     this.chartYearsRange = Array.from(
       { length: maxYear - minYear + 1 },
-      (_, index) => minYear + index
+      (_, index) => minYear + index,
     );
 
     this.chartLabels = this.chartYearsRange.map((year) => formatSeasonShort(year));
@@ -627,7 +681,6 @@ export class PlayerCardGraphsComponent implements OnInit, OnChanges, AfterViewIn
       seasonByYear.set(season.season, season);
     });
 
-    // Determine if we should use position-based scores
     const usePositionScores = !this.isGoalie && this.positionFilter !== 'all';
 
     const datasets: ChartDataset<'line', (number | null)[]>[] = activeKeys.map((key, index) => {
@@ -637,7 +690,6 @@ export class PlayerCardGraphsComponent implements OnInit, OnChanges, AfterViewIn
           return null;
         }
 
-        // Use position-based score values when filter is active
         const seasonRecord = season as Record<string, unknown>;
         let value: number | string | undefined;
         if (usePositionScores && key === 'score') {
@@ -645,7 +697,9 @@ export class PlayerCardGraphsComponent implements OnInit, OnChanges, AfterViewIn
           value = playerSeason.scoreByPosition ?? (seasonRecord[key] as number | undefined);
         } else if (usePositionScores && key === 'scoreAdjustedByGames') {
           const playerSeason = season as PlayerSeasonStats;
-          value = playerSeason.scoreByPositionAdjustedByGames ?? (seasonRecord[key] as number | undefined);
+          value =
+            playerSeason.scoreByPositionAdjustedByGames ??
+            (seasonRecord[key] as number | undefined);
         } else {
           value = seasonRecord[key] as number | string | undefined;
         }
@@ -672,8 +726,8 @@ export class PlayerCardGraphsComponent implements OnInit, OnChanges, AfterViewIn
       datasets,
     };
 
-    const allValues = datasets.flatMap((ds) =>
-      (ds.data as (number | null)[]).filter((value): value is number => typeof value === 'number')
+    const allValues = datasets.flatMap((dataset) =>
+      (dataset.data as (number | null)[]).filter((value): value is number => typeof value === 'number'),
     );
 
     if (allValues.length > 0) {

--- a/src/app/shared/player-card/player-card.component.html
+++ b/src/app/shared/player-card/player-card.component.html
@@ -96,7 +96,7 @@
       @if (showGraphsTab) {
       <mat-tab label="{{ 'playerCard.graphs' | translate }}">
         @if (graphsComponent) {
-        <ng-container *ngComponentOutlet="graphsComponent; inputs: graphsInputs"></ng-container>
+        <ng-container *ngComponentOutlet="graphsComponent; inputs: graphsInputs()"></ng-container>
         } @else {
         <div class="tab-content">
           @if (graphsLoading) {

--- a/src/app/shared/player-card/player-card.component.ts
+++ b/src/app/shared/player-card/player-card.component.ts
@@ -1,5 +1,18 @@
 import { DOCUMENT, NgComponentOutlet } from '@angular/common';
-import { ChangeDetectorRef, Component, ElementRef, Type, ViewChild, inject } from '@angular/core';
+import {
+  AfterViewInit,
+  ChangeDetectorRef,
+  Component,
+  DestroyRef,
+  ElementRef,
+  Type,
+  ViewChild,
+  computed,
+  effect,
+  inject,
+  signal,
+} from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { MatTableModule } from '@angular/material/table';
 import { MatCardModule } from '@angular/material/card';
@@ -20,7 +33,7 @@ import { FilterService, PositionFilter } from '@services/filter.service';
 import { TeamService } from '@services/team.service';
 import { MatTooltip, MatTooltipModule } from '@angular/material/tooltip';
 import { toSlug } from '@shared/utils/slug.utils';
-import { take } from 'rxjs';
+import { fromEvent, take } from 'rxjs';
 import { PlayerCardStatsService, StatRow } from './player-card-stats.service';
 import { PlayerCardSeasonsService } from './player-card-seasons.service';
 import { PlayerCardNavigationService } from './player-card-navigation.service';
@@ -59,141 +72,150 @@ export type PlayerCardDialogData = {
   styleUrl: './player-card.component.scss',
   providers: [PlayerCardNavigationService],
 })
-export class PlayerCardComponent {
+export class PlayerCardComponent implements AfterViewInit {
   readonly dialogRef = inject(MatDialogRef<PlayerCardComponent>);
-  private rawDialogData = inject<Player | Goalie | PlayerCardDialogData>(MAT_DIALOG_DATA);
-  private document = inject(DOCUMENT);
-  private host = inject(ElementRef<HTMLElement>);
-  private apiService = inject(ApiService);
-  private teamService = inject(TeamService);
-  private filterService = inject(FilterService);
-  private cdr = inject(ChangeDetectorRef);
-  private statsService = inject(PlayerCardStatsService);
-  private seasonsService = inject(PlayerCardSeasonsService);
+  private readonly rawDialogData = inject<Player | Goalie | PlayerCardDialogData>(MAT_DIALOG_DATA);
+  private readonly document = inject(DOCUMENT);
+  private readonly destroyRef = inject(DestroyRef);
+  private readonly host = inject(ElementRef<HTMLElement>);
+  private readonly apiService = inject(ApiService);
+  private readonly teamService = inject(TeamService);
+  private readonly filterService = inject(FilterService);
+  private readonly cdr = inject(ChangeDetectorRef);
+  private readonly statsService = inject(PlayerCardStatsService);
+  private readonly seasonsService = inject(PlayerCardSeasonsService);
   readonly navigationService = inject(PlayerCardNavigationService);
-
-  // Copy link feedback state
-  linkCopied = false;
-  positionFilter: PositionFilter = 'all';
-  statsPerGame = false;
-  selectedTeam: Team | undefined;
 
   @ViewChild('closeButton', { read: ElementRef })
   closeButton?: ElementRef<HTMLButtonElement>;
 
-  // Support both wrapped format { player, initialTab } and direct Player/Goalie
-  data: Player | Goalie = this.isWrappedData(this.rawDialogData)
-    ? this.rawDialogData.player
-    : this.rawDialogData;
+  private readonly initialData = this.unwrapDialogData(this.rawDialogData);
+  private readonly dataState = signal<Player | Goalie>(this.initialData);
+  private readonly positionFilterState = signal<PositionFilter>('all');
+  private readonly statsPerGameState = signal(false);
+  private readonly selectedTeamState = signal<Team | undefined>(undefined);
+  private readonly isMobileState = signal(false);
+  private readonly filtersHydratedState = signal(false);
+  private readonly closeButtonElementState = signal<HTMLButtonElement | undefined>(undefined);
+
+  private readonly isGoalieState = computed(() => 'wins' in this.dataState());
+  private readonly hasSeasonsState = computed(() => Boolean(this.dataState().seasons?.length));
+  private readonly viewContextState = computed<'combined' | 'season'>(() =>
+    this.hasSeasonsState() ? 'combined' : 'season',
+  );
+  private readonly showGraphsTabState = computed(() => {
+    const data = this.dataState();
+    const seasons = data.seasons ?? [];
+
+    return seasons.length > 1 || (seasons.length === 0 && Boolean(data.scores));
+  });
+
   readonly initialTab: PlayerCardTab | undefined = this.isWrappedData(this.rawDialogData)
     ? this.rawDialogData.initialTab
     : undefined;
 
-  // Navigation state
   readonly navigationContext = this.isWrappedData(this.rawDialogData)
     ? this.rawDialogData.navigationContext
     : undefined;
 
-  readonly isGoalie = 'wins' in this.data;
+  readonly graphsInputs = computed<Record<string, unknown>>(() => ({
+    data: this.dataState(),
+    viewContext: this.viewContextState(),
+    positionFilter: this.positionFilterState(),
+    closeButtonEl: this.closeButtonElementState(),
+    requestFocusTabHeader: () => this.focusActiveTabHeader(),
+  }));
 
-  private isWrappedData(data: Player | Goalie | PlayerCardDialogData): data is PlayerCardDialogData {
-    return 'player' in data && (data as PlayerCardDialogData).player !== undefined;
-  }
-
-  // Check if this data has seasons (combined stats)
-  readonly hasSeasons = !!this.data.seasons && this.data.seasons.length > 0;
-
-  // Determine view context (combined vs season)
-  readonly viewContext: 'combined' | 'season' = this.hasSeasons ? 'combined' : 'season';
-
-  // Show Graphs tab if combined data with multiple seasons OR season data with scores
-  readonly showGraphsTab = (this.hasSeasons && this.data.seasons!.length > 1) || (!this.hasSeasons && !!this.data.scores);
-
-  // Track which tab is active (0 = All, 1 = By Season)
+  linkCopied = false;
   selectedTabIndex = 0;
-
-  // Track screen size for season format
-  isMobile = false;
-
-  // Combined stats - will be populated in constructor after getting filter state
   stats: StatRow[] = [];
-
-  // Columns for combined stats table
   displayedColumns: string[] = ['label', 'value'];
-
-  // Columns for season breakdown table
   seasonColumns: string[] = [];
   seasonDataSource: (PlayerSeasonStats | GoalieSeasonStats)[] = [];
   careerBests: Map<string, Set<number>> = new Map();
   graphsComponent: Type<unknown> | null = null;
   graphsLoading = false;
   graphsLoadPromise: Promise<void> | null = null;
-  // Exposed mainly so tests can await the dynamic import deterministically.
-
-  // Keep inputs as a TS-visible field (so it isn't considered "template-only" usage).
-  graphsInputs: Record<string, unknown> = {
-    data: this.data,
-    viewContext: this.viewContext,
-    positionFilter: this.positionFilter,
-    closeButtonEl: undefined,
-    requestFocusTabHeader: () => this.focusActiveTabHeader(),
-  };
 
   constructor() {
     this.checkScreenSize();
-    window.addEventListener('resize', () => this.checkScreenSize());
 
-    // Fetch selected team once
-    this.apiService.getTeams().pipe(take(1)).subscribe((teams) => {
-      this.selectedTeam = teams.find((t) => t.id === this.teamService.selectedTeamId);
-    });
+    const defaultView = this.document.defaultView;
+    if (defaultView) {
+      fromEvent(defaultView, 'resize')
+        .pipe(takeUntilDestroyed(this.destroyRef))
+        .subscribe(() => this.checkScreenSize());
+    }
 
-    // Get filter state for proper column display
+    this.apiService.getTeams()
+      .pipe(take(1), takeUntilDestroyed(this.destroyRef))
+      .subscribe((teams) => {
+        this.selectedTeamState.set(teams.find((t) => t.id === this.teamService.selectedTeamId));
+      });
+
     const filterObservable = this.isGoalie
       ? this.filterService.goalieFilters$
       : this.filterService.playerFilters$;
 
-    filterObservable.pipe(take(1)).subscribe((f) => {
-      this.statsPerGame = f.statsPerGame;
-      if (!this.isGoalie) {
-        this.positionFilter = f.positionFilter;
-      }
-      this.stats = this.statsService.buildStats(this.data, {
-        isGoalie: this.isGoalie,
-        statsPerGame: this.statsPerGame,
-        positionFilter: this.positionFilter,
-        viewContext: this.viewContext,
+    filterObservable
+      .pipe(take(1), takeUntilDestroyed(this.destroyRef))
+      .subscribe((filters) => {
+        this.statsPerGameState.set(filters.statsPerGame);
+        if (!this.isGoalie) {
+          this.positionFilterState.set(filters.positionFilter);
+        }
+        this.filtersHydratedState.set(true);
       });
-      if (this.hasSeasons) {
-        this.refreshSeasonData();
+
+    effect(() => {
+      if (!this.filtersHydratedState()) {
+        return;
       }
-      this.updateGraphsInputs();
+
+      this.stats = this.statsService.buildStats(this.dataState(), {
+        isGoalie: this.isGoalieState(),
+        statsPerGame: this.statsPerGameState(),
+        positionFilter: this.positionFilterState(),
+        viewContext: this.viewContextState(),
+      });
     });
 
-    // Initialize navigation service
+    effect(() => {
+      if (!this.filtersHydratedState()) {
+        return;
+      }
+
+      if (!this.hasSeasonsState()) {
+        this.seasonColumns = [];
+        this.seasonDataSource = [];
+        this.careerBests = new Map();
+        return;
+      }
+
+      const { seasonColumns, seasonDataSource, careerBests } =
+        this.seasonsService.setupSeasonData(this.dataState(), {
+          isGoalie: this.isGoalieState(),
+          statsPerGame: this.statsPerGameState(),
+          positionFilter: this.positionFilterState(),
+          isMobile: this.isMobileState(),
+        });
+
+      this.seasonColumns = seasonColumns;
+      this.seasonDataSource = seasonDataSource;
+      this.careerBests = careerBests;
+    });
+
     this.navigationService.init(
       this.navigationContext,
       this.host,
       this.cdr,
-      (player, _index) => {
-        this.data = player;
-        this.stats = this.statsService.buildStats(this.data, {
-          isGoalie: this.isGoalie,
-          statsPerGame: this.statsPerGame,
-          positionFilter: this.positionFilter,
-          viewContext: this.viewContext,
-        });
-        if (this.hasSeasons) {
-          this.refreshSeasonData();
-        }
-        this.updateGraphsInputs();
+      (player) => {
+        this.dataState.set(player);
       },
     );
 
-    // Set initial tab from dialog data if provided
     if (this.initialTab) {
       this.selectedTabIndex = this.getTabIndexFromName(this.initialTab);
-      // Pre-load graphs if that's the initial tab
       const graphsTabIndex = this.hasSeasons ? 2 : 1;
       if (this.selectedTabIndex === graphsTabIndex && this.showGraphsTab) {
         this.graphsLoadPromise = this.ensureGraphsLoaded();
@@ -202,29 +224,51 @@ export class PlayerCardComponent {
     }
   }
 
-  // --- Navigation ---
+  ngAfterViewInit(): void {
+    this.closeButtonElementState.set(this.closeButton?.nativeElement);
+  }
+
+  get data(): Player | Goalie {
+    return this.dataState();
+  }
+
+  get positionFilter(): PositionFilter {
+    return this.positionFilterState();
+  }
+
+  get statsPerGame(): boolean {
+    return this.statsPerGameState();
+  }
+
+  get selectedTeam(): Team | undefined {
+    return this.selectedTeamState();
+  }
+
+  get isMobile(): boolean {
+    return this.isMobileState();
+  }
+
+  get isGoalie(): boolean {
+    return this.isGoalieState();
+  }
+
+  get hasSeasons(): boolean {
+    return this.hasSeasonsState();
+  }
+
+  get viewContext(): 'combined' | 'season' {
+    return this.viewContextState();
+  }
+
+  get showGraphsTab(): boolean {
+    return this.showGraphsTabState();
+  }
 
   onKeydown(event: KeyboardEvent): void { this.navigationService.handleKeydown(event); }
 
   onTouchStart(event: TouchEvent): void { this.navigationService.handleTouchStart(event); }
 
   onTouchEnd(event: TouchEvent): void { this.navigationService.handleTouchEnd(event); }
-
-  private getTabIndexFromName(tabName: PlayerCardTab): number {
-    switch (tabName) {
-      case 'all':
-        return 0;
-      case 'by-season':
-        // Only valid if hasSeasons, otherwise fall back to 0
-        return this.hasSeasons ? 1 : 0;
-      case 'graphs':
-        // Graphs is at index 2 if hasSeasons, otherwise index 1
-        if (!this.showGraphsTab) return 0;
-        return this.hasSeasons ? 2 : 1;
-      default:
-        return 0;
-    }
-  }
 
   get positionAbbreviation(): string {
     if (this.isGoalie) return 'M';
@@ -238,7 +282,6 @@ export class PlayerCardComponent {
     return player.position === 'D' ? 'Puolustaja' : 'Hyökkääjä';
   }
 
-  // Getter for position filter switch label
   get positionSwitchLabel(): string {
     if (this.isGoalie) return '';
     const player = this.data as Player;
@@ -247,50 +290,16 @@ export class PlayerCardComponent {
       : 'playerCardPositionFilter.forwards';
   }
 
-  // Check if position filter is enabled (specific position selected, not 'all')
   get isPositionFilterEnabled(): boolean {
     return this.positionFilter !== 'all';
   }
 
-  // Toggle position filter between player's position and 'all'
   onPositionFilterToggle(checked: boolean): void {
     if (this.isGoalie) return;
     const player = this.data as Player;
     const newFilter: PositionFilter = checked ? ((player.position as PositionFilter) ?? 'F') : 'all';
     this.filterService.updatePlayerFilters({ positionFilter: newFilter });
-    this.positionFilter = newFilter;
-    this.stats = this.statsService.buildStats(this.data, {
-      isGoalie: this.isGoalie,
-      statsPerGame: this.statsPerGame,
-      positionFilter: this.positionFilter,
-      viewContext: this.viewContext,
-    });
-    if (this.hasSeasons) {
-      this.refreshSeasonData();
-    }
-    this.updateGraphsInputs();
-    this.cdr.detectChanges();
-  }
-
-  private checkScreenSize(): void {
-    this.isMobile = window.innerWidth <= 768;
-    // Update season display if already initialized
-    if (this.hasSeasons && this.seasonDataSource.length > 0) {
-      this.refreshSeasonData();
-    }
-  }
-
-  private refreshSeasonData(): void {
-    const { seasonColumns, seasonDataSource, careerBests } =
-      this.seasonsService.setupSeasonData(this.data, {
-        isGoalie: this.isGoalie,
-        statsPerGame: this.statsPerGame,
-        positionFilter: this.positionFilter,
-        isMobile: this.isMobile,
-      });
-    this.seasonColumns = seasonColumns;
-    this.seasonDataSource = seasonDataSource;
-    this.careerBests = careerBests;
+    this.positionFilterState.set(newFilter);
   }
 
   isCareerBest(column: string, season: number): boolean {
@@ -299,10 +308,7 @@ export class PlayerCardComponent {
 
   onTabChange(index: number): void {
     this.selectedTabIndex = index;
-    this.updateGraphsInputs();
 
-    // Graphs tab is heavy (Chart.js). Lazy-load it to keep the initial bundle small.
-    // Tab index: 0=All, 1=By Season (if hasSeasons), 2=Graphs (if hasSeasons) OR 1=Graphs (if !hasSeasons)
     const graphsTabIndex = this.hasSeasons ? 2 : 1;
     if (index === graphsTabIndex) {
       this.graphsLoadPromise = this.ensureGraphsLoaded();
@@ -321,11 +327,9 @@ export class PlayerCardComponent {
     const playerSlug = toSlug(this.data.name);
     const type = this.isGoalie ? 'goalie' : 'player';
 
-    // Build path - season is now in path for better SEO
     const season = (this.data as { season?: number }).season;
     const seasonPath = season !== undefined ? `/${season}` : '';
 
-    // Tab stays as query param (UI detail)
     const tabName = this.getCurrentTabName();
     const queryString = tabName !== 'all' ? `?tab=${tabName}` : '';
 
@@ -333,7 +337,6 @@ export class PlayerCardComponent {
 
     navigator.clipboard.writeText(url).then(() => {
       this.linkCopied = true;
-      // Show the tooltip with the "copied" message
       tooltip?.show();
       setTimeout(() => {
         this.linkCopied = false;
@@ -342,18 +345,43 @@ export class PlayerCardComponent {
     });
   }
 
+  private isWrappedData(data: Player | Goalie | PlayerCardDialogData): data is PlayerCardDialogData {
+    return 'player' in data && (data as PlayerCardDialogData).player !== undefined;
+  }
+
+  private unwrapDialogData(data: Player | Goalie | PlayerCardDialogData): Player | Goalie {
+    return this.isWrappedData(data) ? data.player : data;
+  }
+
+  private getTabIndexFromName(tabName: PlayerCardTab): number {
+    switch (tabName) {
+      case 'all':
+        return 0;
+      case 'by-season':
+        return this.hasSeasons ? 1 : 0;
+      case 'graphs':
+        if (!this.showGraphsTab) return 0;
+        return this.hasSeasons ? 2 : 1;
+      default:
+        return 0;
+    }
+  }
+
+  private checkScreenSize(): void {
+    const viewportWidth = this.document.defaultView?.innerWidth ?? 1024;
+    this.isMobileState.set(viewportWidth <= 768);
+  }
+
   private getCurrentTabName(): PlayerCardTab {
     if (this.hasSeasons) {
-      // Tabs: 0=all, 1=by-season, 2=graphs
       switch (this.selectedTabIndex) {
         case 1: return 'by-season';
         case 2: return 'graphs';
         default: return 'all';
       }
-    } else {
-      // Tabs: 0=all, 1=graphs (no by-season tab)
-      return this.selectedTabIndex === 1 ? 'graphs' : 'all';
     }
+
+    return this.selectedTabIndex === 1 ? 'graphs' : 'all';
   }
 
   private async ensureGraphsLoaded(): Promise<void> {
@@ -374,22 +402,10 @@ export class PlayerCardComponent {
     return this.graphsLoadPromise;
   }
 
-  private updateGraphsInputs(): void {
-    this.graphsInputs = {
-      data: this.data,
-      viewContext: this.viewContext,
-      positionFilter: this.positionFilter,
-      closeButtonEl: this.closeButton?.nativeElement,
-      requestFocusTabHeader: () => this.focusActiveTabHeader(),
-    };
-  }
-
   private focusActiveTabHeader(): void {
-    // Angular Material tabs render the header within the component DOM.
-    // Prefer focusing the active tab label so users can move between tabs.
     const root = this.host.nativeElement;
     const activeTab = root.querySelector(
-      '.mat-mdc-tab-header .mdc-tab--active'
+      '.mat-mdc-tab-header .mdc-tab--active',
     ) as HTMLElement | null;
 
     if (activeTab) {
@@ -397,9 +413,8 @@ export class PlayerCardComponent {
       return;
     }
 
-    // Fallback: if the component isn't fully rendered yet.
     const anyTabHeader = this.document.querySelector(
-      '.mat-mdc-tab-header .mdc-tab'
+      '.mat-mdc-tab-header .mdc-tab',
     ) as HTMLElement | null;
     anyTabHeader?.focus();
   }

--- a/src/app/shared/settings-panel/min-games-slider/min-games-slider.component.ts
+++ b/src/app/shared/settings-panel/min-games-slider/min-games-slider.component.ts
@@ -6,7 +6,6 @@ import {
   inject,
   input,
 } from '@angular/core';
-import { toSignal } from '@angular/core/rxjs-interop';
 import { TranslateModule } from '@ngx-translate/core';
 import { MatSliderModule } from '@angular/material/slider';
 import { FilterService } from '@services/filter.service';
@@ -24,14 +23,10 @@ export class MinGamesSliderComponent {
   readonly maxGames = input.required<number>();
 
   private readonly filterService = inject(FilterService);
-  private readonly playerFilterState = toSignal(this.filterService.playerFilters$, {
-    initialValue: this.filterService.playerFilters,
-  });
-  private readonly goalieFilterState = toSignal(this.filterService.goalieFilters$, {
-    initialValue: this.filterService.goalieFilters,
-  });
   private readonly filterState = computed(() =>
-    this.context() === 'goalie' ? this.goalieFilterState() : this.playerFilterState()
+    this.context() === 'goalie'
+      ? this.filterService.goalieFiltersSignal()
+      : this.filterService.playerFiltersSignal()
   );
 
   readonly minGames = computed(() => this.filterState().minGames);

--- a/src/app/shared/settings-panel/position-filter-toggle/position-filter-toggle.component.ts
+++ b/src/app/shared/settings-panel/position-filter-toggle/position-filter-toggle.component.ts
@@ -1,5 +1,4 @@
 import { ChangeDetectionStrategy, Component, computed, inject } from '@angular/core';
-import { toSignal } from '@angular/core/rxjs-interop';
 import {
   MatButtonToggleModule,
   MatButtonToggleChange,
@@ -17,12 +16,8 @@ import { FilterService, PositionFilter } from '@services/filter.service';
 })
 export class PositionFilterToggleComponent {
   private readonly filterService = inject(FilterService);
-  private readonly playerFilterState = toSignal(this.filterService.playerFilters$, {
-    initialValue: this.filterService.playerFilters,
-  });
-
   readonly positionFilter = computed<PositionFilter>(() =>
-    this.playerFilterState().positionFilter
+    this.filterService.playerFiltersSignal().positionFilter
   );
 
   onPositionChange(event: MatButtonToggleChange): void {

--- a/src/app/shared/settings-panel/stats-mode-toggle/stats-mode-toggle.component.ts
+++ b/src/app/shared/settings-panel/stats-mode-toggle/stats-mode-toggle.component.ts
@@ -1,5 +1,4 @@
 import { ChangeDetectionStrategy, Component, computed, inject, input } from '@angular/core';
-import { toSignal } from '@angular/core/rxjs-interop';
 import {
   MatSlideToggleModule,
   MatSlideToggleChange,
@@ -19,14 +18,10 @@ import { StatsContext } from '@shared/types/context.types';
 export class StatsModeToggleComponent {
   readonly context = input.required<StatsContext>();
   private readonly filterService = inject(FilterService);
-  private readonly playerFilterState = toSignal(this.filterService.playerFilters$, {
-    initialValue: this.filterService.playerFilters,
-  });
-  private readonly goalieFilterState = toSignal(this.filterService.goalieFilters$, {
-    initialValue: this.filterService.goalieFilters,
-  });
   private readonly filterState = computed(() =>
-    this.context() === 'goalie' ? this.goalieFilterState() : this.playerFilterState()
+    this.context() === 'goalie'
+      ? this.filterService.goalieFiltersSignal()
+      : this.filterService.playerFiltersSignal()
   );
 
   readonly statsPerGame = computed(() => this.filterState().statsPerGame);

--- a/src/app/shared/stats-table/stats-table.component.ts
+++ b/src/app/shared/stats-table/stats-table.component.ts
@@ -1,13 +1,12 @@
 import {
-  ChangeDetectorRef,
-  inject,
-  Component,
-  Input,
-  ElementRef,
-  ViewChild,
-  SimpleChanges,
-  OnChanges,
   AfterViewInit,
+  ChangeDetectorRef,
+  Component,
+  ElementRef,
+  effect,
+  inject,
+  input,
+  ViewChild,
   OnDestroy,
 } from '@angular/core';
 import { AsyncPipe, NgClass } from '@angular/common';
@@ -65,39 +64,87 @@ export type TableRow =
   templateUrl: './stats-table.component.html',
   styleUrl: './stats-table.component.scss',
 })
-export class StatsTableComponent implements OnChanges, AfterViewInit, OnDestroy {
+export class StatsTableComponent implements AfterViewInit, OnDestroy {
   private cdr = inject(ChangeDetectorRef);
   readonly dialog = inject(MatDialog);
   private translate = inject(TranslateService);
 
+  readonly dataInput = input.required<TableRow[]>({ alias: 'data' });
+  readonly columnsInput = input.required<Column[]>({ alias: 'columns' });
+  readonly defaultSortColumnInput = input('score', { alias: 'defaultSortColumn' });
+  readonly loadingInput = input(false, { alias: 'loading' });
+  readonly apiErrorInput = input(false, { alias: 'apiError' });
+  readonly tableIdInput = input('stats-table', { alias: 'tableId' });
+  readonly showSearchInput = input(true, { alias: 'showSearch' });
+  readonly searchLabelKeyInput = input('table.playerSearch', { alias: 'searchLabelKey' });
+  readonly showPositionColumnInput = input(true, { alias: 'showPositionColumn' });
+  readonly positionValueInput = input<
+    ((row: TableRow, index: number) => string | number) | undefined
+  >(undefined, { alias: 'positionValue' });
+  readonly selectRowInput = input(false, { alias: 'selectRow' });
+  readonly isRowSelectedInput = input<((row: TableRow) => boolean) | undefined>(undefined, {
+    alias: 'isRowSelected',
+  });
+  readonly canSelectRowInput = input<Observable<boolean>>(of(true), { alias: 'canSelectRow$' });
+  readonly onRowSelectInput = input<((row: TableRow) => void) | undefined>(undefined, {
+    alias: 'onRowSelect',
+  });
+  readonly clickableInput = input(true, { alias: 'clickable' });
+  readonly formatCellInput = input<
+    ((column: string, value: number | string | undefined) => string) | undefined
+  >(undefined, { alias: 'formatCell' });
+  readonly expandableInput = input(false, { alias: 'expandable' });
+  readonly rowKeyInput = input<((row: TableRow, index: number) => string) | undefined>(undefined, {
+    alias: 'rowKey',
+  });
+  readonly isRowExpandableInput = input<((row: TableRow) => boolean) | undefined>(undefined, {
+    alias: 'isRowExpandable',
+  });
+  readonly expandedRowsForInput = input<((row: TableRow) => ExpandedRowViewModel[]) | undefined>(
+    undefined,
+    { alias: 'expandedRowsFor' },
+  );
+  readonly expandToggleAriaLabelInput = input<
+    ((row: TableRow, expanded: boolean) => string) | undefined
+  >(undefined, { alias: 'expandToggleAriaLabel' });
+  readonly expandedHeaderLabelsInput = input<
+    { season: string; primary: string; secondary?: string } | undefined
+  >(undefined, { alias: 'expandedHeaderLabels' });
+
   private loadingIntervalId?: ReturnType<typeof setInterval>;
   private loadingStartMs?: number;
+  private previousData?: TableRow[];
+  private previousColumns?: Column[];
+  private previousDefaultSortColumn?: string;
+  private previousLoading?: boolean;
+  private previousTableId?: string;
+  private previousShowPositionColumn?: boolean;
 
   loadingProgress = 0;
   loadingBuffer = 0;
 
-  @Input() data: TableRow[] = [];
-  @Input() columns: Column[] = [];
-  @Input() defaultSortColumn = 'score';
-  @Input() loading = false;
-  @Input() apiError = false;
-  @Input() tableId = 'stats-table';
-  @Input() showSearch = true;
-  @Input() searchLabelKey = 'table.playerSearch';
-  @Input() showPositionColumn = true;
-  @Input() positionValue?: (row: TableRow, index: number) => string | number;
-  @Input() selectRow = false;
-  @Input() isRowSelected?: (row: TableRow) => boolean;
-  @Input() canSelectRow$: Observable<boolean> = of(true);
-  @Input() onRowSelect?: (row: TableRow) => void;
-  @Input() clickable = true;
-  @Input() formatCell?: (column: string, value: number | string | undefined) => string;
-  @Input() expandable = false;
-  @Input() rowKey?: (row: TableRow, index: number) => string;
-  @Input() isRowExpandable?: (row: TableRow) => boolean;
-  @Input() expandedRowsFor?: (row: TableRow) => ExpandedRowViewModel[];
-  @Input() expandToggleAriaLabel?: (row: TableRow, expanded: boolean) => string;
-  @Input() expandedHeaderLabels?: { season: string; primary: string; secondary?: string };
+  data: TableRow[] = [];
+  columns: Column[] = [];
+  defaultSortColumn = 'score';
+  loading = false;
+  apiError = false;
+  tableId = 'stats-table';
+  showSearch = true;
+  searchLabelKey = 'table.playerSearch';
+  showPositionColumn = true;
+  positionValue?: (row: TableRow, index: number) => string | number;
+  selectRow = false;
+  isRowSelected?: (row: TableRow) => boolean;
+  canSelectRow$: Observable<boolean> = of(true);
+  onRowSelect?: (row: TableRow) => void;
+  clickable = true;
+  formatCell?: (column: string, value: number | string | undefined) => string;
+  expandable = false;
+  rowKey?: (row: TableRow, index: number) => string;
+  isRowExpandable?: (row: TableRow) => boolean;
+  expandedRowsFor?: (row: TableRow) => ExpandedRowViewModel[];
+  expandToggleAriaLabel?: (row: TableRow, expanded: boolean) => string;
+  expandedHeaderLabels?: { season: string; primary: string; secondary?: string };
 
   instructionsId = 'stats-table-instructions';
   activeRowIndex = 0;
@@ -113,53 +160,114 @@ export class StatsTableComponent implements OnChanges, AfterViewInit, OnDestroy 
   @ViewChild('searchInput', { read: ElementRef }) searchInput?: ElementRef<HTMLInputElement>;
   @ViewChild('tableRoot', { read: ElementRef }) tableRootRef?: ElementRef<HTMLElement>;
 
-  ngOnChanges(changes: SimpleChanges) {
-    if (changes['tableId']) {
-      this.instructionsId = `${this.tableId}-instructions`;
-    }
+  constructor() {
+    effect(() => {
+      const data = this.dataInput();
+      const columns = this.columnsInput();
+      const defaultSortColumn = this.defaultSortColumnInput();
+      const loading = this.loadingInput();
+      const apiError = this.apiErrorInput();
+      const tableId = this.tableIdInput();
+      const showSearch = this.showSearchInput();
+      const searchLabelKey = this.searchLabelKeyInput();
+      const showPositionColumn = this.showPositionColumnInput();
+      const positionValue = this.positionValueInput();
+      const selectRow = this.selectRowInput();
+      const isRowSelected = this.isRowSelectedInput();
+      const canSelectRow$ = this.canSelectRowInput();
+      const onRowSelect = this.onRowSelectInput();
+      const clickable = this.clickableInput();
+      const formatCell = this.formatCellInput();
+      const expandable = this.expandableInput();
+      const rowKey = this.rowKeyInput();
+      const isRowExpandable = this.isRowExpandableInput();
+      const expandedRowsFor = this.expandedRowsForInput();
+      const expandToggleAriaLabel = this.expandToggleAriaLabelInput();
+      const expandedHeaderLabels = this.expandedHeaderLabelsInput();
 
-    if (changes['loading']) {
-      this.onLoadingChanged(this.loading);
-    }
+      const dataChanged = data !== this.previousData;
+      const columnsChanged = columns !== this.previousColumns;
+      const defaultSortChanged = defaultSortColumn !== this.previousDefaultSortColumn;
+      const loadingChanged = loading !== this.previousLoading;
+      const tableIdChanged = tableId !== this.previousTableId;
+      const showPositionChanged = showPositionColumn !== this.previousShowPositionColumn;
 
-    const sortRelevantChange =
-      Boolean(changes['defaultSortColumn']) || Boolean(changes['columns']);
+      this.data = data;
+      this.columns = columns;
+      this.defaultSortColumn = defaultSortColumn;
+      this.loading = loading;
+      this.apiError = apiError;
+      this.tableId = tableId;
+      this.showSearch = showSearch;
+      this.searchLabelKey = searchLabelKey;
+      this.showPositionColumn = showPositionColumn;
+      this.positionValue = positionValue;
+      this.selectRow = selectRow;
+      this.isRowSelected = isRowSelected;
+      this.canSelectRow$ = canSelectRow$;
+      this.onRowSelect = onRowSelect;
+      this.clickable = clickable;
+      this.formatCell = formatCell;
+      this.expandable = expandable;
+      this.rowKey = rowKey;
+      this.isRowExpandable = isRowExpandable;
+      this.expandedRowsFor = expandedRowsFor;
+      this.expandToggleAriaLabel = expandToggleAriaLabel;
+      this.expandedHeaderLabels = expandedHeaderLabels;
 
-    if (changes['data'] && this.data) {
-      this.dataSource.data = this.data;
-      this.rebuildRowKeyMap();
-      this.expandedRowKeys.clear();
+      if (tableIdChanged) {
+        this.instructionsId = `${tableId}-instructions`;
+      }
 
-      if (this.columns?.length > 0) {
-        this.dynamicColumns = this.columns;
+      if (loadingChanged) {
+        this.onLoadingChanged(loading);
+      }
+
+      const sortRelevantChange = columnsChanged || defaultSortChanged;
+
+      if (dataChanged) {
+        this.dataSource.data = data;
+        this.rebuildRowKeyMap();
+        this.expandedRowKeys.clear();
+
+        if (columns.length > 0) {
+          this.dynamicColumns = columns;
+          this.displayedFields = this.buildDisplayedFields();
+        }
+        if (this.sort) {
+          this.dataSource.sort = this.sort;
+        }
+
+        if (this.sort && sortRelevantChange) {
+          this.applyDefaultSort();
+        }
+
+        // Reset focus to first row when the dataset changes.
+        this.activeRowIndex = 0;
+        setTimeout(() => this.ensureActiveRowInRange(), 0);
+      }
+
+      if (columnsChanged && !dataChanged) {
+        this.dynamicColumns = columns;
         this.displayedFields = this.buildDisplayedFields();
       }
-      if (this.sort) {
-        this.dataSource.sort = this.sort;
+
+      if (showPositionChanged) {
+        this.displayedFields = this.buildDisplayedFields();
       }
 
-      if (this.sort && sortRelevantChange) {
+      if (this.sort && sortRelevantChange && !dataChanged) {
+        // When only the sort inputs changed, apply immediately.
         this.applyDefaultSort();
       }
 
-      // Reset focus to first row when the dataset changes.
-      this.activeRowIndex = 0;
-      setTimeout(() => this.ensureActiveRowInRange(), 0);
-    }
-
-    if (changes['columns'] && !changes['data']) {
-      this.dynamicColumns = this.columns;
-      this.displayedFields = this.buildDisplayedFields();
-    }
-
-    if (changes['showPositionColumn']) {
-      this.displayedFields = this.buildDisplayedFields();
-    }
-
-    if (this.sort && sortRelevantChange && !(changes['data'] && this.data)) {
-      // When only the sort inputs changed, apply immediately.
-      this.applyDefaultSort();
-    }
+      this.previousData = data;
+      this.previousColumns = columns;
+      this.previousDefaultSortColumn = defaultSortColumn;
+      this.previousLoading = loading;
+      this.previousTableId = tableId;
+      this.previousShowPositionColumn = showPositionColumn;
+    });
   }
 
   ngOnDestroy(): void {

--- a/src/app/shared/stats-table/virtual-table.component.html
+++ b/src/app/shared/stats-table/virtual-table.component.html
@@ -1,5 +1,5 @@
 <div class="stats-table-wrapper mat-elevation-z4" id="career-table" tabindex="-1" #tableRoot>
-  <p class="sr-only" id="career-table-instructions">
+  <p class="sr-only" [attr.id]="instructionsId">
     {{ 'a11y.tableNavigationHintReadOnly' | translate }}
   </p>
 
@@ -20,7 +20,7 @@
   <div
     class="table-container table-container--virtual"
     role="table"
-    aria-describedby="career-table-instructions"
+    [attr.aria-describedby]="instructionsId"
   >
     <div
       class="virtual-table-grid"

--- a/src/app/shared/stats-table/virtual-table.component.spec.ts
+++ b/src/app/shared/stats-table/virtual-table.component.spec.ts
@@ -215,6 +215,20 @@ describe('VirtualTableComponent — user behavior', () => {
     expect(getRows()[0]).toHaveTextContent('Alpha Center');
   });
 
+  it('reacts when the parent changes the default sort column after render', async () => {
+    const view = await setup();
+
+    await screen.findByText('Beta Blueliner');
+    expect(getRows()[0]).toHaveTextContent('Gamma Grinder');
+
+    view.fixture.componentInstance.defaultSortColumn = 'name';
+    view.fixture.detectChanges();
+
+    await vi.waitFor(() => {
+      expect(getRows()[0]).toHaveTextContent('Alpha Center');
+    });
+  });
+
   it('covers helper methods and internal branches used by the career tables', async () => {
     const view = await setup({ data: [] as unknown as TableRow[] });
     const table = view.fixture.debugElement.children[0].componentInstance as VirtualTableComponent;

--- a/src/app/shared/stats-table/virtual-table.component.ts
+++ b/src/app/shared/stats-table/virtual-table.component.ts
@@ -2,13 +2,14 @@ import {
   AfterViewInit,
   ChangeDetectorRef,
   Component,
+  DestroyRef,
   ElementRef,
-  Input,
-  OnChanges,
-  SimpleChanges,
   ViewChild,
+  effect,
   inject,
+  input,
 } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { NgClass } from '@angular/common';
 import { CdkVirtualScrollViewport, ScrollingModule } from '@angular/cdk/scrolling';
 import { MatFormFieldModule } from '@angular/material/form-field';
@@ -44,25 +45,30 @@ const DEFAULT_ROW_HEIGHT = 52;
   templateUrl: './virtual-table.component.html',
   styleUrl: './virtual-table.component.scss',
 })
-export class VirtualTableComponent implements OnChanges, AfterViewInit {
+export class VirtualTableComponent implements AfterViewInit {
   private readonly cdr = inject(ChangeDetectorRef);
+  private readonly destroyRef = inject(DestroyRef);
 
-  @Input() data: TableRow[] = [];
-  @Input() columns: Column[] = [];
-  @Input() defaultSortColumn = 'name';
-  @Input() loading = false;
-  @Input() apiError = false;
-  @Input() tableId = 'stats-table';
-  @Input() showSearch = true;
-  @Input() searchLabelKey = 'table.playerSearch';
-  @Input() showPositionColumn = true;
-  @Input() positionValue?: (row: TableRow, index: number) => string | number;
-  @Input() formatCell?: (
+  readonly dataInput = input.required<TableRow[]>({ alias: 'data' });
+  readonly columnsInput = input.required<Column[]>({ alias: 'columns' });
+  readonly defaultSortColumnInput = input('name', { alias: 'defaultSortColumn' });
+  readonly loadingInput = input(false, { alias: 'loading' });
+  readonly apiErrorInput = input(false, { alias: 'apiError' });
+  readonly searchLabelKeyInput = input('table.playerSearch', { alias: 'searchLabelKey' });
+  readonly formatCellInput = input<
+    ((row: TableRow, column: string, value: number | string | undefined) => string) | undefined
+  >(undefined, { alias: 'formatCell' });
+
+  data: TableRow[] = [];
+  defaultSortColumn = 'name';
+  loading = false;
+  apiError = false;
+  searchLabelKey = 'table.playerSearch';
+  formatCell?: (
     row: TableRow,
     column: string,
     value: number | string | undefined,
   ) => string;
-  @Input() rowKey?: (row: TableRow, index: number) => string;
 
   @ViewChild(MatSort) sort?: MatSort;
   @ViewChild(CdkVirtualScrollViewport) viewport?: CdkVirtualScrollViewport;
@@ -72,8 +78,8 @@ export class VirtualTableComponent implements OnChanges, AfterViewInit {
   @ViewChild('tableRoot', { read: ElementRef }) tableRootRef?: ElementRef<HTMLElement>;
 
   readonly rowHeight = DEFAULT_ROW_HEIGHT;
+  readonly instructionsId = 'career-table-instructions';
 
-  instructionsId = 'stats-table-instructions';
   activeRowIndex = 0;
   dynamicColumns: Column[] = [];
   displayedFields: string[] = [];
@@ -84,35 +90,59 @@ export class VirtualTableComponent implements OnChanges, AfterViewInit {
 
   private filterValue = '';
   private initialized = false;
+  private previousData?: TableRow[];
+  private previousColumns?: Column[];
+  private previousDefaultSortColumn?: string;
 
-  ngOnChanges(changes: SimpleChanges): void {
-    if (changes['tableId']) {
-      this.instructionsId = `${this.tableId}-instructions`;
-    }
+  constructor() {
+    effect(() => {
+      const data = this.dataInput();
+      const columns = this.columnsInput();
+      const defaultSortColumn = this.defaultSortColumnInput();
+      const loading = this.loadingInput();
+      const apiError = this.apiErrorInput();
+      const searchLabelKey = this.searchLabelKeyInput();
+      const formatCell = this.formatCellInput();
 
-    if (changes['columns'] || changes['showPositionColumn']) {
-      this.dynamicColumns = this.columns ?? [];
-      this.displayedFields = this.showPositionColumn
-        ? [ROW_NUMBER_COLUMN, ...this.dynamicColumns.map((column) => column.field)]
-        : this.dynamicColumns.map((column) => column.field);
-      this.gridTemplateColumns = this.buildGridTemplateColumns();
-    }
+      const dataChanged = data !== this.previousData;
+      const columnsChanged = columns !== this.previousColumns;
+      const defaultSortChanged = defaultSortColumn !== this.previousDefaultSortColumn;
 
-    if (changes['data'] || changes['defaultSortColumn']) {
-      this.recomputeRows(true);
-    }
+      this.data = data;
+      this.defaultSortColumn = defaultSortColumn;
+      this.loading = loading;
+      this.apiError = apiError;
+      this.searchLabelKey = searchLabelKey;
+      this.formatCell = formatCell;
+
+      if (columnsChanged) {
+        this.dynamicColumns = columns;
+        this.displayedFields = this.buildDisplayedFields();
+        this.gridTemplateColumns = this.buildGridTemplateColumns();
+      }
+
+      if (this.sort && defaultSortChanged) {
+        this.applyDefaultSort();
+      }
+
+      if (dataChanged || defaultSortChanged) {
+        this.recomputeRows(true);
+      }
+
+      this.previousData = data;
+      this.previousColumns = columns;
+      this.previousDefaultSortColumn = defaultSortColumn;
+    });
   }
 
   ngAfterViewInit(): void {
     this.initialized = true;
 
     if (this.sort) {
-      if (this.defaultSortColumn) {
-        this.sort.active = this.defaultSortColumn;
-        this.sort.direction = 'asc';
-      }
-
-      this.sort.sortChange.subscribe(() => this.recomputeRows(false));
+      this.applyDefaultSort();
+      this.sort.sortChange
+        .pipe(takeUntilDestroyed(this.destroyRef))
+        .subscribe(() => this.recomputeRows(false));
     }
 
     this.recomputeRows(false);
@@ -137,10 +167,6 @@ export class VirtualTableComponent implements OnChanges, AfterViewInit {
       'col-left': column.align === 'left',
       'col-center': column.align !== 'left',
     };
-  }
-
-  getPositionDisplay(row: TableRow, index: number): string | number {
-    return this.positionValue ? this.positionValue(row, index) : index + 1;
   }
 
   getCellValue(row: TableRow, field: string): number | string | undefined {
@@ -174,7 +200,7 @@ export class VirtualTableComponent implements OnChanges, AfterViewInit {
         this.focusRow(0);
         return;
       case 'ArrowUp':
-        if (!this.showSearch || !this.searchInput) return;
+        if (!this.searchInput) return;
         event.preventDefault();
         this.searchInput.nativeElement.focus();
         return;
@@ -223,13 +249,22 @@ export class VirtualTableComponent implements OnChanges, AfterViewInit {
   }
 
   trackRow = (index: number, row: TableRow): string => {
-    if (this.rowKey) {
-      return this.rowKey(row, index);
-    }
-
     const keyValue = (row as Record<string, unknown>)['id'];
     return typeof keyValue === 'string' && keyValue.length > 0 ? keyValue : `${index}`;
   };
+
+  private applyDefaultSort(): void {
+    if (!this.sort || !this.defaultSortColumn) {
+      return;
+    }
+
+    this.sort.active = this.defaultSortColumn;
+    this.sort.direction = 'asc';
+  }
+
+  private buildDisplayedFields(): string[] {
+    return [ROW_NUMBER_COLUMN, ...this.dynamicColumns.map((column) => column.field)];
+  }
 
   private recomputeRows(resetScroll: boolean): void {
     const filtered = this.data.filter((row) => this.matchesFilter(row));

--- a/src/app/shared/top-controls/report-switcher/report-switcher.component.ts
+++ b/src/app/shared/top-controls/report-switcher/report-switcher.component.ts
@@ -1,5 +1,4 @@
 import { ChangeDetectionStrategy, Component, computed, inject, input } from '@angular/core';
-import { toSignal } from '@angular/core/rxjs-interop';
 import { TranslateModule } from '@ngx-translate/core';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatSelectModule } from '@angular/material/select';
@@ -17,14 +16,10 @@ import { StatsContext } from '@shared/types/context.types';
 export class ReportSwitcherComponent {
   readonly context = input.required<StatsContext>();
   private readonly filterService = inject(FilterService);
-  private readonly playerFilterState = toSignal(this.filterService.playerFilters$, {
-    initialValue: this.filterService.playerFilters,
-  });
-  private readonly goalieFilterState = toSignal(this.filterService.goalieFilters$, {
-    initialValue: this.filterService.goalieFilters,
-  });
   private readonly filterState = computed(() =>
-    this.context() === 'goalie' ? this.goalieFilterState() : this.playerFilterState()
+    this.context() === 'goalie'
+      ? this.filterService.goalieFiltersSignal()
+      : this.filterService.playerFiltersSignal()
   );
 
   readonly reportType = computed<ReportType>(() => this.filterState().reportType);

--- a/src/app/shared/top-controls/season-switcher/season-switcher.component.ts
+++ b/src/app/shared/top-controls/season-switcher/season-switcher.component.ts
@@ -39,14 +39,10 @@ export class SeasonSwitcherComponent {
   private readonly filterService = inject(FilterService);
   private readonly teamService = inject(TeamService);
   private readonly settingsService = inject(SettingsService);
-  private readonly playerFilterState = toSignal(this.filterService.playerFilters$, {
-    initialValue: this.filterService.playerFilters,
-  });
-  private readonly goalieFilterState = toSignal(this.filterService.goalieFilters$, {
-    initialValue: this.filterService.goalieFilters,
-  });
   private readonly filterState = computed(() =>
-    this.context() === 'goalie' ? this.goalieFilterState() : this.playerFilterState()
+    this.context() === 'goalie'
+      ? this.filterService.goalieFiltersSignal()
+      : this.filterService.playerFiltersSignal()
   );
   readonly reportType = computed(() => this.filterState().reportType);
   readonly selectedSeason = computed<number | 'all'>(() =>

--- a/src/app/shared/top-controls/team-switcher/team-switcher.component.ts
+++ b/src/app/shared/top-controls/team-switcher/team-switcher.component.ts
@@ -49,9 +49,7 @@ export class TeamSwitcherComponent {
   readonly teams = computed(() => this.teamsState().teams);
   readonly loading = computed(() => this.teamsState().loading);
   readonly loadError = computed(() => this.teamsState().loadError);
-  readonly selectedTeamId = toSignal(this.teamService.selectedTeamId$, {
-    initialValue: this.teamService.selectedTeamId,
-  });
+  readonly selectedTeamId = this.teamService.selectedTeamIdSignal;
   readonly selectedTeam = computed(() =>
     this.teams().find((team) => team.id === this.selectedTeamId())
   );

--- a/src/app/shared/top-controls/top-controls.component.ts
+++ b/src/app/shared/top-controls/top-controls.component.ts
@@ -1,5 +1,4 @@
 import { ChangeDetectionStrategy, Component, computed, inject, input } from '@angular/core';
-import { toSignal } from '@angular/core/rxjs-interop';
 import { TranslateModule } from '@ngx-translate/core';
 import { TeamSwitcherComponent } from './team-switcher/team-switcher.component';
 import { ReportSwitcherComponent } from './report-switcher/report-switcher.component';
@@ -25,9 +24,7 @@ export class TopControlsComponent {
   readonly context = input.required<StatsContext>();
   readonly contentOnly = input(false);
   private readonly settingsService = inject(SettingsService);
-  private readonly persistedExpanded = toSignal(this.settingsService.topControlsExpanded$, {
-    initialValue: this.settingsService.topControlsExpanded,
-  });
+  private readonly persistedExpanded = this.settingsService.topControlsExpandedSignal;
 
   readonly isExpanded = computed(() =>
     this.contentOnly() ? true : this.persistedExpanded()


### PR DESCRIPTION
## Summary

This PR continues the Angular modernization work across state services and stateful/shared components, removes now-unused compatibility APIs discovered during the refactor, and tightens component contracts to match real app usage.

### What changed

- Modernized state reads in `SettingsService`, `FilterService`, and `TeamService` to expose signal-facing APIs for component consumption while keeping observable streams only where still needed for async composition.
- Removed dead service surface left behind by the refactor instead of keeping unused getters/streams "just in case".
- Modernized the remaining stateful table/card components:
  - `StatsTableComponent`
  - `VirtualTableComponent`
  - `PlayerCardComponent`
  - `PlayerCardGraphsComponent`
- Finished the input-contract audit by converting the remaining shared and feature components from decorator `@Input()` APIs to signal inputs, using `input.required()` only where parents always provide the value:
  - comparison components
  - `NavigationComponent`
  - `LeaderboardComponent`
- Kept behavior aligned with existing real user flows and added regression coverage where parent-driven state syncing needed protection.
- Updated project docs to reflect the modernized service/component patterns and added explicit guidance to remove proven-unused legacy paths after refactors.
- Raised enforced coverage thresholds in `angular.json`:
  - statements: `92 -> 93`
  - functions: `93 -> 94`
- Audited Angular deprecations currently used in the repo and added a roadmap follow-up for deprecated animation providers (`provideAnimationsAsync`, `provideNoopAnimations`).

### Notes

- Production code no longer uses decorator-era `@Input()` APIs in app components covered by this modernization sweep.
- The deprecated Angular usage found in current code is limited to animation provider APIs; that work was intentionally captured as a separate roadmap follow-up rather than mixed into this refactor batch.

## Testing

- `npm run lint`
- `npm test`
- `npm run verify`

Coverage after the threshold raise:
- statements: `93.35%`
- branches: `79.93%`
- functions: `94.26%`
- lines: `95.53%`
