### PR TITLE
Feature: Core web vitals polishments

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ Run `npm run perf:audit` to execute a local lab-style performance audit against 
 - Mocks API responses from `e2e/fixtures/data/` so results are deterministic and backend-independent
 - Audits `/` and `/career/players` in both desktop and mobile browser profiles
 - Reports `LCP`, `CLS`, and an interaction-delay proxy for common user actions
+- Logs the top layout-shift sources to make CLS regressions easier to diagnose
 
 Important:
 
@@ -161,6 +162,7 @@ Important:
 - `LCP` and `CLS` map directly to Core Web Vitals thresholds
 - The interaction number is a scripted lab proxy, not full field `INP`
 - Use PageSpeed Insights / CrUX field data to judge the real shipped user experience
+- Current local baseline as of `2026-03-09`: desktop `/` `CLS 0.040`, desktop `/career/players` `CLS 0.010`, mobile audited routes `CLS 0.000`
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ Run `npm run perf:audit` to execute a local lab-style performance audit against 
 - The command rebuilds the app in production mode
 - Serves `dist/fantrax-stats-parser-ui/browser` locally
 - Mocks API responses from `e2e/fixtures/data/` so results are deterministic and backend-independent
-- Audits `/` and `/career/players` in both desktop and mobile browser profiles
+- Audits `/`, `/career/players`, and `/leaderboards/regular` in both desktop and mobile browser profiles
 - Reports `LCP`, `CLS`, and an interaction-delay proxy for common user actions
 - Logs the top layout-shift sources to make CLS regressions easier to diagnose
 
@@ -162,7 +162,7 @@ Important:
 - `LCP` and `CLS` map directly to Core Web Vitals thresholds
 - The interaction number is a scripted lab proxy, not full field `INP`
 - Use PageSpeed Insights / CrUX field data to judge the real shipped user experience
-- Current local baseline as of `2026-03-09`: desktop `/` `CLS 0.040`, desktop `/career/players` `CLS 0.010`, mobile audited routes `CLS 0.000`
+- Current local baseline as of `2026-03-09`: desktop `/` `CLS 0.040`, desktop `/career/players` `CLS 0.010`, desktop `/leaderboards/regular` `CLS 0.010`, mobile audited routes `CLS 0.000`
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ npm run e2e:capture-fixtures           # Re-capture API fixtures from live backe
 
 # CI / verification
 npm run verify                         # Headless unit tests + production build
+npm run perf:audit                     # Local production performance audit (CWV-oriented)
 
 # Production build
 npm run build
@@ -143,6 +144,23 @@ Best practice when `npm run verify` or `npm run build` shows a budget warning:
 4. Raise a budget only when the size increase is understood, justified by real functionality, and the new threshold still acts as a meaningful guardrail.
 
 Local test policy: run only one heavy test command at a time, and wait about 2 minutes between repeated `npm run verify` runs on local machines. See [docs/project-testing.md](docs/project-testing.md).
+
+### Performance audit (Core Web Vitals oriented)
+
+Run `npm run perf:audit` to execute a local lab-style performance audit against the production build.
+
+- The command rebuilds the app in production mode
+- Serves `dist/fantrax-stats-parser-ui/browser` locally
+- Mocks API responses from `e2e/fixtures/data/` so results are deterministic and backend-independent
+- Audits `/` and `/career/players` in both desktop and mobile browser profiles
+- Reports `LCP`, `CLS`, and an interaction-delay proxy for common user actions
+
+Important:
+
+- This is a local guardrail, not a replacement for public PageSpeed Insights scores
+- `LCP` and `CLS` map directly to Core Web Vitals thresholds
+- The interaction number is a scripted lab proxy, not full field `INP`
+- Use PageSpeed Insights / CrUX field data to judge the real shipped user experience
 
 ## Testing
 

--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -88,6 +88,7 @@ npm run perf:audit
 - Reuses Playwright plus the repo's fixture-backed API mocking to keep the audit deterministic
 - Covers `/` and `/career/players` in desktop + mobile profiles
 - Reports `LCP`, `CLS`, and a scripted interaction-delay proxy
+- Prints the top layout-shift sources so desktop/mobile CLS regressions are easier to trace
 
 Use this as a local regression check after startup-bundle or rendering changes. It is intentionally a lab audit, so keep using PageSpeed Insights / Chrome DevTools when you need public-score or field-data confirmation.
 

--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -86,7 +86,7 @@ npm run perf:audit
 - Builds the production bundle before auditing
 - Serves the local production output instead of `ng serve`
 - Reuses Playwright plus the repo's fixture-backed API mocking to keep the audit deterministic
-- Covers `/` and `/career/players` in desktop + mobile profiles
+- Covers `/`, `/career/players`, and `/leaderboards/regular` in desktop + mobile profiles
 - Reports `LCP`, `CLS`, and a scripted interaction-delay proxy
 - Prints the top layout-shift sources so desktop/mobile CLS regressions are easier to trace
 

--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -79,6 +79,18 @@ Use this rule during development after `npm run verify`:
 4. Adjust the budget only if the size increase is understood and justified by current product scope.
 5. When budgets are changed, update `README.md` and relevant docs so the threshold change is explicit.
 
+### Run Performance Audit
+```bash
+npm run perf:audit
+```
+- Builds the production bundle before auditing
+- Serves the local production output instead of `ng serve`
+- Reuses Playwright plus the repo's fixture-backed API mocking to keep the audit deterministic
+- Covers `/` and `/career/players` in desktop + mobile profiles
+- Reports `LCP`, `CLS`, and a scripted interaction-delay proxy
+
+Use this as a local regression check after startup-bundle or rendering changes. It is intentionally a lab audit, so keep using PageSpeed Insights / Chrome DevTools when you need public-score or field-data confirmation.
+
 ### Theming / Automatic Dark Mode
 
 The UI follows the device/browser color scheme automatically (no manual toggle).

--- a/docs/project-testing.md
+++ b/docs/project-testing.md
@@ -54,7 +54,7 @@ This command is a local production performance audit, not a replacement for unit
 - It builds the production bundle first
 - Serves the built app locally
 - Mocks API responses from `e2e/fixtures/data/`
-- Audits `/` and `/career/players`
+- Audits `/`, `/career/players`, and `/leaderboards/regular`
 - Reports `LCP`, `CLS`, and a scripted interaction-delay proxy
 - Prints the top layout-shift sources to speed up CLS debugging
 
@@ -64,7 +64,7 @@ Interpretation rules:
 - Treat the interaction number as an `INP`-style proxy only; it is useful for regressions, but it is not field `INP`
 - Treat PageSpeed Insights / CrUX field data as the source of truth for real public performance
 - Keep `npm run perf:audit` outside `npm run verify` unless the repo later adopts stable CI thresholds for it
-- Current local baseline as of `2026-03-09`: desktop `/` `CLS 0.040`, desktop `/career/players` `CLS 0.010`, mobile audited routes `CLS 0.000`
+- Current local baseline as of `2026-03-09`: desktop `/` `CLS 0.040`, desktop `/career/players` `CLS 0.010`, desktop `/leaderboards/regular` `CLS 0.010`, mobile audited routes `CLS 0.000`
 
 ### Local Safety Policy
 

--- a/docs/project-testing.md
+++ b/docs/project-testing.md
@@ -43,6 +43,27 @@ npm run verify
 
 The coverage gate used by `npm run test:coverage` and `npm run verify` is configured in `angular.json`, not `vitest.config.ts`, because the project runs tests through Angular's `@angular/build:unit-test` builder.
 
+### Performance Audit
+
+```bash
+npm run perf:audit
+```
+
+This command is a local production performance audit, not a replacement for unit/E2E coverage:
+
+- It builds the production bundle first
+- Serves the built app locally
+- Mocks API responses from `e2e/fixtures/data/`
+- Audits `/` and `/career/players`
+- Reports `LCP`, `CLS`, and a scripted interaction-delay proxy
+
+Interpretation rules:
+
+- Treat `LCP` and `CLS` as direct Core Web Vitals-aligned lab signals
+- Treat the interaction number as an `INP`-style proxy only; it is useful for regressions, but it is not field `INP`
+- Treat PageSpeed Insights / CrUX field data as the source of truth for real public performance
+- Keep `npm run perf:audit` outside `npm run verify` unless the repo later adopts stable CI thresholds for it
+
 ### Local Safety Policy
 
 - Do not run partial or targeted test commands as a normal workflow. Use the full suite commands (`npm test`, `npm run test:coverage`, `npm run verify`) unless the user explicitly asks for isolated debugging.

--- a/docs/project-testing.md
+++ b/docs/project-testing.md
@@ -56,6 +56,7 @@ This command is a local production performance audit, not a replacement for unit
 - Mocks API responses from `e2e/fixtures/data/`
 - Audits `/` and `/career/players`
 - Reports `LCP`, `CLS`, and a scripted interaction-delay proxy
+- Prints the top layout-shift sources to speed up CLS debugging
 
 Interpretation rules:
 
@@ -63,6 +64,7 @@ Interpretation rules:
 - Treat the interaction number as an `INP`-style proxy only; it is useful for regressions, but it is not field `INP`
 - Treat PageSpeed Insights / CrUX field data as the source of truth for real public performance
 - Keep `npm run perf:audit` outside `npm run verify` unless the repo later adopts stable CI thresholds for it
+- Current local baseline as of `2026-03-09`: desktop `/` `CLS 0.040`, desktop `/career/players` `CLS 0.010`, mobile audited routes `CLS 0.000`
 
 ### Local Safety Policy
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -43,8 +43,3 @@ Persist the user's last sort column and direction per table (players/goalies) in
 ### Advanced testing
 
 - Visual regression testing (Playwright screenshot comparison)
