### PR TITLE
Fix: Default sort direction to descending for stats table columns

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,8 +5,14 @@ See @README for project overview and @package.json for available npm commands fo
 
 Update @README and @docs/* after every task if needed.
 
-Challenge user if documentation have some clearly bad decisions and propose better. User make decision if those will be applied.
+If documentation includes clearly bad decisions, challenge them and propose better alternatives. User decides whether to apply changes.
 
-Ask every time explicitly with explanations if want to use git worktree instead of user created branch in the main workflow.
+Always ask explicitly (with explanation) whether to use git worktree instead of a user-created branch before the first mutating step of a new implementation task or approved plan. Do not ask again between batches, review rounds, verify runs, or commits within the same plan unless the user asks to revisit the workflow or circumstances materially change.
 
-In every task there is user review phase before final verify. After review is accepted and verify pass, offer PR notes as copypasteable code block and user will handle rest.
+For planning-heavy tasks, save the approved plan first under @docs/plans/ using a dated filename before implementation starts.
+
+For an approved multi-batch plan, treat all batches as part of the same task until the user declares the plan complete or redirects to a different task.
+
+If a proposed change would alter user-visible application behavior or semantics, stop and confirm with the user before implementing it. Do not make behavior-changing production edits based only on inference from a plan or coverage goal.
+
+In every task, include a user review phase before final verify. After review is accepted and verify passes, you can commit. After each user-accepted and verified batch, you may commit if useful as a checkpoint. Offer PR notes as a copy-pasteable code block only when the branch is fully implemented and ready for PR; user will handle the rest.

--- a/src/app/leaderboards/playoffs/leaderboard-playoffs.component.ts
+++ b/src/app/leaderboards/playoffs/leaderboard-playoffs.component.ts
@@ -41,7 +41,7 @@ export class LeaderboardPlayoffsComponent {
   readonly fetchFn = () => this.apiService.getLeaderboardPlayoffs();
   readonly columns: Column[] = [
     { field: 'displayPosition', align: 'left', sortable: false },
-    { field: 'teamName', align: 'left' },
+    { field: 'teamName', align: 'left', initialSortDirection: 'asc' },
     { field: 'championships', icon: { name: '🏆', type: 'emoji' } },
     { field: 'finals' },
     { field: 'conferenceFinals' },

--- a/src/app/leaderboards/regular/leaderboard-regular.component.ts
+++ b/src/app/leaderboards/regular/leaderboard-regular.component.ts
@@ -39,7 +39,7 @@ export class LeaderboardRegularComponent {
   readonly fetchFn = () => this.apiService.getLeaderboardRegular();
   readonly columns: Column[] = [
     { field: 'displayPosition', align: 'left', sortable: false },
-    { field: 'teamName', align: 'left' },
+    { field: 'teamName', align: 'left', initialSortDirection: 'asc' },
     { field: 'regularTrophies', icon: { name: '🏆', type: 'emoji' } },
     { field: 'points' },
     { field: 'wins' },

--- a/src/app/shared/stats-table/stats-table.component.spec.ts
+++ b/src/app/shared/stats-table/stats-table.component.spec.ts
@@ -40,9 +40,9 @@ class StatsTableHostComponent {
   searchLabelKey = 'table.playerSearch';
 
   readonly columns: Column[] = [
-    { field: 'name', align: 'left' },
-    { field: 'score', align: 'left', initialSortDirection: 'desc' },
-    { field: 'scoreAdjustedByGames', align: 'left', initialSortDirection: 'desc' },
+    { field: 'name', align: 'left', initialSortDirection: 'asc' },
+    { field: 'score', align: 'left' },
+    { field: 'scoreAdjustedByGames', align: 'left' },
   ];
 
   data = [

--- a/src/app/shared/stats-table/stats-table.component.ts
+++ b/src/app/shared/stats-table/stats-table.component.ts
@@ -406,7 +406,7 @@ export class StatsTableComponent implements AfterViewInit, OnDestroy {
   }
 
   getInitialSortDirection(column: Column): SortDirection {
-    return column.initialSortDirection ?? 'asc';
+    return column.initialSortDirection ?? 'desc';
   }
 
   getInstructionsTranslateKey(): string {

--- a/src/app/shared/stats-table/virtual-table.component.spec.ts
+++ b/src/app/shared/stats-table/virtual-table.component.spec.ts
@@ -32,9 +32,9 @@ class VirtualTableHostComponent {
   searchLabelKey = 'table.careerPlayerSearch';
 
   readonly columns: Column[] = [
-    { field: 'name', align: 'left' },
-    { field: 'score', initialSortDirection: 'desc' },
-    { field: 'regularGames', initialSortDirection: 'desc' },
+    { field: 'name', align: 'left', initialSortDirection: 'asc' },
+    { field: 'score' },
+    { field: 'regularGames' },
   ];
 
   readonly formatCell = (_row: unknown, column: string, value: number | string | undefined): string => {

--- a/src/app/shared/stats-table/virtual-table.component.ts
+++ b/src/app/shared/stats-table/virtual-table.component.ts
@@ -159,7 +159,7 @@ export class VirtualTableComponent implements AfterViewInit {
   }
 
   getInitialSortDirection(column: Column): SortDirection {
-    return column.initialSortDirection ?? 'asc';
+    return column.initialSortDirection ?? 'desc';
   }
 
   getCellClass(column: Column): { 'col-left': boolean; 'col-center': boolean } {

--- a/src/app/shared/table-columns.ts
+++ b/src/app/shared/table-columns.ts
@@ -1,7 +1,7 @@
 import { Column } from './column.types';
 
 const BASE_COLUMNS: Column[] = [
-  { field: 'name', align: 'left' },
+  { field: 'name', align: 'left', initialSortDirection: 'asc' },
   { field: 'score' },
   { field: 'scoreAdjustedByGames' },
   { field: 'games' },
@@ -27,7 +27,7 @@ const GOALIE_ONLY_COLUMNS: Column[] = [{ field: 'wins' }, { field: 'saves' }];
 const GOALIE_ONLY_COMBINED_COLUMNS: Column[] = [...GOALIE_ONLY_COLUMNS, { field: 'shutouts' }];
 const GOALIE_ONLY_SEASON_COLUMNS: Column[] = [
   ...GOALIE_ONLY_COLUMNS,
-  { field: 'gaa' },
+  { field: 'gaa', initialSortDirection: 'asc' },
   { field: 'savePercent' },
   { field: 'shutouts' },
 ];
@@ -37,16 +37,16 @@ export const GOALIE_COLUMNS: Column[] = [...BASE_COLUMNS, ...GOALIE_ONLY_COMBINE
 export const GOALIE_SEASON_COLUMNS: Column[] = [...BASE_COLUMNS, ...GOALIE_ONLY_SEASON_COLUMNS, ...COMMON_COLUMNS];
 
 const CAREER_COMMON_COLUMNS: Column[] = [
-  { field: 'seasonsOwned', initialSortDirection: 'desc' },
-  { field: 'seasonsPlayedRegular', initialSortDirection: 'desc' },
-  { field: 'seasonsPlayedPlayoffs', initialSortDirection: 'desc' },
-  { field: 'teamsOwned', initialSortDirection: 'desc' },
-  { field: 'teamsPlayedRegular', initialSortDirection: 'desc' },
-  { field: 'teamsPlayedPlayoffs', initialSortDirection: 'desc' },
-  { field: 'regularGames', initialSortDirection: 'desc' },
-  { field: 'playoffGames', initialSortDirection: 'desc' },
+  { field: 'seasonsOwned' },
+  { field: 'seasonsPlayedRegular' },
+  { field: 'seasonsPlayedPlayoffs' },
+  { field: 'teamsOwned' },
+  { field: 'teamsPlayedRegular' },
+  { field: 'teamsPlayedPlayoffs' },
+  { field: 'regularGames' },
+  { field: 'playoffGames' },
   { field: 'firstSeason', initialSortDirection: 'asc' },
-  { field: 'lastSeason', initialSortDirection: 'desc' },
+  { field: 'lastSeason' },
 ];
 
 export const CAREER_PLAYER_COLUMNS: Column[] = [


### PR DESCRIPTION
### Summary
- Changed default first-click sort direction from ascending to **descending** for all stat columns, making numeric values sort highest-first intuitively
- Columns that should sort ascending are explicitly marked: `name`, `teamName`, `gaa`, `firstSeason`
- Cleaned up redundant `initialSortDirection: 'desc'` from 8 career column definitions
- Updated CLAUDE.md with refined workflow instructions

### Test plan
- [x] `npm run verify` passes (lint + coverage + build)
- [x] Click any numeric stat column header → sorts descending (highest first)
- [x] Click player name or team name column → sorts ascending (A–Z)
- [x] Click GAA column in goalie season view → sorts ascending (lowest first)
