### PR TITLE
Refactor: Retire deprecated animation providers

### DIFF
--- a/docs/project-testing.md
+++ b/docs/project-testing.md
@@ -87,6 +87,7 @@ Rules:
 - In component/behavior tests, do not introduce partial control harnesses with mocked state services just to drive a specific branch; cover the branch through the real page flow instead
 - If a branch exists only because the component API still models an impossible state, simplify the component first and test the smaller real behavior surface
 - Do not rewrite UI behavior tests into service tests just to raise coverage
+- When behavior tests need Material transitions disabled, prefer `MATERIAL_ANIMATIONS` with `{ animationsDisabled: true }` over deprecated Angular animation providers
 
 ### Test Template
 
@@ -94,7 +95,7 @@ Rules:
 import { render, screen } from '@testing-library/angular';
 import { provideRouter } from '@angular/router';
 import { provideHttpClient } from '@angular/common/http';
-import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { MATERIAL_ANIMATIONS } from '@angular/material/core';
 import { TranslateModule } from '@ngx-translate/core';
 import { of } from 'rxjs';
 
@@ -112,7 +113,10 @@ describe('MyComponent', { timeout: 15_000 }, () => {
       providers: [
         provideRouter([]),
         provideHttpClient(),
-        provideNoopAnimations(),
+        {
+          provide: MATERIAL_ANIMATIONS,
+          useValue: { animationsDisabled: true },
+        },
         { provide: ApiService, useValue: mockApiService },
       ],
     });

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -30,19 +30,13 @@ Persist the user's last sort column and direction per table (players/goalies) in
 
 ## Modernizing components
 
+### Recently completed
+
+- 2026-03-09: Retired deprecated Angular animation providers by removing runtime `provideAnimationsAsync()` from `src/app/app.config.ts`, replacing behavior-test `provideNoopAnimations()` usage with `MATERIAL_ANIMATIONS` disabling in the shared test setup and affected specs, and re-verifying animation-sensitive flows with `npm test` and `npm run verify`.
+
 ### Remaining modernization work
 
 - Revisit the temporary branch-coverage workaround after Angular fixes signal-input coverage accounting, then raise the branch threshold back up.