-- Performance testing (Core Web Vitals)
-  Local `npm run perf:audit` now covers the production build with fixture-backed API mocks for the front page and career players entry route.
-  The first optimization pass is now in place: overlay-only UI is lazy-loaded, footer rendering waits for route readiness, and route shells no longer flash stats-only controls on `/career` or `/leaderboards`.
-  Current local baseline as of `2026-03-09`: desktop `/` `CLS 0.040`, desktop `/career/players` `CLS 0.010`, mobile audited routes `CLS 0.000`.
-  Next steps are adding stable leaderboard coverage, comparing lab results against PageSpeed Insights / CrUX field data, and deciding whether the remaining front-page top-controls shift is worth further polish.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -45,4 +45,6 @@ Persist the user's last sort column and direction per table (players/goalies) in
 - Visual regression testing (Playwright screenshot comparison)
 - Performance testing (Core Web Vitals)
   Local `npm run perf:audit` now covers the production build with fixture-backed API mocks for the front page and career players entry route.
-  Next steps are adding stable leaderboard coverage, comparing lab results against PageSpeed Insights / CrUX field data, and deciding whether more aggressive delivery work (for example font/icon delivery or deeper app-shell trimming) is justified.
+  The first optimization pass is now in place: overlay-only UI is lazy-loaded, footer rendering waits for route readiness, and route shells no longer flash stats-only controls on `/career` or `/leaderboards`.
+  Current local baseline as of `2026-03-09`: desktop `/` `CLS 0.040`, desktop `/career/players` `CLS 0.010`, mobile audited routes `CLS 0.000`.
+  Next steps are adding stable leaderboard coverage, comparing lab results against PageSpeed Insights / CrUX field data, and deciding whether the remaining front-page top-controls shift is worth further polish.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -44,3 +44,5 @@ Persist the user's last sort column and direction per table (players/goalies) in
 
 - Visual regression testing (Playwright screenshot comparison)
 - Performance testing (Core Web Vitals)
+  Local `npm run perf:audit` now covers the production build with fixture-backed API mocks for the front page and career players entry route.
+  Next steps are adding stable leaderboard coverage, comparing lab results against PageSpeed Insights / CrUX field data, and deciding whether more aggressive delivery work (for example font/icon delivery or deeper app-shell trimming) is justified.

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "ng": "ng",
     "start": "npm run clean:playwright && ng serve",
     "build": "NODE_OPTIONS=--max-old-space-size=6144 ng build --configuration production",
+    "perf:audit": "npm run build && npx tsx scripts/perf-audit.ts",
     "generate:types": "openapi-typescript https://ffhl-stats-api.vercel.app/openapi.json -o src/app/services/api.types.generated.ts",
     "watch": "ng build --watch --configuration development",
     "test": "ng test --watch=false",

--- a/scripts/perf-audit.ts
+++ b/scripts/perf-audit.ts
@@ -157,6 +157,17 @@ const routes: RouteSpec[] = [
       await searchInput.fill('jamie');
     },
   },
+  {
+    label: 'leaderboards regular',
+    path: '/leaderboards/regular',
+    readySelector: '#leaderboard-table tr[mat-row]',
+    interactionLabel: 'expand leaderboard details',
+    async runInteraction(page) {
+      const firstRow = page.locator('#leaderboard-table tr[mat-row]:not(.expanded-detail-row)').first();
+      await firstRow.click();
+      await page.locator('#leaderboard-table .expanded-detail-content').waitFor({ state: 'visible' });
+    },
+  },
 ];
 
 const profiles: ProfileSpec[] = [
@@ -320,7 +331,7 @@ async function collectResult(
   await setupApiMocks(page);
 
   await page.goto(`${origin}${route.path}`, { waitUntil: 'domcontentloaded' });
-  await page.locator(route.readySelector).waitFor({ state: 'visible' });
+  await page.locator(route.readySelector).first().waitFor({ state: 'visible' });
   await page.waitForTimeout(800);
 
   await route.runInteraction(page);

--- a/scripts/perf-audit.ts
+++ b/scripts/perf-audit.ts
@@ -14,6 +14,89 @@ import { setupApiMocks } from '../e2e/mocks/api-mock';
 
 const DIST_DIR = resolve('dist/fantrax-stats-parser-ui/browser');
 const INDEX_PATH = resolve(DIST_DIR, 'index.html');
+const PERF_OBSERVER_SCRIPT = `
+(() => {
+  const describeRect = (rect) => {
+    if (!rect) {
+      return null;
+    }
+
+    const round = (value) => Math.round(value * 10) / 10;
+    return 'x=' + round(rect.x) + ', y=' + round(rect.y) + ', w=' + round(rect.width) + ', h=' + round(rect.height);
+  };
+
+  const describeNode = (node) => {
+    if (!(node instanceof HTMLElement)) {
+      return 'unknown';
+    }
+
+    const selectorParts = [node.tagName.toLowerCase()];
+    if (node.id) {
+      selectorParts.push('#' + node.id);
+    }
+
+    const classNames = Array.from(node.classList).slice(0, 3);
+    for (const className of classNames) {
+      selectorParts.push('.' + className);
+    }
+
+    const text = (node.textContent || '').trim().replace(/\\s+/g, ' ').slice(0, 40);
+    return text ? selectorParts.join('') + ' "' + text + '"' : selectorParts.join('');
+  };
+
+  const state = {
+    cls: 0,
+    lcpMs: null,
+    interactionDelayMs: null,
+    interactionType: null,
+    shiftSources: [],
+  };
+
+  window.__perfAudit = state;
+
+  try {
+    new PerformanceObserver((list) => {
+      for (const entry of list.getEntries()) {
+        if (entry.hadRecentInput) {
+          continue;
+        }
+
+        state.cls += entry.value || 0;
+        const topSource = entry.sources && entry.sources.length > 0 ? entry.sources[0] : null;
+        state.shiftSources.push({
+          value: Math.round((entry.value || 0) * 1000) / 1000,
+          selector: describeNode(topSource && topSource.node),
+          previousRect: describeRect(topSource && topSource.previousRect),
+          currentRect: describeRect(topSource && topSource.currentRect),
+        });
+      }
+    }).observe({ type: 'layout-shift', buffered: true });
+  } catch {}
+
+  try {
+    new PerformanceObserver((list) => {
+      const entries = list.getEntries();
+      const lastEntry = entries[entries.length - 1];
+      if (lastEntry) {
+        state.lcpMs = lastEntry.startTime;
+      }
+    }).observe({ type: 'largest-contentful-paint', buffered: true });
+  } catch {}
+
+  try {
+    new PerformanceObserver((list) => {
+      for (const entry of list.getEntries()) {
+        const processingStart = entry.processingStart || entry.startTime;
+        const delay = processingStart - entry.startTime;
+        if (state.interactionDelayMs === null || delay > state.interactionDelayMs) {
+          state.interactionDelayMs = delay;
+          state.interactionType = entry.name || 'interaction';
+        }
+      }
+    }).observe({ type: 'event', buffered: true, durationThreshold: 16 });
+  } catch {}
+})();
+`;
 
 type RouteSpec = {
   label: string;
@@ -42,6 +125,12 @@ type AuditResult = {
   loadMs: number | null;
   totalTransferKb: number;
   jsTransferKb: number;
+  shiftSources: Array<{
+    value: number;
+    selector: string;
+    previousRect: string | null;
+    currentRect: string | null;
+  }>;
 };
 
 const routes: RouteSpec[] = [
@@ -163,60 +252,6 @@ async function startStaticServer(): Promise<{ origin: string; close(): Promise<v
   };
 }
 
-async function installPerformanceObservers(page: Page): Promise<void> {
-  await page.addInitScript(() => {
-    const state = {
-      cls: 0,
-      lcpMs: null as number | null,
-      interactionDelayMs: null as number | null,
-      interactionType: null as string | null,
-    };
-
-    (window as typeof window & { __perfAudit?: typeof state }).__perfAudit = state;
-
-    new PerformanceObserver((list) => {
-      for (const entry of list.getEntries() as Array<PerformanceEntry & { hadRecentInput?: boolean; value?: number }>) {
-        if (entry.hadRecentInput) {
-          continue;
-        }
-
-        state.cls += entry.value ?? 0;
-      }
-    }).observe({ type: 'layout-shift', buffered: true });
-
-    new PerformanceObserver((list) => {
-      const entries = list.getEntries();
-      const lastEntry = entries[entries.length - 1];
-
-      if (lastEntry) {
-        state.lcpMs = lastEntry.startTime;
-      }
-    }).observe({ type: 'largest-contentful-paint', buffered: true });
-
-    try {
-      new PerformanceObserver((list) => {
-        for (const entry of list.getEntries() as Array<
-          PerformanceEntry & {
-            interactionId?: number;
-            name?: string;
-            processingStart?: number;
-          }
-        >) {
-          const processingStart = entry.processingStart ?? entry.startTime;
-          const delay = processingStart - entry.startTime;
-
-          if (state.interactionDelayMs === null || delay > state.interactionDelayMs) {
-            state.interactionDelayMs = delay;
-            state.interactionType = entry.name ?? 'interaction';
-          }
-        }
-      }).observe({ type: 'event', buffered: true, durationThreshold: 16 });
-    } catch {
-      // Event Timing is not available in every browser context.
-    }
-  });
-}
-
 function classifyLcp(value: number | null): MetricRating {
   if (value === null) return 'not-supported';
   if (value <= 2500) return 'good';
@@ -268,6 +303,10 @@ function formatNumber(value: number | null, digits = 2): string {
   return value === null ? 'n/a' : value.toFixed(digits);
 }
 
+async function installPerformanceObservers(page: Page): Promise<void> {
+  await page.addInitScript({ content: PERF_OBSERVER_SCRIPT });
+}
+
 async function collectResult(
   page: Page,
   profile: ProfileSpec,
@@ -294,6 +333,12 @@ async function collectResult(
         lcpMs: number | null;
         interactionDelayMs: number | null;
         interactionType: string | null;
+        shiftSources: Array<{
+          value: number;
+          selector: string;
+          previousRect: string | null;
+          currentRect: string | null;
+        }>;
       };
     }).__perfAudit;
 
@@ -348,6 +393,7 @@ async function collectResult(
     loadMs: round(navigation?.loadMs ?? null),
     totalTransferKb: round(resources.totalTransferKb, 1) ?? 0,
     jsTransferKb: round(resources.jsTransferKb, 1) ?? 0,
+    shiftSources: (perfState?.shiftSources ?? []).slice(0, 5),
   };
 }
 
@@ -367,6 +413,14 @@ function printResult(result: AuditResult, route: RouteSpec): void {
   console.log(
     `  Transfer -> ${result.totalTransferKb.toFixed(1)} kB total, ${result.jsTransferKb.toFixed(1)} kB JS`,
   );
+  if (result.shiftSources.length > 0) {
+    console.log('  Shift sources:');
+    for (const source of result.shiftSources) {
+      console.log(
+        `    - ${source.value.toFixed(3)} ${source.selector} (${source.previousRect ?? 'n/a'} -> ${source.currentRect ?? 'n/a'})`,
+      );
+    }
+  }
 }
 
 async function main(): Promise<void> {

--- a/scripts/perf-audit.ts
+++ b/scripts/perf-audit.ts
@@ -1,0 +1,424 @@
+import { once } from 'node:events';
+import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
+import { existsSync } from 'node:fs';
+import { readFile } from 'node:fs/promises';
+import { extname, join, normalize, resolve } from 'node:path';
+import {
+  chromium,
+  devices,
+  type BrowserContextOptions,
+  type Page,
+} from '@playwright/test';
+
+import { setupApiMocks } from '../e2e/mocks/api-mock';
+
+const DIST_DIR = resolve('dist/fantrax-stats-parser-ui/browser');
+const INDEX_PATH = resolve(DIST_DIR, 'index.html');
+
+type RouteSpec = {
+  label: string;
+  path: string;
+  readySelector: string;
+  interactionLabel: string;
+  runInteraction(page: Page): Promise<void>;
+};
+
+type ProfileSpec = {
+  label: string;
+  contextOptions: BrowserContextOptions;
+};
+
+type MetricRating = 'good' | 'needs-improvement' | 'poor' | 'not-supported';
+
+type AuditResult = {
+  profile: string;
+  route: string;
+  path: string;
+  lcpMs: number | null;
+  cls: number | null;
+  interactionDelayMs: number | null;
+  interactionType: string | null;
+  domContentLoadedMs: number | null;
+  loadMs: number | null;
+  totalTransferKb: number;
+  jsTransferKb: number;
+};
+
+const routes: RouteSpec[] = [
+  {
+    label: 'frontpage',
+    path: '/',
+    readySelector: 'tr[mat-row][data-row-index="0"]',
+    interactionLabel: 'open player card',
+    async runInteraction(page) {
+      await page.locator('tr[mat-row][data-row-index="0"]').click();
+      await page.locator('.player-card').waitFor({ state: 'visible' });
+      await page.locator('.player-card > button').first().click();
+      await page.locator('.player-card').waitFor({ state: 'hidden' });
+    },
+  },
+  {
+    label: 'career players',
+    path: '/career/players',
+    readySelector: '.virtual-table-row[data-row-index="0"]',
+    interactionLabel: 'search career table',
+    async runInteraction(page) {
+      const searchInput = page.locator('input[type="search"]');
+      await searchInput.click();
+      await searchInput.fill('jamie');
+    },
+  },
+];
+
+const profiles: ProfileSpec[] = [
+  {
+    label: 'desktop',
+    contextOptions: {
+      ...devices['Desktop Chrome'],
+      serviceWorkers: 'block',
+    },
+  },
+  {
+    label: 'mobile',
+    contextOptions: {
+      ...devices['Pixel 5'],
+      serviceWorkers: 'block',
+    },
+  },
+];
+
+const mimeTypes: Record<string, string> = {
+  '.css': 'text/css; charset=utf-8',
+  '.html': 'text/html; charset=utf-8',
+  '.ico': 'image/x-icon',
+  '.js': 'application/javascript; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.map': 'application/json; charset=utf-8',
+  '.png': 'image/png',
+  '.svg': 'image/svg+xml',
+  '.txt': 'text/plain; charset=utf-8',
+  '.webmanifest': 'application/manifest+json; charset=utf-8',
+  '.woff2': 'font/woff2',
+};
+
+async function handleRequest(req: IncomingMessage, res: ServerResponse): Promise<void> {
+  const requestUrl = new URL(req.url ?? '/', 'http://127.0.0.1');
+  const pathname = decodeURIComponent(requestUrl.pathname);
+  const extension = extname(pathname);
+
+  let filePath = INDEX_PATH;
+  let statusCode = 200;
+
+  if (extension) {
+    const candidatePath = normalize(join(DIST_DIR, pathname));
+    const isInsideDist = candidatePath.startsWith(DIST_DIR);
+
+    if (isInsideDist && existsSync(candidatePath)) {
+      filePath = candidatePath;
+    } else {
+      statusCode = 404;
+      filePath = INDEX_PATH;
+    }
+  }
+
+  try {
+    const body = await readFile(filePath);
+    res.writeHead(statusCode, {
+      'content-type': mimeTypes[extname(filePath)] ?? 'application/octet-stream',
+      'cache-control': 'no-store',
+    });
+    res.end(statusCode === 404 ? 'Not found' : body);
+  } catch (error) {
+    res.writeHead(500, { 'content-type': 'text/plain; charset=utf-8' });
+    res.end(`Failed to serve ${filePath}: ${String(error)}`);
+  }
+}
+
+async function startStaticServer(): Promise<{ origin: string; close(): Promise<void> }> {
+  const server = createServer((req, res) => {
+    void handleRequest(req, res);
+  });
+
+  server.listen(0, '127.0.0.1');
+  await once(server, 'listening');
+
+  const address = server.address();
+  if (!address || typeof address === 'string') {
+    throw new Error('Could not determine local server address.');
+  }
+
+  return {
+    origin: `http://127.0.0.1:${address.port}`,
+    close: () =>
+      new Promise<void>((resolveClose, rejectClose) => {
+        server.close((error) => {
+          if (error) {
+            rejectClose(error);
+            return;
+          }
+
+          resolveClose();
+        });
+      }),
+  };
+}
+
+async function installPerformanceObservers(page: Page): Promise<void> {
+  await page.addInitScript(() => {
+    const state = {
+      cls: 0,
+      lcpMs: null as number | null,
+      interactionDelayMs: null as number | null,
+      interactionType: null as string | null,
+    };
+
+    (window as typeof window & { __perfAudit?: typeof state }).__perfAudit = state;
+
+    new PerformanceObserver((list) => {
+      for (const entry of list.getEntries() as Array<PerformanceEntry & { hadRecentInput?: boolean; value?: number }>) {
+        if (entry.hadRecentInput) {
+          continue;
+        }
+
+        state.cls += entry.value ?? 0;
+      }
+    }).observe({ type: 'layout-shift', buffered: true });
+
+    new PerformanceObserver((list) => {
+      const entries = list.getEntries();
+      const lastEntry = entries[entries.length - 1];
+
+      if (lastEntry) {
+        state.lcpMs = lastEntry.startTime;
+      }
+    }).observe({ type: 'largest-contentful-paint', buffered: true });
+
+    try {
+      new PerformanceObserver((list) => {
+        for (const entry of list.getEntries() as Array<
+          PerformanceEntry & {
+            interactionId?: number;
+            name?: string;
+            processingStart?: number;
+          }
+        >) {
+          const processingStart = entry.processingStart ?? entry.startTime;
+          const delay = processingStart - entry.startTime;
+
+          if (state.interactionDelayMs === null || delay > state.interactionDelayMs) {
+            state.interactionDelayMs = delay;
+            state.interactionType = entry.name ?? 'interaction';
+          }
+        }
+      }).observe({ type: 'event', buffered: true, durationThreshold: 16 });
+    } catch {
+      // Event Timing is not available in every browser context.
+    }
+  });
+}
+
+function classifyLcp(value: number | null): MetricRating {
+  if (value === null) return 'not-supported';
+  if (value <= 2500) return 'good';
+  if (value <= 4000) return 'needs-improvement';
+  return 'poor';
+}
+
+function classifyCls(value: number | null): MetricRating {
+  if (value === null) return 'not-supported';
+  if (value <= 0.1) return 'good';
+  if (value <= 0.25) return 'needs-improvement';
+  return 'poor';
+}
+
+function classifyInteractionDelay(value: number | null): MetricRating {
+  if (value === null) return 'not-supported';
+  if (value <= 200) return 'good';
+  if (value <= 500) return 'needs-improvement';
+  return 'poor';
+}
+
+function formatRating(label: string, rating: MetricRating): string {
+  const suffix =
+    rating === 'good'
+      ? 'GOOD'
+      : rating === 'needs-improvement'
+        ? 'NEEDS-IMPROVEMENT'
+        : rating === 'poor'
+          ? 'POOR'
+          : 'N/A';
+
+  return `${label}: ${suffix}`;
+}
+
+function round(value: number | null, digits = 0): number | null {
+  if (value === null) {
+    return null;
+  }
+
+  const multiplier = 10 ** digits;
+  return Math.round(value * multiplier) / multiplier;
+}
+
+function formatMs(value: number | null): string {
+  return value === null ? 'n/a' : `${value.toFixed(0)} ms`;
+}
+
+function formatNumber(value: number | null, digits = 2): string {
+  return value === null ? 'n/a' : value.toFixed(digits);
+}
+
+async function collectResult(
+  page: Page,
+  profile: ProfileSpec,
+  route: RouteSpec,
+  origin: string,
+): Promise<AuditResult> {
+  page.setDefaultTimeout(15000);
+  page.setDefaultNavigationTimeout(15000);
+
+  await installPerformanceObservers(page);
+  await setupApiMocks(page);
+
+  await page.goto(`${origin}${route.path}`, { waitUntil: 'domcontentloaded' });
+  await page.locator(route.readySelector).waitFor({ state: 'visible' });
+  await page.waitForTimeout(800);
+
+  await route.runInteraction(page);
+  await page.waitForTimeout(500);
+
+  const perfState = await page.evaluate(() => {
+    const state = (window as typeof window & {
+      __perfAudit?: {
+        cls: number;
+        lcpMs: number | null;
+        interactionDelayMs: number | null;
+        interactionType: string | null;
+      };
+    }).__perfAudit;
+
+    return state ?? null;
+  });
+
+  const navigation = await page.evaluate(() => {
+    const entry = performance.getEntriesByType('navigation')[0] as PerformanceNavigationTiming | undefined;
+    if (!entry) {
+      return null;
+    }
+
+    return {
+      domContentLoadedMs: entry.domContentLoadedEventEnd - entry.startTime,
+      loadMs: entry.loadEventEnd - entry.startTime,
+    };
+  });
+
+  const resources = await page.evaluate(() => {
+    const summary = {
+      totalTransferKb: 0,
+      jsTransferKb: 0,
+    };
+
+    for (const entry of performance.getEntriesByType('resource') as PerformanceResourceTiming[]) {
+      const transferSize = entry.transferSize || entry.encodedBodySize || 0;
+      const transferKb = transferSize / 1024;
+      summary.totalTransferKb += transferKb;
+
+      try {
+        const pathname = new URL(entry.name).pathname;
+        if (pathname.endsWith('.js')) {
+          summary.jsTransferKb += transferKb;
+        }
+      } catch {
+        // Ignore malformed resource URLs.
+      }
+    }
+
+    return summary;
+  });
+
+  return {
+    profile: profile.label,
+    route: route.label,
+    path: route.path,
+    lcpMs: round(perfState?.lcpMs ?? null),
+    cls: round(perfState?.cls ?? null, 3),
+    interactionDelayMs: round(perfState?.interactionDelayMs ?? null),
+    interactionType: perfState?.interactionType ?? null,
+    domContentLoadedMs: round(navigation?.domContentLoadedMs ?? null),
+    loadMs: round(navigation?.loadMs ?? null),
+    totalTransferKb: round(resources.totalTransferKb, 1) ?? 0,
+    jsTransferKb: round(resources.jsTransferKb, 1) ?? 0,
+  };
+}
+
+function printResult(result: AuditResult, route: RouteSpec): void {
+  const lcpRating = classifyLcp(result.lcpMs);
+  const clsRating = classifyCls(result.cls);
+  const interactionRating = classifyInteractionDelay(result.interactionDelayMs);
+
+  console.log(`\n[${result.profile}] ${result.route} (${result.path})`);
+  console.log(`  ${formatRating('LCP', lcpRating)} -> ${formatMs(result.lcpMs)}`);
+  console.log(`  ${formatRating('CLS', clsRating)} -> ${formatNumber(result.cls, 3)}`);
+  console.log(
+    `  ${formatRating('Interaction proxy', interactionRating)} -> ${formatMs(result.interactionDelayMs)} (${route.interactionLabel}${result.interactionType ? ` / ${result.interactionType}` : ''})`,
+  );
+  console.log(`  DOMContentLoaded -> ${formatMs(result.domContentLoadedMs)}`);
+  console.log(`  Load -> ${formatMs(result.loadMs)}`);
+  console.log(
+    `  Transfer -> ${result.totalTransferKb.toFixed(1)} kB total, ${result.jsTransferKb.toFixed(1)} kB JS`,
+  );
+}
+
+async function main(): Promise<void> {
+  if (!existsSync(INDEX_PATH)) {
+    throw new Error(
+      'Production build output is missing. Run `npm run build` before the performance audit.',
+    );
+  }
+
+  const server = await startStaticServer();
+  const browser = await chromium.launch({ headless: true });
+  const results: AuditResult[] = [];
+
+  try {
+    for (const profile of profiles) {
+      const context = await browser.newContext(profile.contextOptions);
+
+      try {
+        for (const route of routes) {
+          const page = await context.newPage();
+
+          try {
+            console.log(`Auditing [${profile.label}] ${route.label} (${route.path})...`);
+            const result = await collectResult(page, profile, route, server.origin);
+            results.push(result);
+            printResult(result, route);
+          } finally {
+            await page.close();
+          }
+        }
+      } finally {
+        await context.close();
+      }
+    }
+  } finally {
+    await browser.close();
+    await server.close();
+  }
+
+  const hasPoorVital = results.some((result) => {
+    return classifyLcp(result.lcpMs) === 'poor' || classifyCls(result.cls) === 'poor';
+  });
+
+  console.log('\nNote: this audit uses a local production build with mocked API responses.');
+  console.log('Use PageSpeed Insights or Chrome DevTools for public scores and field-data validation.');
+
+  if (hasPoorVital) {
+    process.exitCode = 1;
+  }
+}
+
+void main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -137,10 +137,14 @@
       </div>
     </div>
 
-    @if (lastModifiedText$ | async; as lastModifiedText) {
     @if (showStatsShell) {
+    @if (lastModifiedText$ | async; as lastModifiedText) {
     <div class="last-modified">
       {{ "lastModified.label" | translate }}: {{ lastModifiedText }}
+    </div>
+    } @else {
+    <div class="last-modified last-modified--empty" aria-hidden="true">
+      &nbsp;
     </div>
     }
     }
@@ -168,4 +172,6 @@
 @if (showStatsShell) {
 <app-comparison-bar [context]="controlsContext" />
 }
+@if (isFooterVisible()) {
 <app-footer />
+}

--- a/src/app/app.component.mobile.spec.ts
+++ b/src/app/app.component.mobile.spec.ts
@@ -58,7 +58,7 @@ describe('AppComponent — mobile frontpage', { timeout: 60_000 }, () => {
     expect(rows).toHaveLength(PLAYER_SLICE_COUNT + 1);
 
     // -- Footer --
-    expect(screen.getByRole('navigation', { name: 'footer.links.ariaLabel' })).toBeInTheDocument();
+    expect(await screen.findByRole('navigation', { name: 'footer.links.ariaLabel' })).toBeInTheDocument();
     expect(screen.getByText('footer.links.linkedin.label')).toBeInTheDocument();
     expect(screen.getByText('footer.links.ui.label')).toBeInTheDocument();
     expect(screen.getByText('footer.links.api.label')).toBeInTheDocument();

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -23,9 +23,14 @@
 .last-modified {
 	margin: -6px 8px 12px 8px;
 	padding: 0 4px;
+	min-height: 1.1rem;
 	font-size: 0.85rem;
 	color: var(--mat-sys-on-surface-variant);
 	text-align: center;
+}
+
+.last-modified--empty {
+	visibility: hidden;
 }
 
 .route-subtitle {

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -2,7 +2,7 @@ import { fireEvent, render, screen } from '@testing-library/angular';
 import { TestBed } from '@angular/core/testing';
 import { MatSnackBar } from '@angular/material/snack-bar';
 
-import { AppComponent } from './app.component';
+import { AppComponent, buildRouteUiState } from './app.component';
 import {
   getBehaviorTestConfig,
   polyfillJsdom,
@@ -83,7 +83,7 @@ describe('AppComponent — desktop frontpage', { timeout: 60_000 }, () => {
     expect(screen.getByLabelText('table.playerSearch')).toBeInTheDocument();
 
     // -- Footer --
-    expect(screen.getByRole('navigation', { name: 'footer.links.ariaLabel' })).toBeInTheDocument();
+    expect(await screen.findByRole('navigation', { name: 'footer.links.ariaLabel' })).toBeInTheDocument();
     expect(screen.getByText('footer.links.linkedin.label')).toBeInTheDocument();
     expect(screen.getByText('footer.links.ui.label')).toBeInTheDocument();
     expect(screen.getByText('footer.links.api.label')).toBeInTheDocument();
@@ -202,5 +202,27 @@ describe('AppComponent — desktop frontpage', { timeout: 60_000 }, () => {
       'reportType.regular'
     );
     expect(screen.getByRole('table')).toBeInTheDocument();
+  });
+});
+
+describe('buildRouteUiState', () => {
+  it('hides the stats shell for career routes before navigation settles', () => {
+    expect(buildRouteUiState('/career/players?tab=goalies')).toEqual({
+      controlsContext: 'player',
+      isLeaderboardsRoute: false,
+      isCareerRoute: true,
+      showStatsShell: false,
+      currentRouteSubtitleKey: 'nav.playerCareers',
+    });
+  });
+
+  it('hides the stats shell for leaderboard routes before navigation settles', () => {
+    expect(buildRouteUiState('/leaderboards/playoffs')).toEqual({
+      controlsContext: 'player',
+      isLeaderboardsRoute: true,
+      isCareerRoute: false,
+      showStatsShell: false,
+      currentRouteSubtitleKey: 'nav.leaderboards',
+    });
   });
 });

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -114,7 +114,11 @@ describe('AppComponent — desktop frontpage', { timeout: 60_000 }, () => {
     searchInput.blur();
     fireEvent.keyDown(document, { key: '?' });
 
-    const helpCloseButton = await screen.findByRole('button', { name: 'helpDialog.close' });
+    const helpCloseButton = await screen.findByRole(
+      'button',
+      { name: 'helpDialog.close' },
+      { timeout: 5000 }
+    );
     fireEvent.click(helpCloseButton);
 
     await vi.waitFor(() => {

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -2,7 +2,7 @@ import { fireEvent, render, screen } from '@testing-library/angular';
 import { TestBed } from '@angular/core/testing';
 import { MatSnackBar } from '@angular/material/snack-bar';
 
-import { AppComponent, buildRouteUiState } from './app.component';
+import { AppComponent, buildInitialMobileState, buildRouteUiState } from './app.component';
 import {
   getBehaviorTestConfig,
   polyfillJsdom,
@@ -223,6 +223,30 @@ describe('buildRouteUiState', () => {
       isCareerRoute: false,
       showStatsShell: false,
       currentRouteSubtitleKey: 'nav.leaderboards',
+    });
+  });
+});
+
+describe('buildInitialMobileState', () => {
+  it('seeds desktop state synchronously from matchMedia', () => {
+    expect(
+      buildInitialMobileState({
+        matchMedia: () => ({ matches: false }) as MediaQueryList,
+      })
+    ).toEqual({
+      ready: true,
+      isMobile: false,
+    });
+  });
+
+  it('seeds mobile state synchronously from matchMedia', () => {
+    expect(
+      buildInitialMobileState({
+        matchMedia: () => ({ matches: true }) as MediaQueryList,
+      })
+    ).toEqual({
+      ready: true,
+      isMobile: true,
     });
   });
 });

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -6,7 +6,7 @@ import {
   OnInit,
   DestroyRef,
 } from "@angular/core";
-import { NavigationEnd, Router, RouterOutlet } from "@angular/router";
+import { NavigationEnd, NavigationStart, Router, RouterOutlet } from "@angular/router";
 import { Title } from "@angular/platform-browser";
 import { TranslateModule, TranslateService } from "@ngx-translate/core";
 import { MatTabNavPanel, MatTabsModule } from "@angular/material/tabs";
@@ -43,6 +43,7 @@ import {
 import { ApiService, Team } from "@services/api.service";
 import { TeamService } from "@services/team.service";
 import { PwaUpdateService } from "@services/pwa-update.service";
+import { FooterVisibilityService } from "@services/footer-visibility.service";
 
 let helpDialogComponentPromise: Promise<
   typeof import("@shared/help-dialog/help-dialog.component")
@@ -60,6 +61,30 @@ let globalNavComponentPromise: Promise<
 function loadGlobalNavComponent() {
   globalNavComponentPromise ??= import("@shared/global-nav/global-nav.component");
   return globalNavComponentPromise;
+}
+
+type RouteUiState = {
+  controlsContext: ControlsContext;
+  isLeaderboardsRoute: boolean;
+  isCareerRoute: boolean;
+  showStatsShell: boolean;
+  currentRouteSubtitleKey: string | null;
+};
+
+export function buildRouteUiState(url: string): RouteUiState {
+  const normalizedUrl = url.split("?")[0]?.split("#")[0] ?? "/";
+  const isLeaderboardsRoute = normalizedUrl.startsWith("/leaderboards");
+  const isCareerRoute = normalizedUrl.startsWith("/career");
+
+  return {
+    controlsContext: normalizedUrl.includes("goalie-stats") ? "goalie" : "player",
+    isLeaderboardsRoute,
+    isCareerRoute,
+    showStatsShell: !isLeaderboardsRoute && !isCareerRoute,
+    currentRouteSubtitleKey: isCareerRoute
+      ? "nav.playerCareers"
+      : (isLeaderboardsRoute ? "nav.leaderboards" : null),
+  };
 }
 
 @Component({
@@ -92,7 +117,12 @@ export class AppComponent implements OnInit {
   @ViewChild("tabPanel") tabPanel!: MatTabNavPanel;
   @ViewChild("settingsDrawer") settingsDrawer?: MatSidenav;
 
-  controlsContext: ControlsContext = "player";
+  private readonly document = inject(DOCUMENT);
+  private readonly initialRouteUiState = buildRouteUiState(
+    `${this.document.location.pathname}${this.document.location.search}${this.document.location.hash}`,
+  );
+
+  controlsContext: ControlsContext = this.initialRouteUiState.controlsContext;
   private readonly controlsContextSubject =
     new BehaviorSubject<ControlsContext>(this.controlsContext);
   readonly controlsContext$ = this.controlsContextSubject.asObservable();
@@ -105,6 +135,7 @@ export class AppComponent implements OnInit {
 
   private readonly teamService = inject(TeamService);
   private readonly apiService = inject(ApiService);
+  readonly isFooterVisible = inject(FooterVisibilityService).footerVisible;
 
   private readonly fiLastModifiedFormatter = new Intl.DateTimeFormat("fi-FI", {
     timeZone: "Europe/Helsinki",
@@ -149,10 +180,10 @@ export class AppComponent implements OnInit {
   );
 
   isSettingsDrawerOpen = false;
-  isLeaderboardsRoute = false;
-  isCareerRoute = false;
-  showStatsShell = true;
-  currentRouteSubtitleKey: string | null = null;
+  isLeaderboardsRoute = this.initialRouteUiState.isLeaderboardsRoute;
+  isCareerRoute = this.initialRouteUiState.isCareerRoute;
+  showStatsShell = this.initialRouteUiState.showStatsShell;
+  currentRouteSubtitleKey: string | null = this.initialRouteUiState.currentRouteSubtitleKey;
 
   get skipLinkTargetId(): string {
     if (this.isLeaderboardsRoute) return "leaderboard-table";
@@ -177,7 +208,7 @@ export class AppComponent implements OnInit {
   private translateService = inject(TranslateService);
   private dialog = inject(MatDialog);
   private router = inject(Router);
-  private document = inject(DOCUMENT);
+  private footerVisibilityService = inject(FooterVisibilityService);
 
   ngOnInit(): void {
     this.translateService.get("pageTitle").subscribe((name) => {
@@ -194,14 +225,18 @@ export class AppComponent implements OnInit {
         this.openUpdateAvailableSnackbar();
       });
 
-    this.updateControlsContext(this.router.url);
     this.router.events
-      .pipe(
-        filter(
-          (event): event is NavigationEnd => event instanceof NavigationEnd,
-        ),
-      )
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe((event) => {
+        if (event instanceof NavigationStart) {
+          this.footerVisibilityService.beginNavigation();
+          return;
+        }
+
+        if (!(event instanceof NavigationEnd)) {
+          return;
+        }
+
         this.updateControlsContext(event.urlAfterRedirects);
         this.settingsDrawer?.close();
       });
@@ -260,16 +295,14 @@ export class AppComponent implements OnInit {
   }
 
   private updateControlsContext(url: string): void {
-    const normalizedUrl = url.split('?')[0];
+    const nextState = buildRouteUiState(url);
 
-    this.controlsContext = normalizedUrl.includes("goalie-stats") ? "goalie" : "player";
+    this.controlsContext = nextState.controlsContext;
     this.controlsContextSubject.next(this.controlsContext);
-    this.isLeaderboardsRoute = normalizedUrl.startsWith("/leaderboards");
-    this.isCareerRoute = normalizedUrl.startsWith('/career');
-    this.showStatsShell = !this.isLeaderboardsRoute && !this.isCareerRoute;
-    this.currentRouteSubtitleKey = this.isCareerRoute
-      ? 'nav.playerCareers'
-      : (this.isLeaderboardsRoute ? 'nav.leaderboards' : null);
+    this.isLeaderboardsRoute = nextState.isLeaderboardsRoute;
+    this.isCareerRoute = nextState.isCareerRoute;
+    this.showStatsShell = nextState.showStatsShell;
+    this.currentRouteSubtitleKey = nextState.currentRouteSubtitleKey;
   }
 
   skipToTarget(targetId: string, event: MouseEvent): void {

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -71,6 +71,11 @@ type RouteUiState = {
   currentRouteSubtitleKey: string | null;
 };
 
+type MobileState = {
+  ready: boolean;
+  isMobile: boolean;
+};
+
 export function buildRouteUiState(url: string): RouteUiState {
   const normalizedUrl = url.split("?")[0]?.split("#")[0] ?? "/";
   const isLeaderboardsRoute = normalizedUrl.startsWith("/leaderboards");
@@ -84,6 +89,18 @@ export function buildRouteUiState(url: string): RouteUiState {
     currentRouteSubtitleKey: isCareerRoute
       ? "nav.playerCareers"
       : (isLeaderboardsRoute ? "nav.leaderboards" : null),
+  };
+}
+
+export function buildInitialMobileState(
+  defaultView: Pick<Window, "matchMedia"> | null | undefined,
+): MobileState {
+  return {
+    ready: true,
+    isMobile:
+      typeof defaultView?.matchMedia === "function"
+        ? defaultView.matchMedia("(max-width: 768px)").matches
+        : false,
   };
 }
 
@@ -121,6 +138,7 @@ export class AppComponent implements OnInit {
   private readonly initialRouteUiState = buildRouteUiState(
     `${this.document.location.pathname}${this.document.location.search}${this.document.location.hash}`,
   );
+  private readonly initialMobileState = buildInitialMobileState(this.document.defaultView);
 
   controlsContext: ControlsContext = this.initialRouteUiState.controlsContext;
   private readonly controlsContextSubject =
@@ -129,7 +147,10 @@ export class AppComponent implements OnInit {
 
   readonly mobileState$ = inject(ViewportService).isMobile$.pipe(
     map((isMobile) => ({ ready: true, isMobile })),
-    startWith({ ready: false, isMobile: false }),
+    startWith(this.initialMobileState),
+    distinctUntilChanged(
+      (a, b) => a.ready === b.ready && a.isMobile === b.isMobile,
+    ),
     shareReplay({ bufferSize: 1, refCount: true }),
   );
 

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -35,8 +35,6 @@ import {
   startWith,
   take,
 } from "rxjs";
-import { HelpDialogComponent } from "@shared/help-dialog/help-dialog.component";
-import { GlobalNavComponent } from "@shared/global-nav/global-nav.component";
 import { ViewportService } from "@services/viewport.service";
 import {
   ControlsContext,
@@ -45,6 +43,24 @@ import {
 import { ApiService, Team } from "@services/api.service";
 import { TeamService } from "@services/team.service";
 import { PwaUpdateService } from "@services/pwa-update.service";
+
+let helpDialogComponentPromise: Promise<
+  typeof import("@shared/help-dialog/help-dialog.component")
+> | null = null;
+
+function loadHelpDialogComponent() {
+  helpDialogComponentPromise ??= import("@shared/help-dialog/help-dialog.component");
+  return helpDialogComponentPromise;
+}
+
+let globalNavComponentPromise: Promise<
+  typeof import("@shared/global-nav/global-nav.component")
+> | null = null;
+
+function loadGlobalNavComponent() {
+  globalNavComponentPromise ??= import("@shared/global-nav/global-nav.component");
+  return globalNavComponentPromise;
+}
 
 @Component({
   selector: "app-root",
@@ -297,7 +313,7 @@ export class AppComponent implements OnInit {
 
     if (event.key === "?" && !isInFormField) {
       event.preventDefault();
-      this.openHelpDialog();
+      void this.openHelpDialog();
       return;
     }
 
@@ -318,7 +334,9 @@ export class AppComponent implements OnInit {
     }
   }
 
-  openHelpDialog(): void {
+  async openHelpDialog(): Promise<void> {
+    const { HelpDialogComponent } = await loadHelpDialogComponent();
+
     this.dialog.open(HelpDialogComponent, {
       panelClass: "help-dialog",
       autoFocus: "first-tabbable",
@@ -326,7 +344,8 @@ export class AppComponent implements OnInit {
     });
   }
 
-  openNavMenu(): void {
+  async openNavMenu(): Promise<void> {
+    const { GlobalNavComponent } = await loadGlobalNavComponent();
     this.bottomSheet.open(GlobalNavComponent, { autoFocus: false });
   }
 

--- a/src/app/base/stats/stats-base.component.ts
+++ b/src/app/base/stats/stats-base.component.ts
@@ -23,6 +23,7 @@ import { TableRow } from '@shared/stats-table/stats-table.component';
 import { Column } from '@shared/column.types';
 import { ComparisonService } from '@services/comparison.service';
 import { toApiTeamId } from '@shared/utils/api.utils';
+import { FooterVisibilityService } from '@services/footer-visibility.service';
 
 @Directive()
 export abstract class StatsBaseComponent<T extends Player | Goalie> implements OnInit, OnDestroy {
@@ -33,6 +34,7 @@ export abstract class StatsBaseComponent<T extends Player | Goalie> implements O
   protected settingsService = inject(SettingsService);
   protected drawerContextService = inject(DrawerContextService);
   protected destroy$ = new Subject<void>();
+  private readonly footerVisibilityService = inject(FooterVisibilityService);
 
   readonly isMobile$ = inject(ViewportService).isMobile$;
   readonly comparisonService = inject(ComparisonService);
@@ -50,8 +52,10 @@ export abstract class StatsBaseComponent<T extends Player | Goalie> implements O
   tableData: T[] = [];
   tableColumns: Column[] = [];
   defaultSortColumn: 'score' | 'scoreAdjustedByGames' = 'score';
-  loading = false;
+  loading = true;
   apiError = false;
+  private footerVisibilityCycle = 0;
+  private footerReadyMarked = false;
 
   protected abstract get filters$(): Observable<FilterState>;
   protected abstract fetchApi(params: ApiParams): Observable<T[]>;
@@ -70,6 +74,9 @@ export abstract class StatsBaseComponent<T extends Player | Goalie> implements O
   }
 
   ngOnInit(): void {
+    this.footerVisibilityCycle = this.footerVisibilityService.currentCycle();
+    this.footerReadyMarked = false;
+
     combineLatest([
       this.filters$,
       this.teamService.selectedTeamId$,
@@ -144,6 +151,7 @@ export abstract class StatsBaseComponent<T extends Player | Goalie> implements O
             this.maxGames = 0;
             this.loading = false;
             this.apiError = true;
+            this.markFooterReady();
             return;
           }
           let processedData = this.statsPerGame ? this.applyPerGame(data) : data;
@@ -152,6 +160,7 @@ export abstract class StatsBaseComponent<T extends Player | Goalie> implements O
           this.drawerContextService.setMaxGames(this.drawerKey, this.maxGames);
           this.tableData = processedData.filter((g) => g.games >= this.minGames);
           this.loading = false;
+          this.markFooterReady();
         },
         // Stream should not error due to catchError above.
       });
@@ -160,5 +169,14 @@ export abstract class StatsBaseComponent<T extends Player | Goalie> implements O
   ngOnDestroy(): void {
     this.destroy$.next();
     this.destroy$.complete();
+  }
+
+  private markFooterReady(): void {
+    if (this.footerReadyMarked) {
+      return;
+    }
+
+    this.footerReadyMarked = true;
+    this.footerVisibilityService.markReady(this.footerVisibilityCycle);
   }
 }

--- a/src/app/career/goalies/career-goalies.component.ts
+++ b/src/app/career/goalies/career-goalies.component.ts
@@ -7,6 +7,7 @@ import { VirtualTableComponent } from '@shared/stats-table/virtual-table.compone
 import { CAREER_GOALIE_COLUMNS } from '@shared/table-columns';
 import { Column } from '@shared/column.types';
 import { formatSeasonDisplay } from '@shared/utils/season.utils';
+import { FooterVisibilityService } from '@services/footer-visibility.service';
 
 @Component({
   selector: 'app-career-goalies',
@@ -16,6 +17,7 @@ import { formatSeasonDisplay } from '@shared/utils/season.utils';
 export class CareerGoaliesComponent implements OnInit, OnDestroy {
   private readonly apiService = inject(ApiService);
   private readonly destroy$ = new Subject<void>();
+  private readonly footerVisibilityService = inject(FooterVisibilityService);
 
   readonly columns: Column[] = CAREER_GOALIE_COLUMNS;
   readonly searchLabelKey = 'table.playerSearch';
@@ -28,8 +30,10 @@ export class CareerGoaliesComponent implements OnInit, OnDestroy {
   data: CareerGoalieListItem[] = [];
   loading = true;
   apiError = false;
+  private footerVisibilityCycle = 0;
 
   ngOnInit(): void {
+    this.footerVisibilityCycle = this.footerVisibilityService.currentCycle();
     this.loading = true;
     this.apiService
       .getCareerGoalies()
@@ -38,11 +42,13 @@ export class CareerGoaliesComponent implements OnInit, OnDestroy {
         next: (data) => {
           this.data = data;
           this.loading = false;
+          this.footerVisibilityService.markReady(this.footerVisibilityCycle);
         },
         error: () => {
           this.data = [];
           this.apiError = true;
           this.loading = false;
+          this.footerVisibilityService.markReady(this.footerVisibilityCycle);
         },
       });
   }

--- a/src/app/career/players/career-players.component.ts
+++ b/src/app/career/players/career-players.component.ts
@@ -7,6 +7,7 @@ import { VirtualTableComponent } from '@shared/stats-table/virtual-table.compone
 import { CAREER_PLAYER_COLUMNS } from '@shared/table-columns';
 import { Column } from '@shared/column.types';
 import { formatSeasonDisplay } from '@shared/utils/season.utils';
+import { FooterVisibilityService } from '@services/footer-visibility.service';
 
 @Component({
   selector: 'app-career-players',
@@ -16,6 +17,7 @@ import { formatSeasonDisplay } from '@shared/utils/season.utils';
 export class CareerPlayersComponent implements OnInit, OnDestroy {
   private readonly apiService = inject(ApiService);
   private readonly destroy$ = new Subject<void>();
+  private readonly footerVisibilityService = inject(FooterVisibilityService);
 
   readonly columns: Column[] = CAREER_PLAYER_COLUMNS;
   readonly searchLabelKey = 'table.careerPlayerSearch';
@@ -28,8 +30,10 @@ export class CareerPlayersComponent implements OnInit, OnDestroy {
   data: CareerPlayerListItem[] = [];
   loading = true;
   apiError = false;
+  private footerVisibilityCycle = 0;
 
   ngOnInit(): void {
+    this.footerVisibilityCycle = this.footerVisibilityService.currentCycle();
     this.loading = true;
     this.apiService
       .getCareerPlayers()
@@ -38,11 +42,13 @@ export class CareerPlayersComponent implements OnInit, OnDestroy {
         next: (data) => {
           this.data = data;
           this.loading = false;
+          this.footerVisibilityService.markReady(this.footerVisibilityCycle);
         },
         error: () => {
           this.data = [];
           this.apiError = true;
           this.loading = false;
+          this.footerVisibilityService.markReady(this.footerVisibilityCycle);
         },
       });
   }

--- a/src/app/leaderboards/leaderboard/leaderboard.component.ts
+++ b/src/app/leaderboards/leaderboard/leaderboard.component.ts
@@ -6,6 +6,7 @@ import { Column } from '@shared/column.types';
 import { ExpandedRowViewModel } from '@shared/table-row-expansion.types';
 import { derivePositions } from '@shared/utils/position.utils';
 import { RegularLeaderboardEntry, PlayoffLeaderboardEntry } from '@services/api.service';
+import { FooterVisibilityService } from '@services/footer-visibility.service';
 
 type LeaderboardEntry = RegularLeaderboardEntry | PlayoffLeaderboardEntry;
 type LeaderboardRow = LeaderboardEntry & { displayPosition: string };
@@ -53,6 +54,7 @@ export class LeaderboardComponent implements OnInit {
     secondary?: string;
   }>();
   private destroyRef = inject(DestroyRef);
+  private footerVisibilityService = inject(FooterVisibilityService);
 
   readonly rowKeyForTable = (row: TableRow, index: number): string =>
     this.rowKey()(row as LeaderboardRow, index);
@@ -66,8 +68,10 @@ export class LeaderboardComponent implements OnInit {
   data: LeaderboardRow[] = [];
   loading = true;
   apiError = false;
+  private footerVisibilityCycle = 0;
 
   ngOnInit(): void {
+    this.footerVisibilityCycle = this.footerVisibilityService.currentCycle();
     this.loading = true;
     this.fetchFn()()
       .pipe(takeUntilDestroyed(this.destroyRef))
@@ -75,10 +79,12 @@ export class LeaderboardComponent implements OnInit {
         next: (data) => {
           this.data = derivePositions(data);
           this.loading = false;
+          this.footerVisibilityService.markReady(this.footerVisibilityCycle);
         },
         error: () => {
           this.apiError = true;
           this.loading = false;
+          this.footerVisibilityService.markReady(this.footerVisibilityCycle);
         },
       });
   }

--- a/src/app/services/footer-visibility.service.spec.ts
+++ b/src/app/services/footer-visibility.service.spec.ts
@@ -1,0 +1,63 @@
+import { TestBed } from '@angular/core/testing';
+
+import {
+  FooterVisibilityService,
+  FOOTER_VISIBILITY_FALLBACK_MS,
+} from './footer-visibility.service';
+
+describe('FooterVisibilityService', () => {
+  let service: FooterVisibilityService;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+
+    TestBed.configureTestingModule({
+      providers: [FooterVisibilityService],
+    });
+
+    service = TestBed.inject(FooterVisibilityService);
+  });
+
+  afterEach(() => {
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
+    TestBed.resetTestingModule();
+  });
+
+  it('starts hidden and becomes visible after the fallback delay', () => {
+    expect(service.footerVisible()).toBe(false);
+
+    vi.advanceTimersByTime(FOOTER_VISIBILITY_FALLBACK_MS - 1);
+    expect(service.footerVisible()).toBe(false);
+
+    vi.advanceTimersByTime(1);
+    expect(service.footerVisible()).toBe(true);
+  });
+
+  it('shows the footer immediately when the current navigation cycle is marked ready', () => {
+    const cycle = service.currentCycle();
+
+    service.markReady(cycle);
+
+    expect(service.footerVisible()).toBe(true);
+
+    vi.advanceTimersByTime(FOOTER_VISIBILITY_FALLBACK_MS);
+    expect(service.footerVisible()).toBe(true);
+  });
+
+  it('ignores ready signals from older navigation cycles', () => {
+    const initialCycle = service.currentCycle();
+
+    service.markReady(initialCycle);
+    expect(service.footerVisible()).toBe(true);
+
+    const currentCycle = service.beginNavigation();
+    expect(service.footerVisible()).toBe(false);
+
+    service.markReady(initialCycle);
+    expect(service.footerVisible()).toBe(false);
+
+    service.markReady(currentCycle);
+    expect(service.footerVisible()).toBe(true);
+  });
+});

--- a/src/app/services/footer-visibility.service.ts
+++ b/src/app/services/footer-visibility.service.ts
@@ -1,0 +1,56 @@
+import { Injectable, signal } from '@angular/core';
+
+export const FOOTER_VISIBILITY_FALLBACK_MS = 2500;
+
+@Injectable({ providedIn: 'root' })
+export class FooterVisibilityService {
+  readonly footerVisible = signal(false);
+
+  private navigationCycle = 0;
+  private fallbackTimerId?: ReturnType<typeof setTimeout>;
+
+  constructor() {
+    this.scheduleFallback(this.navigationCycle);
+  }
+
+  currentCycle(): number {
+    return this.navigationCycle;
+  }
+
+  beginNavigation(): number {
+    this.navigationCycle += 1;
+    this.footerVisible.set(false);
+    this.scheduleFallback(this.navigationCycle);
+    return this.navigationCycle;
+  }
+
+  markReady(cycle: number = this.navigationCycle): void {
+    if (cycle !== this.navigationCycle) {
+      return;
+    }
+
+    this.clearFallback();
+    this.footerVisible.set(true);
+  }
+
+  private scheduleFallback(cycle: number): void {
+    this.clearFallback();
+    this.fallbackTimerId = setTimeout(() => {
+      if (cycle !== this.navigationCycle) {
+        return;
+      }
+
+      this.fallbackTimerId = undefined;
+      this.footerVisible.set(true);
+    }, FOOTER_VISIBILITY_FALLBACK_MS);
+  }
+
+  private clearFallback(): void {
+    if (!this.fallbackTimerId) {
+      return;
+    }
+
+    clearTimeout(this.fallbackTimerId);
+    this.fallbackTimerId = undefined;
+  }
+}

--- a/src/app/shared/global-nav/global-nav.component.ts
+++ b/src/app/shared/global-nav/global-nav.component.ts
@@ -5,7 +5,15 @@ import { MatDialog } from '@angular/material/dialog';
 import { MatListModule } from '@angular/material/list';
 import { MatIconModule } from '@angular/material/icon';
 import { TranslateModule } from '@ngx-translate/core';
-import { HelpDialogComponent } from '@shared/help-dialog/help-dialog.component';
+
+let helpDialogComponentPromise: Promise<
+  typeof import('@shared/help-dialog/help-dialog.component')
+> | null = null;
+
+function loadHelpDialogComponent() {
+  helpDialogComponentPromise ??= import('@shared/help-dialog/help-dialog.component');
+  return helpDialogComponentPromise;
+}
 
 type NavItemType = 'route' | 'action';
 
@@ -55,11 +63,12 @@ export class GlobalNavComponent {
     return !!item.path && url.startsWith(item.path);
   }
 
-  onItemClick(item: NavItem): void {
+  async onItemClick(item: NavItem): Promise<void> {
     if (item.type === 'route' && item.path) {
       void this.router.navigateByUrl(item.path);
       this.bottomSheetRef.dismiss();
     } else if (item.type === 'action') {
+      const { HelpDialogComponent } = await loadHelpDialogComponent();
       this.dialog.open(HelpDialogComponent, {
         panelClass: 'help-dialog',
         autoFocus: 'first-tabbable',

--- a/src/app/shared/player-card/player-card.component.spec.ts
+++ b/src/app/shared/player-card/player-card.component.spec.ts
@@ -39,7 +39,11 @@ describe('PlayerCardComponent — desktop user flow', { timeout: 90_000 }, () =>
         // Open card by clicking a player row in stats table.
         fireEvent.click(firstPlayerCell);
 
-        const closePlayerCardButton = await screen.findByRole('button', { name: 'a11y.closePlayerCard' });
+        const closePlayerCardButton = await screen.findByRole(
+            'button',
+            { name: 'a11y.closePlayerCard' },
+            { timeout: 5000 }
+        );
         expect(closePlayerCardButton).toBeInTheDocument();
 
         // Card tabs exist for combined player data.

--- a/src/app/shared/stats-table/stats-table.component.html
+++ b/src/app/shared/stats-table/stats-table.component.html
@@ -15,7 +15,10 @@
     </div>
   }
 
-  <div class="table-container">
+  <div
+    class="table-container"
+    [class.table-container--loading]="loadingInput() && !apiErrorInput() && dataSource.data.length === 0"
+  >
     <table mat-table [dataSource]="dataSource" matSort matSortStart="desc"
       [attr.aria-describedby]="instructionsId"
       [multiTemplateDataRows]="expandable">
@@ -147,15 +150,15 @@
       <tr class="mat-row" *matNoDataRow>
         <td class="mat-cell no-results" [colSpan]="displayedFields.length">
           <span>
-            @if (apiError) {
+            @if (apiErrorInput()) {
               {{ "table.apiUnavailable" | translate }}
-            } @else if (loading) {
+            } @else if (loadingInput()) {
               {{ "table.loading" | translate }}
             } @else {
               {{ "table.noSearchResults" | translate }}
             }
           </span>
-          @if (loading && !apiError) {
+          @if (loadingInput() && !apiErrorInput()) {
             <mat-progress-bar class="loading-bar" mode="buffer"
               [value]="loadingProgress" [bufferValue]="loadingBuffer">
             </mat-progress-bar>

--- a/src/app/shared/stats-table/stats-table.component.spec.ts
+++ b/src/app/shared/stats-table/stats-table.component.spec.ts
@@ -173,7 +173,9 @@ describe('StatsTableComponent — user behavior', () => {
 
     fireEvent.keyDown(rows[0], { key: 'Enter' });
 
-    expect(open).toHaveBeenCalledTimes(1);
+    await vi.waitFor(() => {
+      expect(open).toHaveBeenCalledTimes(1);
+    });
 
     const dialogCall = open.mock.calls[0] as unknown as [
       unknown,

--- a/src/app/shared/stats-table/stats-table.component.ts
+++ b/src/app/shared/stats-table/stats-table.component.ts
@@ -33,9 +33,18 @@ import {
   CareerGoalieListItem,
 } from '@services/api.service';
 import { ExpandedRowViewModel } from '@shared/table-row-expansion.types';
-import { PlayerCardComponent, PlayerCardDialogData } from '@shared/player-card/player-card.component';
+import type { PlayerCardDialogData } from '@shared/player-card/player-card.component';
 
 const ROW_NUMBER_COLUMN = '__rowNumber';
+
+let playerCardComponentPromise: Promise<
+  typeof import('@shared/player-card/player-card.component')
+> | null = null;
+
+function loadPlayerCardComponent() {
+  playerCardComponentPromise ??= import('@shared/player-card/player-card.component');
+  return playerCardComponentPromise;
+}
 
 export type TableRow =
   | Player
@@ -119,6 +128,10 @@ export class StatsTableComponent implements AfterViewInit, OnDestroy {
   private previousLoading?: boolean;
   private previousTableId?: string;
   private previousShowPositionColumn?: boolean;
+  private playerCardPrefetchScheduled = false;
+  private openingPlayerCard = false;
+  private playerCardPrefetchIdleId?: number;
+  private playerCardPrefetchTimerId?: number;
 
   loadingProgress = 0;
   loadingBuffer = 0;
@@ -223,6 +236,11 @@ export class StatsTableComponent implements AfterViewInit, OnDestroy {
         this.onLoadingChanged(loading);
       }
 
+      if (clickable && !this.playerCardPrefetchScheduled) {
+        this.playerCardPrefetchScheduled = true;
+        this.schedulePlayerCardPrefetch();
+      }
+
       const sortRelevantChange = columnsChanged || defaultSortChanged;
 
       if (dataChanged) {
@@ -272,6 +290,7 @@ export class StatsTableComponent implements AfterViewInit, OnDestroy {
 
   ngOnDestroy(): void {
     this.clearLoadingProgressTimer();
+    this.clearPlayerCardPrefetch();
   }
 
   private onLoadingChanged(isLoading: boolean) {
@@ -414,7 +433,7 @@ export class StatsTableComponent implements AfterViewInit, OnDestroy {
 
   onMainRowClick(row: TableRow, event: MouseEvent): void {
     if (this.clickable) {
-      this.selectItem(row);
+      void this.selectItem(row);
       return;
     }
 
@@ -463,7 +482,13 @@ export class StatsTableComponent implements AfterViewInit, OnDestroy {
     setTimeout(() => this.ensureActiveRowInRange(), 0);
   }
 
-  selectItem(data: TableRow) {
+  async selectItem(data: TableRow): Promise<void> {
+    if (this.openingPlayerCard) {
+      return;
+    }
+
+    this.openingPlayerCard = true;
+
     // Track navigated index in a closure so CDK focus restoration
     // (which triggers onRowFocus) cannot overwrite it before afterClosed fires.
     let navigatedIndex = this.dataSource.filteredData.indexOf(data);
@@ -481,21 +506,66 @@ export class StatsTableComponent implements AfterViewInit, OnDestroy {
         },
       },
     };
-    const dialogRef = this.dialog.open(PlayerCardComponent, {
-      data: dialogData,
-      maxWidth: '95vw',
-      width: 'auto',
-      panelClass: 'player-card-dialog',
-    });
 
-    // Focus the navigated-to row when dialog closes.
-    dialogRef.afterClosed().subscribe(() => {
-      this.focusRow(navigatedIndex);
-    });
+    try {
+      const { PlayerCardComponent } = await loadPlayerCardComponent();
+      const dialogRef = this.dialog.open(PlayerCardComponent, {
+        data: dialogData,
+        maxWidth: '95vw',
+        width: 'auto',
+        panelClass: 'player-card-dialog',
+      });
+
+      // Focus the navigated-to row when dialog closes.
+      dialogRef.afterClosed().subscribe(() => {
+        this.focusRow(navigatedIndex);
+      });
+    } finally {
+      this.openingPlayerCard = false;
+    }
   }
 
   onRowSelectToggle(row: TableRow): void {
     this.onRowSelect?.(row);
+  }
+
+  private schedulePlayerCardPrefetch(): void {
+    const warmPlayerCardChunk = () => {
+      void loadPlayerCardComponent();
+    };
+
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    if ('requestIdleCallback' in window) {
+      this.playerCardPrefetchIdleId = window.requestIdleCallback(() => {
+        this.playerCardPrefetchIdleId = undefined;
+        warmPlayerCardChunk();
+      }, { timeout: 2000 });
+      return;
+    }
+
+    this.playerCardPrefetchTimerId = setTimeout(() => {
+      this.playerCardPrefetchTimerId = undefined;
+      warmPlayerCardChunk();
+    }, 1500);
+  }
+
+  private clearPlayerCardPrefetch(): void {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    if (this.playerCardPrefetchIdleId !== undefined && 'cancelIdleCallback' in window) {
+      window.cancelIdleCallback(this.playerCardPrefetchIdleId);
+      this.playerCardPrefetchIdleId = undefined;
+    }
+
+    if (this.playerCardPrefetchTimerId !== undefined) {
+      clearTimeout(this.playerCardPrefetchTimerId);
+      this.playerCardPrefetchTimerId = undefined;
+    }
   }
 
   onSearchKeydown(event: KeyboardEvent): void {
@@ -558,7 +628,7 @@ export class StatsTableComponent implements AfterViewInit, OnDestroy {
       case 'Enter': {
         if (this.clickable) {
           event.preventDefault();
-          this.selectItem(row);
+          void this.selectItem(row);
           return;
         }
 

--- a/src/app/shared/stats-table/virtual-table.component.html
+++ b/src/app/shared/stats-table/virtual-table.component.html
@@ -21,6 +21,7 @@
     class="table-container table-container--virtual"
     role="table"
     [attr.aria-describedby]="instructionsId"
+    [class.table-container--loading]="loadingInput() && !apiErrorInput() && filteredRows.length === 0"
   >
     <div
       class="virtual-table-grid"
@@ -84,15 +85,15 @@
       } @else {
         <div class="no-results mat-mdc-cell">
           <span>
-            @if (apiError) {
+            @if (apiErrorInput()) {
               {{ "table.apiUnavailable" | translate }}
-            } @else if (loading) {
+            } @else if (loadingInput()) {
               {{ "table.loading" | translate }}
             } @else {
               {{ "table.noSearchResults" | translate }}
             }
           </span>
-          @if (loading && !apiError) {
+          @if (loadingInput() && !apiErrorInput()) {
             <mat-progress-bar
               class="loading-bar"
               mode="buffer"

--- a/src/app/shared/top-controls/report-switcher/report-switcher.component.scss
+++ b/src/app/shared/top-controls/report-switcher/report-switcher.component.scss
@@ -1,0 +1,10 @@
+:host {
+	display: block;
+	width: 100%;
+	min-width: 0;
+}
+
+mat-form-field {
+	width: 100%;
+	min-width: 0;
+}

--- a/src/app/shared/top-controls/season-switcher/season-switcher.component.scss
+++ b/src/app/shared/top-controls/season-switcher/season-switcher.component.scss
@@ -1,0 +1,10 @@
+:host {
+	display: block;
+	width: 100%;
+	min-width: 0;
+}
+
+mat-form-field {
+	width: 100%;
+	min-width: 0;
+}

--- a/src/app/shared/top-controls/start-from-season-switcher/start-from-season-switcher.component.scss
+++ b/src/app/shared/top-controls/start-from-season-switcher/start-from-season-switcher.component.scss
@@ -1,4 +1,15 @@
+:host {
+	display: block;
+	width: 100%;
+	min-width: 0;
+}
+
 .start-from-season-switcher {
-  display: flex;
-  justify-content: center;
+	display: flex;
+	width: 100%;
+}
+
+mat-form-field {
+	width: 100%;
+	min-width: 0;
 }

--- a/src/app/shared/top-controls/team-switcher/team-switcher.component.scss
+++ b/src/app/shared/top-controls/team-switcher/team-switcher.component.scss
@@ -1,8 +1,19 @@
+:host {
+	display: block;
+	width: 100%;
+	min-width: 0;
+}
+
 .team-switcher {
-  display: flex;
-  justify-content: center;
+	display: flex;
+	width: 100%;
 }
 
 .team-switcher-error {
-  color: #b00020;
+	color: #b00020;
+}
+
+mat-form-field {
+	width: 100%;
+	min-width: 0;
 }

--- a/src/app/shared/top-controls/top-controls.component.scss
+++ b/src/app/shared/top-controls/top-controls.component.scss
@@ -71,8 +71,9 @@
 }
 
 .top-controls .top-control {
-	display: flex;
-	justify-content: center;
+	display: block;
+	width: 100%;
+	min-width: 0;
 }
 
 // Small mobile: stack controls for readability
@@ -97,5 +98,14 @@
 	.top-controls-panel .top-controls .top-control {
 		width: 100%;
 		justify-content: center;
+	}
+}
+
+@media (min-width: 961px) {
+	.top-controls-panel .top-controls {
+		display: grid;
+		grid-template-columns: repeat(4, minmax(0, 1fr));
+		justify-items: stretch;
+		align-items: start;
 	}
 }

--- a/src/index.html
+++ b/src/index.html
@@ -19,6 +19,8 @@
   <meta name="apple-mobile-web-app-title" content="FFHL Stats">
 
   <link rel="apple-touch-icon" href="icons/apple-touch-icon.png">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500&display=swap" rel="stylesheet">
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
 </head>

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -740,6 +740,12 @@ app-stats-table {
       padding-left: 16px;
     }
   }
+
+  @media (min-width: 769px) {
+    .table-container.table-container--loading {
+      min-height: calc(var(--app-height) - 200px);
+    }
+  }
 }
 
 app-virtual-table {
@@ -855,6 +861,12 @@ app-virtual-table {
   @media (max-width: 768px) {
     .no-results {
       text-align: left;
+    }
+  }
+
+  @media (min-width: 769px) {
+    .table-container--virtual.table-container--loading {
+      min-height: calc(var(--app-height) - 200px);
     }
   }
 }


### PR DESCRIPTION
## Summary
- added a local production Core Web Vitals audit workflow covering `/`, `/career/players`, and `/leaderboards/regular`
- lazy-loaded dialog and overlay UI to reduce initial startup pressure
- stabilized route shells during first render so footer and route-specific chrome no longer shift into place after paint
- initialized route UI from the first URL so `/career` and `/leaderboards` no longer render stats-only controls before hiding them
- polished the desktop top-controls layout for more consistent sizing and presentation
- documented the performance workflow and current baseline, and removed the completed Core Web Vitals roadmap item

## Validation
- `npm run verify`
- `npm run perf:audit`

## Current baseline
- desktop `/`: `LCP 360 ms`, `CLS 0.040`, interaction proxy `18 ms`
- desktop `/career/players`: `LCP 320 ms`, `CLS 0.010`, interaction proxy `4 ms`
- desktop `/leaderboards/regular`: `LCP 204 ms`, `CLS 0.010`, interaction proxy `4 ms`
- mobile audited routes: `CLS 0.000`