-
-#### Retire Deprecated Angular Animation Providers (~2-4h)
-
-Angular 21.2.1 still builds cleanly, but the current animation provider APIs used in this repo were deprecated in Angular 20.2 and are marked with intent to remove in v23.
-
-Refactor steps:
-
-1. Verify whether runtime `provideAnimationsAsync()` is still required in `src/app/app.config.ts` for the current Angular Material usage, and remove it if the app behavior stays correct without it.
-2. Replace deprecated `provideNoopAnimations()` usage in `src/app/testing/behavior-test-utils.ts` and the remaining table / leaderboard specs with a non-deprecated test setup that matches the chosen runtime animation strategy.
-3. Re-run behavior coverage around animation-sensitive flows after the migration, especially the navigation sheet, settings drawer, player card dialog, comparison dialog, and expandable tables.
 
 ## E2E Testing
 

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -7,7 +7,6 @@ import {
 import { provideServiceWorker } from '@angular/service-worker';
 import { provideTranslateService } from '@ngx-translate/core';
 import { provideTranslateHttpLoader } from '@ngx-translate/http-loader';
-import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
 
 import { routes } from './app.routes';
 import { environment } from '../environments/environment';
@@ -17,7 +16,6 @@ export const appConfig: ApplicationConfig = {
     provideZoneChangeDetection({ eventCoalescing: true }),
     provideRouter(routes),
     provideHttpClient(withInterceptorsFromDi()),
-    provideAnimationsAsync(),
     provideServiceWorker('ngsw-worker.js', {
       enabled: environment.production,
       registrationStrategy: 'registerWhenStable:30000',

--- a/src/app/leaderboards/leaderboard/leaderboard-expansion.mobile.spec.ts
+++ b/src/app/leaderboards/leaderboard/leaderboard-expansion.mobile.spec.ts
@@ -1,10 +1,10 @@
-import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { fireEvent, render, screen } from '@testing-library/angular';
 import { TranslateModule } from '@ngx-translate/core';
 import { of } from 'rxjs';
 
 import { ApiService } from '@services/api.service';
 import { ViewportService } from '@services/viewport.service';
+import { provideDisabledMaterialAnimations } from '../../testing/behavior-test-utils';
 import { LeaderboardRegularComponent } from '../regular/leaderboard-regular.component';
 
 describe('Leaderboard expansion behavior on mobile', () => {
@@ -12,7 +12,7 @@ describe('Leaderboard expansion behavior on mobile', () => {
     await render(LeaderboardRegularComponent, {
       imports: [TranslateModule.forRoot()],
       providers: [
-        provideNoopAnimations(),
+        provideDisabledMaterialAnimations(),
         {
           provide: ViewportService,
           useValue: {

--- a/src/app/leaderboards/leaderboard/leaderboard-expansion.spec.ts
+++ b/src/app/leaderboards/leaderboard/leaderboard-expansion.spec.ts
@@ -1,10 +1,10 @@
-import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { fireEvent, render, screen, within } from '@testing-library/angular';
 import { TranslateModule } from '@ngx-translate/core';
 import { of } from 'rxjs';
 
 import { ApiService } from '@services/api.service';
 import { ViewportService } from '@services/viewport.service';
+import { provideDisabledMaterialAnimations } from '../../testing/behavior-test-utils';
 import { LeaderboardPlayoffsComponent } from '../playoffs/leaderboard-playoffs.component';
 import { LeaderboardRegularComponent } from '../regular/leaderboard-regular.component';
 
@@ -13,7 +13,7 @@ describe('Leaderboard expansion behavior', () => {
     await render(LeaderboardRegularComponent, {
       imports: [TranslateModule.forRoot()],
       providers: [
-        provideNoopAnimations(),
+        provideDisabledMaterialAnimations(),
         {
           provide: ViewportService,
           useValue: {
@@ -107,7 +107,7 @@ describe('Leaderboard expansion behavior', () => {
     await render(LeaderboardPlayoffsComponent, {
       imports: [TranslateModule.forRoot()],
       providers: [
-        provideNoopAnimations(),
+        provideDisabledMaterialAnimations(),
         {
           provide: ViewportService,
           useValue: {
@@ -156,7 +156,7 @@ describe('Leaderboard expansion behavior', () => {
     await render(LeaderboardPlayoffsComponent, {
       imports: [TranslateModule.forRoot()],
       providers: [
-        provideNoopAnimations(),
+        provideDisabledMaterialAnimations(),
         {
           provide: ViewportService,
           useValue: {

--- a/src/app/shared/stats-table/stats-table-expansion.component.spec.ts
+++ b/src/app/shared/stats-table/stats-table-expansion.component.spec.ts
@@ -1,9 +1,9 @@
 import { Component } from '@angular/core';
-import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { fireEvent, render, screen } from '@testing-library/angular';
 import { TranslateModule } from '@ngx-translate/core';
 
 import { Column } from '@shared/column.types';
+import { provideDisabledMaterialAnimations } from '../../testing/behavior-test-utils';
 import { StatsTableComponent, TableRow } from './stats-table.component';
 
 type LeaderboardRow = {
@@ -67,7 +67,7 @@ describe('StatsTableComponent expansion', () => {
   it('toggles expanded details, supports multiple open rows, and handles keyboard', async () => {
     await render(StatsTableExpansionHostComponent, {
       imports: [TranslateModule.forRoot()],
-      providers: [provideNoopAnimations()],
+      providers: [provideDisabledMaterialAnimations()],
     });
 
     await screen.findByText('Colorado Avalanche');
@@ -97,7 +97,7 @@ describe('StatsTableComponent expansion', () => {
   it('supports space-key expansion and blurs collapsed rows after mouse close', async () => {
     await render(StatsTableExpansionHostComponent, {
       imports: [TranslateModule.forRoot()],
-      providers: [provideNoopAnimations()],
+      providers: [provideDisabledMaterialAnimations()],
     });
 
     await screen.findByText('Colorado Avalanche');

--- a/src/app/shared/stats-table/stats-table.component.spec.ts
+++ b/src/app/shared/stats-table/stats-table.component.spec.ts
@@ -1,5 +1,4 @@
 import { Component } from '@angular/core';
-import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { fireEvent, render, screen } from '@testing-library/angular';
 import { TranslateModule } from '@ngx-translate/core';
 import { MatDialog } from '@angular/material/dialog';
@@ -8,7 +7,10 @@ import { Subject } from 'rxjs';
 import { Column } from '@shared/column.types';
 import { PlayerCardDialogData } from '@shared/player-card/player-card.component';
 import { StatsTableComponent, TableRow } from './stats-table.component';
-import { polyfillJsdom } from '../../testing/behavior-test-utils';
+import {
+  polyfillJsdom,
+  provideDisabledMaterialAnimations,
+} from '../../testing/behavior-test-utils';
 
 @Component({
   standalone: true,
@@ -78,7 +80,7 @@ describe('StatsTableComponent — user behavior', () => {
     const view = await render(StatsTableHostComponent, {
       imports: [TranslateModule.forRoot()],
       providers: [
-        provideNoopAnimations(),
+        provideDisabledMaterialAnimations(),
         { provide: MatDialog, useValue: { open } },
       ],
       componentProperties,

--- a/src/app/shared/stats-table/virtual-table.component.spec.ts
+++ b/src/app/shared/stats-table/virtual-table.component.spec.ts
@@ -1,10 +1,12 @@
 import { Component } from '@angular/core';
-import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { fireEvent, render, screen } from '@testing-library/angular';
 import { TranslateModule } from '@ngx-translate/core';
 
 import { Column } from '@shared/column.types';
-import { polyfillJsdom } from '../../testing/behavior-test-utils';
+import {
+  polyfillJsdom,
+  provideDisabledMaterialAnimations,
+} from '../../testing/behavior-test-utils';
 import { TableRow } from './stats-table.component';
 import { VirtualTableComponent } from './virtual-table.component';
 
@@ -65,7 +67,7 @@ describe('VirtualTableComponent — user behavior', () => {
   async function setup(componentProperties: Partial<VirtualTableHostComponent> = {}) {
     return render(VirtualTableHostComponent, {
       imports: [TranslateModule.forRoot()],
-      providers: [provideNoopAnimations()],
+      providers: [provideDisabledMaterialAnimations()],
       componentProperties,
     });
   }

--- a/src/app/testing/behavior-test-utils.ts
+++ b/src/app/testing/behavior-test-utils.ts
@@ -1,5 +1,6 @@
+import { Provider } from '@angular/core';
+import { MATERIAL_ANIMATIONS } from '@angular/material/core';
 import { provideRouter } from '@angular/router';
-import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { TranslateModule } from '@ngx-translate/core';
 import { Observable, of, throwError } from 'rxjs';
 
@@ -83,6 +84,15 @@ function createApiError() {
   return throwError(() => new Error('Behavior test API error'));
 }
 
+export function provideDisabledMaterialAnimations(): Provider {
+  return {
+    provide: MATERIAL_ANIMATIONS,
+    useValue: {
+      animationsDisabled: true,
+    },
+  };
+}
+
 export function createApiServiceMock(options: BehaviorApiMockOptions = {}) {
   const errorKeys = new Set(options.errorKeys ?? []);
   const lastModified = Object.prototype.hasOwnProperty.call(options, 'lastModified')
@@ -142,7 +152,7 @@ export function getBehaviorTestConfig(options: BehaviorTestConfigOptions) {
     imports: [TranslateModule.forRoot()],
     providers: [
       provideRouter(routes),
-      provideNoopAnimations(),
+      provideDisabledMaterialAnimations(),
       { provide: ApiService, useValue: createApiServiceMock(options) },
       { provide: ViewportService, useValue: { isMobile$: of(options.isMobile) } },
       {


### PR DESCRIPTION
## Summary
- remove deprecated runtime `provideAnimationsAsync()` from the app bootstrap
- replace deprecated `provideNoopAnimations()` usage in shared behavior-test setup and the remaining leaderboard/table specs with `MATERIAL_ANIMATIONS` disabling
- update testing docs and the roadmap to reflect the completed migration

## Verification
- `npm run verify`

## Results
- lint passed
- tests: `25/25` files, `86/86` tests passed
- coverage: `93.35%` statements, `79.93%` branches, `94.26%` functions, `95.53%` lines
- production build passed with initial bundle at `1.14 MB`, under the `1.2 MB` warning budget
