### PR TITLE
Feature: Career highlights

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,10 +9,12 @@ If documentation includes clearly bad decisions, challenge them and propose bett
 
 Always ask explicitly (with explanation) whether to use git worktree instead of a user-created branch before the first mutating step of a new implementation task or approved plan. Do not ask again between batches, review rounds, verify runs, or commits within the same plan unless the user asks to revisit the workflow or circumstances materially change.
 
-For planning-heavy tasks, save the approved plan first under `docs/plans/` using a dated filename before implementation starts.
+For planning-heavy tasks, save the approved plan first under `docs/plans/` using a dated filename before implementation starts. Plans in `docs/plans/` are intentionally gitignored local working files and must not be committed unless the user explicitly asks for that.
 
 For an approved multi-batch plan, treat all batches as part of the same task until the user declares the plan complete or redirects to a different task.
 
 If a proposed change would alter user-visible application behavior or semantics, stop and confirm with the user before implementing it. Do not make behavior-changing production edits based only on inference from a plan or coverage goal.
 
 In every task, include a user review phase before final verify. After review is accepted and verify passes, you can commit. After each user-accepted and verified batch, you may commit if useful as a checkpoint. Offer PR notes as a copy-pasteable code block only when the branch is fully implemented and ready for PR; user will handle the rest.
+
+If using Playwright MCP during a task, close the browser after you are done with it and no longer need it. Do not leave Playwright browser sessions open across unrelated steps or future sessions.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,10 +9,12 @@ If documentation includes clearly bad decisions, challenge them and propose bett
 
 Always ask explicitly (with explanation) whether to use git worktree instead of a user-created branch before the first mutating step of a new implementation task or approved plan. Do not ask again between batches, review rounds, verify runs, or commits within the same plan unless the user asks to revisit the workflow or circumstances materially change.
 
-For planning-heavy tasks, save the approved plan first under @docs/plans/ using a dated filename before implementation starts.
+For planning-heavy tasks, save the approved plan first under @docs/plans/ using a dated filename before implementation starts. Plans in @docs/plans/ are intentionally gitignored local working files and must not be committed unless the user explicitly asks for that.
 
 For an approved multi-batch plan, treat all batches as part of the same task until the user declares the plan complete or redirects to a different task.
 
 If a proposed change would alter user-visible application behavior or semantics, stop and confirm with the user before implementing it. Do not make behavior-changing production edits based only on inference from a plan or coverage goal.
 
 In every task, include a user review phase before final verify. After review is accepted and verify passes, you can commit. After each user-accepted and verified batch, you may commit if useful as a checkpoint. Offer PR notes as a copy-pasteable code block only when the branch is fully implemented and ready for PR; user will handle the rest.
+
+If using Playwright MCP during a task, close the browser after you are done with it and no longer need it. Do not leave Playwright browser sessions open across unrelated steps or future sessions.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Live showcase: https://ffhl-stats.vercel.app/
 	- Searchable and sortable, with no stats-page filters or mobile drawer
 	- Virtualized row rendering keeps long lists responsive
 	- Player rows show position inline with name (for example `D Travis Hamonic`) while still sorting alphabetically by player name
-	- `/career/highlights` adds compact paged highlight cards for focused career leaderboard slices such as most teams played and most seasons played with the same team
+	- `/career/highlights` adds compact paged highlight cards for focused career leaderboard slices such as most teams played/owned and most same-team seasons played/owned
 - 🚦 **Split Route Shells**: Interactive dashboard routes lazy-load their heavier shell (controls, settings drawer, comparison bar, tabs), while career and leaderboard browsing routes stay on a lighter root shell
 - 🗂️ **Global Navigation**: Bottom sheet menu for switching between views (hockey stats, player careers, leaderboards, info/help)
 - 🔗 **Direct Player Links**: Shareable URLs for player/goalie cards

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Live showcase: https://ffhl-stats.vercel.app/
 	- Searchable and sortable, with no stats-page filters or mobile drawer
 	- Virtualized row rendering keeps long lists responsive
 	- Player rows show position inline with name (for example `D Travis Hamonic`) while still sorting alphabetically by player name
+	- `/career/highlights` adds compact paged highlight cards for focused career leaderboard slices such as most teams played and most seasons played with the same team
 - 🚦 **Split Route Shells**: Interactive dashboard routes lazy-load their heavier shell (controls, settings drawer, comparison bar, tabs), while career and leaderboard browsing routes stay on a lighter root shell
 - 🗂️ **Global Navigation**: Bottom sheet menu for switching between views (hockey stats, player careers, leaderboards, info/help)
 - 🔗 **Direct Player Links**: Shareable URLs for player/goalie cards
@@ -47,6 +48,7 @@ Live showcase: https://ffhl-stats.vercel.app/
 - 🌐 **Internationalization**: i18n support with ngx-translate (currently ships with Finnish UI; additional languages can be added under `public/i18n/`)
 - 🎨 **Material Design**: Clean UI with Angular Material components
 - 🌓 **Automatic Dark Mode**: Follows device/browser `prefers-color-scheme` (no manual toggle)
+  - Every UI/styling change must be verified in both light mode and dark mode before review or merge
 - 📦 **Installable PWA**: Installable on desktop/mobile; app shell is cached for offline-friendly reloads (live stats still require the backend)
 - 📱 **Mobile Responsive**: Optimized for all screen sizes with adaptive layouts and collapsible controls
 - 🕒 **Last Updated Indicator**: Shows backend data last-modified timestamp under the title (desktop) and in the settings drawer (mobile)
@@ -175,7 +177,7 @@ For planning-heavy changes, save the approved implementation plan locally under 
 
 E2E tests are organized into feature-based specs under `e2e/specs/`:
 - `smoke.spec.ts` — Core page rendering and navigation
-- `career.spec.ts` — Career players/goalies tabs, search, sorting, and route shell behavior
+- `career.spec.ts` — Career players/goalies/highlights tabs, search, paging, and route shell behavior
 - `leaderboards.spec.ts` — Leaderboards redirect, table data, tab navigation, position tie logic, expandable season details
 - `player-card.spec.ts` — Player card dialog (open/close, tabs, graphs, direct URLs)
 - `team-switching.spec.ts` — Team selector and filter reset behavior
@@ -251,12 +253,13 @@ src/
 │   │   ├── player-card/   # Player detail dialog
 │   │   ├── settings-panel/# Settings UI (toggles/sliders)
 │   │   ├── stats-table/   # Reusable stats table + virtualized career table
+│   │   ├── table-card/    # Reusable paged card with semantic table layout
 │   │   ├── top-controls/  # Header controls (team/season/report switchers)
 │   │   └── table-columns.ts
 │   ├── player-stats/      # Player stats page
 │   ├── goalie-stats/      # Goalie stats page
 │   ├── dashboard-shell/   # Lazy shell for dashboard routes
-│   ├── career/            # Career listings (/career/players, /career/goalies)
+│   ├── career/            # Career listings + highlights (/career/players, /career/goalies, /career/highlights)
 │   ├── leaderboards/      # All-time leaderboards (/leaderboards/regular, /leaderboards/playoffs)
 │   ├── player-route/      # Direct player card route handler
 │   ├── goalie-route/      # Direct goalie card route handler

--- a/docs/README.md
+++ b/docs/README.md
@@ -45,6 +45,7 @@ Fantrax Stats Parser UI is an Angular 21 application that provides a user interf
 2. Follow existing patterns and conventions
 3. Update tests when modifying components or services
 4. Use Angular Material components consistently
+5. For every UI/styling change, verify the affected view in both light mode and dark mode before asking for review
 
 ### Adding Features
 1. Check existing components for similar patterns

--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -60,6 +60,7 @@ Implementation:
 
 - Skip link in the app shell
 - Target table container uses a stable `id` (default `stats-table`)
+- Career highlights reuse the career skip target (`career-table`) and move focus to the first available card row without adding those rows to normal tab order
 
 ### Stats table keyboard navigation
 

--- a/docs/codebase-structure.md
+++ b/docs/codebase-structure.md
@@ -16,7 +16,7 @@ fantrax-stats-parser-ui/
 │   │   ├── base/       # Base layout components
 │   │   │   ├── footer/
 │   │   │   └── navigation/
-│   │   ├── career/            # Career listings feature (shell + players and goalies child components)
+│   │   ├── career/            # Career listings feature (shell + players, goalies, and highlights child components)
 │   │   ├── dashboard-shell/   # Lazy route shell for interactive dashboard routes
 │   │   ├── goalie-stats/     # Goalie stats page
 │   │   ├── goalie-route/     # Direct goalie card route handler
@@ -46,6 +46,7 @@ fantrax-stats-parser-ui/
 │   │   │   │   ├── min-games-slider/
 │   │   │   │   └── stats-mode-toggle/
 │   │   │   ├── stats-table/
+│   │   │   ├── table-card/
 │   │   │   ├── top-controls/
 │   │   │   │   ├── report-switcher/
 │   │   │   │   ├── season-switcher/
@@ -85,10 +86,16 @@ Smart component for goalie statistics view:
 
 ### `/src/app/career/`
 Route shell and smart components for career listings:
-- Handles `/career/players` and `/career/goalies`
-- Renders tab navigation between career skaters and goalies
-- Uses dedicated backend endpoints and a virtualized read-only table
+- Handles `/career/players`, `/career/goalies`, and `/career/highlights`
+- Renders tab navigation between career skaters, goalies, and highlights
+- Uses dedicated backend endpoints and either a virtualized read-only table or compact paged table cards
 - Loads under the lighter root shell without dashboard-only controls, comparison bar, or mobile settings drawer
+
+### `/src/app/shared/table-card/`
+Reusable card-based read-only table presentation:
+- Semantic HTML table inside a Material card container
+- Server-side paging controls for compact leaderboard/highlight lists
+- Shared loading, empty, and API-error states for paged card views
 
 ### `/src/app/dashboard-shell/`
 Lazy route shell for the interactive dashboard experience:
@@ -156,6 +163,12 @@ Main data table component:
 - Column configuration
 - Row selection
 - Also contains `VirtualTableComponent`, used by career listings for virtualized rendering with shared table styling
+
+#### `table-card/`
+Compact paged card table component:
+- Semantic HTML table inside a Material card
+- Previous/next controls for server-paged highlight or leaderboard slices
+- Shared tooltip, loading, empty, and API-error presentation for read-only card lists
 
 #### `player-card/`
 Individual player information card display

--- a/docs/component-guide.md
+++ b/docs/component-guide.md
@@ -186,19 +186,34 @@ TeamService → PlayerStatsComponent (triggers refetch + adds teamId)
 
 ---
 
-### CareerPlayersComponent / CareerGoaliesComponent
+### CareerPlayersComponent / CareerGoaliesComponent / CareerHighlightsComponent
 
-**Location**: `src/app/career/players/`, `src/app/career/goalies/`
+**Location**: `src/app/career/players/`, `src/app/career/goalies/`, `src/app/career/highlights/`
 
 **Type**: Smart Components (Container)
 
-**Purpose**: Render the read-only all-time career tables under `/career/players` and `/career/goalies`
+**Purpose**: Render the read-only career browse views under `/career/players`, `/career/goalies`, and `/career/highlights`
 
 **Responsibilities**:
 
 - Fetch career rows from the dedicated API endpoints
 - Pass column definitions and formatters into the shared virtualized table
 - Keep the player career table sorted by plain `name` while rendering position inline with the displayed player name
+- Normalize paged highlight responses into the shared `TableCardComponent` row shape for the `/career/highlights` route
+
+### TableCardComponent
+
+**Location**: `src/app/shared/table-card/`
+
+**Type**: Shared Presentational Component
+
+**Purpose**: Render compact paged read-only leaderboards or highlight slices inside a Material card using semantic table markup.
+
+**Responsibilities**:
+
+- Show title/description copy, a semantic HTML table, and previous/next paging controls
+- Keep tooltip buttons and pagination controls keyboard accessible
+- Reuse shared loading, empty, and API-error states for compact card views
 
 ### LeaderboardComponent
 

--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -96,6 +96,11 @@ Use this as a local regression check after startup-bundle or rendering changes. 
 
 The UI follows the device/browser color scheme automatically (no manual toggle).
 
+Dark mode verification is mandatory for every UI/styling change.
+
+- Any new component, layout, card, table, dialog, tooltip, or color tweak must be checked in both light mode and dark mode before the task is considered done.
+- Do not assume a change is "too small" to affect dark mode.
+
 Key files:
 
 - `src/theme.scss`: Angular Material theme configuration (emits `--mat-sys-*` tokens via `theme-type: color-scheme`)
@@ -112,6 +117,12 @@ If the page looks like it’s using a stale/light bundle (common during theming 
 
 - Hard refresh: `Cmd+Shift+R`
 - If still wrong under `ng serve`, restart `npm start` (browser/dev-server caching can keep older CSS around)
+
+Before review/verify for any UI-facing change:
+
+- Check the changed view in light mode
+- Check the changed view in dark mode
+- Verify focus, hover, tooltip, loading, and empty/error states in the affected UI where relevant
 
 ### PWA (Installable App)
 

--- a/docs/project-overview.md
+++ b/docs/project-overview.md
@@ -78,7 +78,7 @@ Accessibility is a core requirement: the UI is designed to remain usable via key
    - Searchable and sortable without the stats-page controls/drawer/comparison bar
    - Player position is rendered inline with player name while sorting still uses the underlying plain `name`
    - Uses a virtualized table implementation to keep large result sets responsive
-   - The highlights tab uses compact paged table cards for focused leaderboard slices such as most teams played and most seasons played with the same team
+   - The highlights tab uses compact paged table cards for focused leaderboard slices such as most teams played/owned and most same-team seasons played/owned
 
 7. **Data Management**
    - Caching service to reduce API calls

--- a/docs/project-overview.md
+++ b/docs/project-overview.md
@@ -73,11 +73,12 @@ Accessibility is a core requirement: the UI is designed to remain usable via key
    - Expandable season breakdown rows per team (regular and playoffs) by clicking a team row, with multiple expanded rows allowed
    - Season breakdown rows can show trophy markers for winner/championship seasons
 
-6. **Career Listings** (`/career/players`, `/career/goalies`)
+6. **Career Listings & Highlights** (`/career/players`, `/career/goalies`, `/career/highlights`)
    - Dedicated all-time career tables for players and goalies
    - Searchable and sortable without the stats-page controls/drawer/comparison bar
    - Player position is rendered inline with player name while sorting still uses the underlying plain `name`
    - Uses a virtualized table implementation to keep large result sets responsive
+   - The highlights tab uses compact paged table cards for focused leaderboard slices such as most teams played and most seasons played with the same team
 
 7. **Data Management**
    - Caching service to reduce API calls
@@ -128,6 +129,7 @@ Accessibility is a core requirement: the UI is designed to remain usable via key
    - Browse routes:
      - `/career/players` - Player career listing
      - `/career/goalies` - Goalie career listing
+     - `/career/highlights` - Compact career highlight cards
      - `/leaderboards/regular` - Regular season all-time ranking table
      - `/leaderboards/playoffs` - Playoffs all-time ranking table
 

--- a/docs/project-requirements.md
+++ b/docs/project-requirements.md
@@ -1,7 +1,7 @@
 # Project Requirements & Standards
 
 **Project**: Fantrax Stats Parser UI
-**Last Updated**: March 8, 2026
+**Last Updated**: March 11, 2026
 
 ---
 
@@ -81,6 +81,16 @@ npm run test:coverage
   - Is focus always visible?
   - Does focus avoid collapsed/hidden areas?
   - Are labels/announcements meaningful?
+- **Action on Failure**: Fix before merging
+
+#### 6. ✅ Dark Mode Must Not Regress
+
+- **Requirement**: Every UI, styling, layout, color, or surface change must be checked in both light mode and dark mode before merging
+- **This is mandatory**: do not treat dark mode verification as optional polish or something to check only when a change is "theme related"
+- **Minimum checks (manual)**:
+  - Are text, icons, dividers, and surfaces readable in dark mode?
+  - Do hover, focus, selected, tooltip, dialog, and loading states still have sufficient contrast?
+  - Do new cards/tables/overlays use theme tokens or otherwise render correctly in both schemes?
 - **Action on Failure**: Fix before merging
 
 ---

--- a/docs/project-testing.md
+++ b/docs/project-testing.md
@@ -257,10 +257,11 @@ E2E tests are organized into feature-based spec files under `e2e/specs/`:
   - Collapsible controls
   - Touch interactions
 
-- **career.spec.ts** - Career listings
+- **career.spec.ts** - Career listings and highlights
   - Career route shell and global-navigation entry
-  - Player/goalie tab switching
+  - Player/goalie/highlights tab switching
   - Search and sort behavior in the virtualized career table
+  - Server-paged highlight card behavior
   - Route-specific shell behavior (no stats controls/drawer)
 
 **Supporting files:**
@@ -337,7 +338,7 @@ test('Filter by season', async ({ page }) => {
 **Core Functionality:**
 - ✅ Front page rendering and initial UI state
 - ✅ Navigation between Kenttäpelaajat and Maalivahdit tabs
-- ✅ Navigation between Pelaajaurat player/goalie tabs
+- ✅ Navigation between Pelaajaurat player/goalie/highlights tabs
 - ✅ Opening Player Card dialog with career tabs
 - ✅ Search filtering with "no results" state
 - ✅ Report type switching (Runkosarja ↔ Playoffs)

--- a/docs/service-guide.md
+++ b/docs/service-guide.md
@@ -132,6 +132,13 @@ class ApiService {
   // Fetch goalie statistics
   getGoalieData(params: ApiParams): Observable<Goalie[]>
 
+  // Fetch paged career highlight leaderboard slices
+  getCareerHighlights(
+    type: CareerHighlightType,
+    skip?: number,
+    take?: number
+  ): Observable<CareerHighlightPage>
+
   // Fetch available seasons for a given report type (regular/playoffs)
   // Optional `startFrom` filters out earlier seasons.
   getSeasons(reportType?: ReportType, teamId?: string, startFrom?: number): Observable<Season[]>

--- a/e2e/config/test-data.ts
+++ b/e2e/config/test-data.ts
@@ -34,6 +34,7 @@ export const TAB_LABELS = {
   GOALIES: 'Maalivahdit',
   CAREER_PLAYERS: 'Kenttäpelaajat',
   CAREER_GOALIES: 'Maalivahdit',
+  CAREER_HIGHLIGHTS: 'Nostot',
   PLAYER_CARD_STATS: 'Tilastot',
   PLAYER_CARD_BY_SEASON: 'Kausittain',
   PLAYER_CARD_GRAPHS: 'Graafit',

--- a/e2e/fixtures/data/career--highlights--most-teams-owned--skip=0--take=10.json
+++ b/e2e/fixtures/data/career--highlights--most-teams-owned--skip=0--take=10.json
@@ -1,0 +1,252 @@
+{
+  "type": "most-teams-owned",
+  "skip": 0,
+  "take": 10,
+  "total": 12,
+  "items": [
+    {
+      "id": "goalie-201",
+      "name": "Andrei Vasilevskiy",
+      "position": "G",
+      "teamCount": 6,
+      "teams": [
+        {
+          "id": "201",
+          "name": "Tampa Bay Lightning"
+        },
+        {
+          "id": "202",
+          "name": "Florida Panthers"
+        },
+        {
+          "id": "203",
+          "name": "Carolina Hurricanes"
+        },
+        {
+          "id": "204",
+          "name": "Ottawa Senators"
+        },
+        {
+          "id": "205",
+          "name": "Dallas Stars"
+        },
+        {
+          "id": "206",
+          "name": "Anaheim Ducks"
+        }
+      ]
+    },
+    {
+      "id": "player-202",
+      "name": "Claude Giroux",
+      "position": "F",
+      "teamCount": 5,
+      "teams": [
+        {
+          "id": "207",
+          "name": "Philadelphia Flyers"
+        },
+        {
+          "id": "208",
+          "name": "Ottawa Senators"
+        },
+        {
+          "id": "209",
+          "name": "Florida Panthers"
+        },
+        {
+          "id": "210",
+          "name": "Colorado Avalanche"
+        },
+        {
+          "id": "211",
+          "name": "Vancouver Canucks"
+        }
+      ]
+    },
+    {
+      "id": "player-203",
+      "name": "John Tavares",
+      "position": "F",
+      "teamCount": 5,
+      "teams": [
+        {
+          "id": "212",
+          "name": "New York Islanders"
+        },
+        {
+          "id": "213",
+          "name": "Toronto Maple Leafs"
+        },
+        {
+          "id": "214",
+          "name": "Seattle Kraken"
+        },
+        {
+          "id": "215",
+          "name": "St. Louis Blues"
+        },
+        {
+          "id": "216",
+          "name": "Buffalo Sabres"
+        }
+      ]
+    },
+    {
+      "id": "player-204",
+      "name": "Brent Burns",
+      "position": "D",
+      "teamCount": 4,
+      "teams": [
+        {
+          "id": "217",
+          "name": "Minnesota Wild"
+        },
+        {
+          "id": "218",
+          "name": "San Jose Sharks"
+        },
+        {
+          "id": "219",
+          "name": "Carolina Hurricanes"
+        },
+        {
+          "id": "220",
+          "name": "Florida Panthers"
+        }
+      ]
+    },
+    {
+      "id": "goalie-205",
+      "name": "Cam Talbot",
+      "position": "G",
+      "teamCount": 4,
+      "teams": [
+        {
+          "id": "221",
+          "name": "Edmonton Oilers"
+        },
+        {
+          "id": "222",
+          "name": "Calgary Flames"
+        },
+        {
+          "id": "223",
+          "name": "Los Angeles Kings"
+        },
+        {
+          "id": "224",
+          "name": "Minnesota Wild"
+        }
+      ]
+    },
+    {
+      "id": "player-206",
+      "name": "Ryan Nugent-Hopkins",
+      "position": "F",
+      "teamCount": 4,
+      "teams": [
+        {
+          "id": "225",
+          "name": "Edmonton Oilers"
+        },
+        {
+          "id": "226",
+          "name": "Seattle Kraken"
+        },
+        {
+          "id": "227",
+          "name": "Vegas Golden Knights"
+        },
+        {
+          "id": "228",
+          "name": "Nashville Predators"
+        }
+      ]
+    },
+    {
+      "id": "player-207",
+      "name": "Steven Stamkos",
+      "position": "F",
+      "teamCount": 4,
+      "teams": [
+        {
+          "id": "229",
+          "name": "Tampa Bay Lightning"
+        },
+        {
+          "id": "230",
+          "name": "Nashville Predators"
+        },
+        {
+          "id": "231",
+          "name": "Detroit Red Wings"
+        },
+        {
+          "id": "232",
+          "name": "New York Rangers"
+        }
+      ]
+    },
+    {
+      "id": "player-208",
+      "name": "Roman Josi",
+      "position": "D",
+      "teamCount": 3,
+      "teams": [
+        {
+          "id": "233",
+          "name": "Nashville Predators"
+        },
+        {
+          "id": "234",
+          "name": "Colorado Avalanche"
+        },
+        {
+          "id": "235",
+          "name": "Dallas Stars"
+        }
+      ]
+    },
+    {
+      "id": "player-209",
+      "name": "Mikko Rantanen",
+      "position": "F",
+      "teamCount": 3,
+      "teams": [
+        {
+          "id": "236",
+          "name": "Colorado Avalanche"
+        },
+        {
+          "id": "237",
+          "name": "Carolina Hurricanes"
+        },
+        {
+          "id": "238",
+          "name": "Chicago Blackhawks"
+        }
+      ]
+    },
+    {
+      "id": "goalie-210",
+      "name": "Jacob Markstrom",
+      "position": "G",
+      "teamCount": 3,
+      "teams": [
+        {
+          "id": "239",
+          "name": "Vancouver Canucks"
+        },
+        {
+          "id": "240",
+          "name": "Calgary Flames"
+        },
+        {
+          "id": "241",
+          "name": "New Jersey Devils"
+        }
+      ]
+    }
+  ]
+}

--- a/e2e/fixtures/data/career--highlights--most-teams-owned--skip=10--take=10.json
+++ b/e2e/fixtures/data/career--highlights--most-teams-owned--skip=10--take=10.json
@@ -1,0 +1,48 @@
+{
+  "type": "most-teams-owned",
+  "skip": 10,
+  "take": 10,
+  "total": 12,
+  "items": [
+    {
+      "id": "player-211",
+      "name": "Jonathan Huberdeau",
+      "position": "F",
+      "teamCount": 3,
+      "teams": [
+        {
+          "id": "242",
+          "name": "Florida Panthers"
+        },
+        {
+          "id": "243",
+          "name": "Calgary Flames"
+        },
+        {
+          "id": "244",
+          "name": "Montreal Canadiens"
+        }
+      ]
+    },
+    {
+      "id": "player-212",
+      "name": "Mikael Granlund",
+      "position": "F",
+      "teamCount": 3,
+      "teams": [
+        {
+          "id": "245",
+          "name": "Minnesota Wild"
+        },
+        {
+          "id": "246",
+          "name": "Nashville Predators"
+        },
+        {
+          "id": "247",
+          "name": "San Jose Sharks"
+        }
+      ]
+    }
+  ]
+}

--- a/e2e/fixtures/data/career--highlights--most-teams-played--skip=0--take=10.json
+++ b/e2e/fixtures/data/career--highlights--most-teams-played--skip=0--take=10.json
@@ -1,0 +1,126 @@
+{
+  "type": "most-teams-played",
+  "skip": 0,
+  "take": 10,
+  "total": 12,
+  "items": [
+    {
+      "id": "player-1",
+      "name": "Jamie Benn",
+      "position": "F",
+      "teamCount": 5,
+      "teams": [
+        { "id": "1", "name": "Colorado Avalanche" },
+        { "id": "2", "name": "Carolina Hurricanes" },
+        { "id": "3", "name": "Ottawa Senators" },
+        { "id": "4", "name": "Dallas Stars" },
+        { "id": "5", "name": "Boston Bruins" }
+      ]
+    },
+    {
+      "id": "player-2",
+      "name": "Phil Kessel",
+      "position": "F",
+      "teamCount": 5,
+      "teams": [
+        { "id": "6", "name": "Toronto Maple Leafs" },
+        { "id": "7", "name": "Pittsburgh Penguins" },
+        { "id": "8", "name": "Arizona Coyotes" },
+        { "id": "9", "name": "Vegas Golden Knights" },
+        { "id": "10", "name": "Vancouver Canucks" }
+      ]
+    },
+    {
+      "id": "player-3",
+      "name": "Brent Burns",
+      "position": "D",
+      "teamCount": 4,
+      "teams": [
+        { "id": "11", "name": "Minnesota Wild" },
+        { "id": "12", "name": "San Jose Sharks" },
+        { "id": "13", "name": "Carolina Hurricanes" },
+        { "id": "14", "name": "Florida Panthers" }
+      ]
+    },
+    {
+      "id": "player-4",
+      "name": "Jonathan Quick",
+      "position": "G",
+      "teamCount": 4,
+      "teams": [
+        { "id": "15", "name": "Los Angeles Kings" },
+        { "id": "16", "name": "Vegas Golden Knights" },
+        { "id": "17", "name": "New York Rangers" },
+        { "id": "18", "name": "New Jersey Devils" }
+      ]
+    },
+    {
+      "id": "player-5",
+      "name": "Ryan O'Reilly",
+      "position": "F",
+      "teamCount": 4,
+      "teams": [
+        { "id": "19", "name": "Colorado Avalanche" },
+        { "id": "20", "name": "Buffalo Sabres" },
+        { "id": "21", "name": "St. Louis Blues" },
+        { "id": "22", "name": "Nashville Predators" }
+      ]
+    },
+    {
+      "id": "player-6",
+      "name": "Tyler Seguin",
+      "position": "F",
+      "teamCount": 4,
+      "teams": [
+        { "id": "23", "name": "Boston Bruins" },
+        { "id": "24", "name": "Dallas Stars" },
+        { "id": "25", "name": "Seattle Kraken" },
+        { "id": "26", "name": "Calgary Flames" }
+      ]
+    },
+    {
+      "id": "player-7",
+      "name": "Jeff Skinner",
+      "position": "F",
+      "teamCount": 3,
+      "teams": [
+        { "id": "27", "name": "Carolina Hurricanes" },
+        { "id": "28", "name": "Buffalo Sabres" },
+        { "id": "29", "name": "Edmonton Oilers" }
+      ]
+    },
+    {
+      "id": "player-8",
+      "name": "Erik Karlsson",
+      "position": "D",
+      "teamCount": 3,
+      "teams": [
+        { "id": "30", "name": "Ottawa Senators" },
+        { "id": "31", "name": "San Jose Sharks" },
+        { "id": "32", "name": "Pittsburgh Penguins" }
+      ]
+    },
+    {
+      "id": "player-9",
+      "name": "Mikko Koskinen",
+      "position": "G",
+      "teamCount": 3,
+      "teams": [
+        { "id": "33", "name": "Edmonton Oilers" },
+        { "id": "34", "name": "Winnipeg Jets" },
+        { "id": "35", "name": "Columbus Blue Jackets" }
+      ]
+    },
+    {
+      "id": "player-10",
+      "name": "Dougie Hamilton",
+      "position": "D",
+      "teamCount": 3,
+      "teams": [
+        { "id": "36", "name": "Boston Bruins" },
+        { "id": "37", "name": "Calgary Flames" },
+        { "id": "38", "name": "New Jersey Devils" }
+      ]
+    }
+  ]
+}

--- a/e2e/fixtures/data/career--highlights--most-teams-played--skip=10--take=10.json
+++ b/e2e/fixtures/data/career--highlights--most-teams-played--skip=10--take=10.json
@@ -1,0 +1,30 @@
+{
+  "type": "most-teams-played",
+  "skip": 10,
+  "take": 10,
+  "total": 12,
+  "items": [
+    {
+      "id": "player-11",
+      "name": "Anthony Duclair",
+      "position": "F",
+      "teamCount": 3,
+      "teams": [
+        { "id": "39", "name": "Arizona Coyotes" },
+        { "id": "40", "name": "Florida Panthers" },
+        { "id": "41", "name": "Tampa Bay Lightning" }
+      ]
+    },
+    {
+      "id": "player-12",
+      "name": "Anton Stralman",
+      "position": "D",
+      "teamCount": 3,
+      "teams": [
+        { "id": "42", "name": "New York Rangers" },
+        { "id": "43", "name": "Tampa Bay Lightning" },
+        { "id": "44", "name": "Florida Panthers" }
+      ]
+    }
+  ]
+}

--- a/e2e/fixtures/data/career--highlights--same-team-seasons-owned--skip=0--take=10.json
+++ b/e2e/fixtures/data/career--highlights--same-team-seasons-owned--skip=0--take=10.json
@@ -1,0 +1,108 @@
+{
+  "type": "same-team-seasons-owned",
+  "skip": 0,
+  "take": 10,
+  "total": 11,
+  "items": [
+    {
+      "id": "player-301",
+      "name": "Sidney Crosby",
+      "position": "F",
+      "seasonCount": 11,
+      "team": {
+        "id": "301",
+        "name": "Pittsburgh Penguins"
+      }
+    },
+    {
+      "id": "goalie-302",
+      "name": "Andrei Vasilevskiy",
+      "position": "G",
+      "seasonCount": 10,
+      "team": {
+        "id": "302",
+        "name": "Tampa Bay Lightning"
+      }
+    },
+    {
+      "id": "player-303",
+      "name": "Victor Hedman",
+      "position": "D",
+      "seasonCount": 10,
+      "team": {
+        "id": "303",
+        "name": "Tampa Bay Lightning"
+      }
+    },
+    {
+      "id": "player-304",
+      "name": "Jamie Benn",
+      "position": "F",
+      "seasonCount": 9,
+      "team": {
+        "id": "304",
+        "name": "Dallas Stars"
+      }
+    },
+    {
+      "id": "player-305",
+      "name": "Aleksander Barkov",
+      "position": "F",
+      "seasonCount": 9,
+      "team": {
+        "id": "305",
+        "name": "Florida Panthers"
+      }
+    },
+    {
+      "id": "player-306",
+      "name": "Roman Josi",
+      "position": "D",
+      "seasonCount": 8,
+      "team": {
+        "id": "306",
+        "name": "Nashville Predators"
+      }
+    },
+    {
+      "id": "goalie-307",
+      "name": "Connor Hellebuyck",
+      "position": "G",
+      "seasonCount": 8,
+      "team": {
+        "id": "307",
+        "name": "Winnipeg Jets"
+      }
+    },
+    {
+      "id": "player-308",
+      "name": "Brad Marchand",
+      "position": "F",
+      "seasonCount": 8,
+      "team": {
+        "id": "308",
+        "name": "Boston Bruins"
+      }
+    },
+    {
+      "id": "player-309",
+      "name": "Mark Scheifele",
+      "position": "F",
+      "seasonCount": 8,
+      "team": {
+        "id": "309",
+        "name": "Winnipeg Jets"
+      }
+    },
+    {
+      "id": "player-310",
+      "name": "Anze Kopitar",
+      "position": "F",
+      "seasonCount": 8,
+      "team": {
+        "id": "310",
+        "name": "Los Angeles Kings"
+      }
+    }
+  ]
+}

--- a/e2e/fixtures/data/career--highlights--same-team-seasons-owned--skip=10--take=10.json
+++ b/e2e/fixtures/data/career--highlights--same-team-seasons-owned--skip=10--take=10.json
@@ -1,0 +1,18 @@
+{
+  "type": "same-team-seasons-owned",
+  "skip": 10,
+  "take": 10,
+  "total": 11,
+  "items": [
+    {
+      "id": "player-311",
+      "name": "John Carlson",
+      "position": "D",
+      "seasonCount": 8,
+      "team": {
+        "id": "311",
+        "name": "Washington Capitals"
+      }
+    }
+  ]
+}

--- a/e2e/fixtures/data/career--highlights--same-team-seasons-played--skip=0--take=10.json
+++ b/e2e/fixtures/data/career--highlights--same-team-seasons-played--skip=0--take=10.json
@@ -1,0 +1,78 @@
+{
+  "type": "same-team-seasons-played",
+  "skip": 0,
+  "take": 10,
+  "total": 11,
+  "items": [
+    {
+      "id": "player-101",
+      "name": "Jamie Benn",
+      "position": "F",
+      "seasonCount": 9,
+      "team": { "id": "1", "name": "Colorado Avalanche" }
+    },
+    {
+      "id": "player-102",
+      "name": "Victor Hedman",
+      "position": "D",
+      "seasonCount": 8,
+      "team": { "id": "2", "name": "Tampa Bay Lightning" }
+    },
+    {
+      "id": "player-103",
+      "name": "Marc-Andre Fleury",
+      "position": "G",
+      "seasonCount": 8,
+      "team": { "id": "3", "name": "Vegas Golden Knights" }
+    },
+    {
+      "id": "player-104",
+      "name": "Brent Burns",
+      "position": "D",
+      "seasonCount": 7,
+      "team": { "id": "4", "name": "San Jose Sharks" }
+    },
+    {
+      "id": "player-105",
+      "name": "Aleksander Barkov",
+      "position": "F",
+      "seasonCount": 7,
+      "team": { "id": "5", "name": "Florida Panthers" }
+    },
+    {
+      "id": "player-106",
+      "name": "Jonathan Quick",
+      "position": "G",
+      "seasonCount": 7,
+      "team": { "id": "6", "name": "Los Angeles Kings" }
+    },
+    {
+      "id": "player-107",
+      "name": "Roman Josi",
+      "position": "D",
+      "seasonCount": 6,
+      "team": { "id": "7", "name": "Nashville Predators" }
+    },
+    {
+      "id": "player-108",
+      "name": "Ryan O'Reilly",
+      "position": "F",
+      "seasonCount": 6,
+      "team": { "id": "8", "name": "St. Louis Blues" }
+    },
+    {
+      "id": "player-109",
+      "name": "Cam Talbot",
+      "position": "G",
+      "seasonCount": 6,
+      "team": { "id": "9", "name": "Edmonton Oilers" }
+    },
+    {
+      "id": "player-110",
+      "name": "Tyler Seguin",
+      "position": "F",
+      "seasonCount": 6,
+      "team": { "id": "10", "name": "Dallas Stars" }
+    }
+  ]
+}

--- a/e2e/fixtures/data/career--highlights--same-team-seasons-played--skip=10--take=10.json
+++ b/e2e/fixtures/data/career--highlights--same-team-seasons-played--skip=10--take=10.json
@@ -1,0 +1,15 @@
+{
+  "type": "same-team-seasons-played",
+  "skip": 10,
+  "take": 10,
+  "total": 11,
+  "items": [
+    {
+      "id": "player-111",
+      "name": "Nico Hischier",
+      "position": "F",
+      "seasonCount": 6,
+      "team": { "id": "11", "name": "New Jersey Devils" }
+    }
+  ]
+}

--- a/e2e/scripts/capture-fixtures.ts
+++ b/e2e/scripts/capture-fixtures.ts
@@ -98,8 +98,12 @@ async function buildFixtureList(): Promise<FixtureEntry[]> {
     // ── Career highlights ─────────────────────────────────────────────
     { path: 'career/highlights/most-teams-played', params: { skip: '0', take: '10' } },
     { path: 'career/highlights/most-teams-played', params: { skip: '10', take: '10' } },
+    { path: 'career/highlights/most-teams-owned', params: { skip: '0', take: '10' } },
+    { path: 'career/highlights/most-teams-owned', params: { skip: '10', take: '10' } },
     { path: 'career/highlights/same-team-seasons-played', params: { skip: '0', take: '10' } },
     { path: 'career/highlights/same-team-seasons-played', params: { skip: '10', take: '10' } },
+    { path: 'career/highlights/same-team-seasons-owned', params: { skip: '0', take: '10' } },
+    { path: 'career/highlights/same-team-seasons-owned', params: { skip: '10', take: '10' } },
   ];
 
   return entries;

--- a/e2e/scripts/capture-fixtures.ts
+++ b/e2e/scripts/capture-fixtures.ts
@@ -94,6 +94,12 @@ async function buildFixtureList(): Promise<FixtureEntry[]> {
 
     // ── Goalies — combined (for goalie tab tests) ────────────────────
     { path: 'goalies/combined/regular', params: { startFrom: oldest } },
+
+    // ── Career highlights ─────────────────────────────────────────────
+    { path: 'career/highlights/most-teams-played', params: { skip: '0', take: '10' } },
+    { path: 'career/highlights/most-teams-played', params: { skip: '10', take: '10' } },
+    { path: 'career/highlights/same-team-seasons-played', params: { skip: '0', take: '10' } },
+    { path: 'career/highlights/same-team-seasons-played', params: { skip: '10', take: '10' } },
   ];
 
   return entries;

--- a/e2e/specs/career.spec.ts
+++ b/e2e/specs/career.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from '../fixtures/test-fixture';
 import { TAB_LABELS } from '../config/test-data';
 
 test.describe('Career listings', () => {
-  test('redirects /career to players, renders the table, and switches to goalie careers', async ({ page }) => {
+  test('redirects /career to players, renders the table, switches to highlights, and then to goalie careers', async ({ page }) => {
     await page.goto('/career');
     await expect(page).toHaveURL(/\/career\/players$/);
 
@@ -17,6 +17,22 @@ test.describe('Career listings', () => {
 
     await page.getByLabel('Pelaajahaku').fill('Jamie');
     await expect(page.getByText('Jamie Benn')).toBeVisible();
+
+    const highlightsTab = page.getByRole('tab', { name: TAB_LABELS.CAREER_HIGHLIGHTS });
+    await highlightsTab.click();
+
+    await expect(page).toHaveURL(/\/career\/highlights$/);
+    await expect(highlightsTab).toHaveAttribute('aria-selected', 'true');
+    const highlightCards = page.locator('app-table-card');
+    await expect(highlightCards).toHaveCount(2);
+    await expect(highlightCards.first().getByRole('table')).toBeVisible();
+    await expect(highlightCards.nth(1).getByRole('table')).toBeVisible();
+
+    const mostTeamsCard = highlightCards.first();
+    const firstMostTeamsRow = mostTeamsCard.locator('tbody tr').first();
+    const firstMostTeamsRowText = (await firstMostTeamsRow.textContent())?.trim() ?? '';
+    await mostTeamsCard.getByRole('button', { name: 'Näytä seuraavat rivit' }).click();
+    await expect(firstMostTeamsRow).not.toHaveText(firstMostTeamsRowText);
 
     const goalieTab = page.getByRole('tab', { name: TAB_LABELS.CAREER_GOALIES });
     await goalieTab.click();

--- a/e2e/specs/career.spec.ts
+++ b/e2e/specs/career.spec.ts
@@ -24,9 +24,11 @@ test.describe('Career listings', () => {
     await expect(page).toHaveURL(/\/career\/highlights$/);
     await expect(highlightsTab).toHaveAttribute('aria-selected', 'true');
     const highlightCards = page.locator('app-table-card');
-    await expect(highlightCards).toHaveCount(2);
+    await expect(highlightCards).toHaveCount(4);
     await expect(highlightCards.first().getByRole('table')).toBeVisible();
     await expect(highlightCards.nth(1).getByRole('table')).toBeVisible();
+    await expect(highlightCards.nth(2).getByRole('table')).toBeVisible();
+    await expect(highlightCards.nth(3).getByRole('table')).toBeVisible();
 
     const mostTeamsCard = highlightCards.first();
     const firstMostTeamsRow = mostTeamsCard.locator('tbody tr').first();

--- a/public/i18n/fi.json
+++ b/public/i18n/fi.json
@@ -27,12 +27,20 @@
       },
       "cards": {
         "mostTeamsPlayed": {
-          "title": "Pelannut eniten eri seuroissa",
+          "title": "Eniten seuroja - pelanneet",
           "description": "Pelannut vähintään ottelun seurassa."
         },
+        "mostTeamsOwned": {
+          "title": "Eniten edustusseuroja",
+          "description": "Ollut seurassa vähintään käymässä."
+        },
         "sameTeamSeasonsPlayed": {
-          "title": "Eniten pelattuja kausia samassa seurassa",
-          "description": "Pelannut vähintään ottelun kaudella seurassa."
+          "title": "Eniten pelikausia - sama seura",
+          "description": "Pelannut vähintään ottelun joka kaudella."
+        },
+        "sameTeamSeasonsOwned": {
+          "title": "Eniten edustuskausia - sama seura",
+          "description": "Ollut seurassa joka kaudella."
         }
       }
     }

--- a/public/i18n/fi.json
+++ b/public/i18n/fi.json
@@ -15,7 +15,26 @@
   "career": {
     "tabs": {
       "players": "Kenttäpelaajat",
-      "goalies": "Maalivahdit"
+      "goalies": "Maalivahdit",
+      "highlights": "Nostot"
+    },
+    "highlights": {
+      "sectionTitle": "Uranostot",
+      "columns": {
+        "player": "Pelaaja",
+        "teamCount": "Seurat",
+        "seasonCount": "Kaudet"
+      },
+      "cards": {
+        "mostTeamsPlayed": {
+          "title": "Pelannut eniten eri seuroissa",
+          "description": "Pelannut vähintään ottelun seurassa."
+        },
+        "sameTeamSeasonsPlayed": {
+          "title": "Eniten pelattuja kausia samassa seurassa",
+          "description": "Pelannut vähintään ottelun kaudella seurassa."
+        }
+      }
     }
   },
   "leaderboards": {
@@ -71,6 +90,19 @@
     "loading": "Ladataan dataa...",
     "apiUnavailable": "Rajapinta ei ole saatavilla juuri nyt. Yritä hetken päästä uudelleen."
   },
+  "tableCard": {
+    "columns": {
+      "details": "Lisätiedot"
+    },
+    "showDetails": "Näytä lisätiedot: {{label}}",
+    "apiUnavailable": "Korttidata ei ole saatavilla juuri nyt. Yritä hetken päästä uudelleen.",
+    "noResults": "Ei tuloksia.",
+    "previous": "Edelliset",
+    "next": "Seuraavat",
+    "previousPage": "Näytä edelliset rivit",
+    "nextPage": "Näytä seuraavat rivit",
+    "paginationSummary": "{{start}}-{{end}} / {{total}}"
+  },
   "a11y": {
     "skipToTable": "Siirry taulukkoon",
     "openPlayerCard": "Avaa pelaajakortti: {{name}}",
@@ -120,7 +152,7 @@
         "type": "ul",
         "items": [
           "Pelaajatilastot: joukkuekohtaiset kenttäpelaaja- ja maalivahtitilastot, suodattimet, vertailu ja pelaajakortit",
-          "Pelaajaurat: kaikkien aikojen urataulukot kenttäpelaajille ja maalivahdeille",
+          "Pelaajaurat: kaikkien aikojen urataulukot kenttäpelaajille ja maalivahdeille sekä uranostot",
           "Maratontaulukot: joukkueiden kaikkien aikojen runkosarja- ja playoff-menestys kausierittelyineen"
         ]
       },
@@ -152,7 +184,7 @@
       },
       {
         "type": "p",
-        "text": "Pelaajaurat-näkymä näyttää koko liigan urayhteenvedot erikseen kenttäpelaajille ja maalivahdeille. Taulukot ovat hakukelpoisia ja lajiteltavia, mutta niissä ei käytetä joukkue- tai kausisuodattimia kuten pelaajatilastoissa."
+        "text": "Pelaajaurat-näkymä näyttää koko liigan urayhteenvedot erikseen kenttäpelaajille ja maalivahdeille. Taulukot ovat hakukelpoisia ja lajiteltavia, mutta niissä ei käytetä joukkue- tai kausisuodattimia kuten pelaajatilastoissa. Nostot-välilehdellä näet lisäksi tiiviit kärkilistat uran eri huipuista."
       },
       {
         "type": "h2",

--- a/src/app/app.component.mobile.spec.ts
+++ b/src/app/app.component.mobile.spec.ts
@@ -273,9 +273,15 @@ describe('AppComponent — mobile frontpage', { timeout: 60_000 }, () => {
       await screen.findByRole('heading', { name: 'career.highlights.cards.mostTeamsPlayed.title' })
     ).toBeInTheDocument();
     expect(
+      screen.getByRole('heading', { name: 'career.highlights.cards.mostTeamsOwned.title' })
+    ).toBeInTheDocument();
+    expect(
       screen.getByRole('heading', { name: 'career.highlights.cards.sameTeamSeasonsPlayed.title' })
     ).toBeInTheDocument();
-    expect(screen.getAllByRole('table')).toHaveLength(2);
+    expect(
+      screen.getByRole('heading', { name: 'career.highlights.cards.sameTeamSeasonsOwned.title' })
+    ).toBeInTheDocument();
+    expect(screen.getAllByRole('table')).toHaveLength(4);
 
     fireEvent.click(screen.getByRole('tab', { name: 'career.tabs.goalies' }));
 

--- a/src/app/app.component.mobile.spec.ts
+++ b/src/app/app.component.mobile.spec.ts
@@ -258,6 +258,7 @@ describe('AppComponent — mobile frontpage', { timeout: 60_000 }, () => {
 
     expect(await screen.findByRole('tab', { name: 'career.tabs.players' })).toBeInTheDocument();
     expect(screen.getByRole('tab', { name: 'career.tabs.goalies' })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'career.tabs.highlights' })).toBeInTheDocument();
     expect(screen.getByRole('table')).toBeInTheDocument();
     expect(screen.getByLabelText('table.careerPlayerSearch')).toBeInTheDocument();
 
@@ -265,6 +266,16 @@ describe('AppComponent — mobile frontpage', { timeout: 60_000 }, () => {
       screen.queryByRole('button', { name: 'a11y.openSettingsDrawer' })
     ).not.toBeInTheDocument();
     expect(screen.queryByText(/team\.selector:/)).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('tab', { name: 'career.tabs.highlights' }));
+
+    expect(
+      await screen.findByRole('heading', { name: 'career.highlights.cards.mostTeamsPlayed.title' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: 'career.highlights.cards.sameTeamSeasonsPlayed.title' })
+    ).toBeInTheDocument();
+    expect(screen.getAllByRole('table')).toHaveLength(2);
 
     fireEvent.click(screen.getByRole('tab', { name: 'career.tabs.goalies' }));
 

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -52,6 +52,13 @@ export const routes: Routes = [
             (m) => m.CareerGoaliesComponent
           ),
       },
+      {
+        path: 'highlights',
+        loadComponent: () =>
+          import('./career/highlights/career-highlights.component').then(
+            (m) => m.CareerHighlightsComponent
+          ),
+      },
     ],
   },
   {

--- a/src/app/career/career.component.ts
+++ b/src/app/career/career.component.ts
@@ -1,4 +1,5 @@
-import { Component, ViewChild, inject, OnInit, ChangeDetectorRef } from '@angular/core';
+import { ChangeDetectorRef, Component, DestroyRef, OnInit, ViewChild, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { RouterLink, RouterOutlet, Router } from '@angular/router';
 import { TranslateModule } from '@ngx-translate/core';
 import { MatTabNavPanel, MatTabsModule } from '@angular/material/tabs';
@@ -14,19 +15,24 @@ export class CareerComponent implements OnInit {
 
   private readonly router = inject(Router);
   private readonly cdr = inject(ChangeDetectorRef);
+  private readonly destroyRef = inject(DestroyRef);
 
   activeLink = '';
 
   readonly tabs = [
     { label: 'career.tabs.players', path: '/career/players' },
     { label: 'career.tabs.goalies', path: '/career/goalies' },
+    { label: 'career.tabs.highlights', path: '/career/highlights' },
   ];
 
   ngOnInit(): void {
-    this.router.events.subscribe(() => {
-      this.activeLink = this.router.url.split('?')[0];
-      this.cdr.detectChanges();
-    });
     this.activeLink = this.router.url.split('?')[0];
+
+    this.router.events
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(() => {
+        this.activeLink = this.router.url.split('?')[0];
+        this.cdr.detectChanges();
+      });
   }
 }

--- a/src/app/career/highlights/career-highlights.component.html
+++ b/src/app/career/highlights/career-highlights.component.html
@@ -8,34 +8,21 @@
   </h3>
 
   <div class="career-highlights-grid">
-    <app-table-card
-      [titleKey]="mostTeamsPlayedState().titleKey"
-      [descriptionKey]="mostTeamsPlayedState().descriptionKey"
-      primaryColumnLabelKey="career.highlights.columns.player"
-      [valueColumnLabelKey]="mostTeamsPlayedState().valueColumnLabelKey"
-      [rows]="mostTeamsPlayedState().rows"
-      [loading]="mostTeamsPlayedState().loading"
-      [apiError]="mostTeamsPlayedState().apiError"
-      [skip]="mostTeamsPlayedState().skip"
-      [take]="mostTeamsPlayedState().take"
-      [total]="mostTeamsPlayedState().total"
-      (previousPageRequested)="loadPreviousPage('most-teams-played')"
-      (nextPageRequested)="loadNextPage('most-teams-played')"
-    />
-
-    <app-table-card
-      [titleKey]="sameTeamSeasonsPlayedState().titleKey"
-      [descriptionKey]="sameTeamSeasonsPlayedState().descriptionKey"
-      primaryColumnLabelKey="career.highlights.columns.player"
-      [valueColumnLabelKey]="sameTeamSeasonsPlayedState().valueColumnLabelKey"
-      [rows]="sameTeamSeasonsPlayedState().rows"
-      [loading]="sameTeamSeasonsPlayedState().loading"
-      [apiError]="sameTeamSeasonsPlayedState().apiError"
-      [skip]="sameTeamSeasonsPlayedState().skip"
-      [take]="sameTeamSeasonsPlayedState().take"
-      [total]="sameTeamSeasonsPlayedState().total"
-      (previousPageRequested)="loadPreviousPage('same-team-seasons-played')"
-      (nextPageRequested)="loadNextPage('same-team-seasons-played')"
-    />
+    @for (card of cards(); track card.type) {
+      <app-table-card
+        [titleKey]="card.state.titleKey"
+        [descriptionKey]="card.state.descriptionKey"
+        primaryColumnLabelKey="career.highlights.columns.player"
+        [valueColumnLabelKey]="card.state.valueColumnLabelKey"
+        [rows]="card.state.rows"
+        [loading]="card.state.loading"
+        [apiError]="card.state.apiError"
+        [skip]="card.state.skip"
+        [take]="card.state.take"
+        [total]="card.state.total"
+        (previousPageRequested)="loadPreviousPage(card.type)"
+        (nextPageRequested)="loadNextPage(card.type)"
+      />
+    }
   </div>
 </section>

--- a/src/app/career/highlights/career-highlights.component.html
+++ b/src/app/career/highlights/career-highlights.component.html
@@ -1,0 +1,41 @@
+<section
+  class="career-highlights"
+  id="career-table"
+  aria-labelledby="career-highlights-title"
+>
+  <h3 id="career-highlights-title" class="sr-only">
+    {{ 'career.highlights.sectionTitle' | translate }}
+  </h3>
+
+  <div class="career-highlights-grid">
+    <app-table-card
+      [titleKey]="mostTeamsPlayedState().titleKey"
+      [descriptionKey]="mostTeamsPlayedState().descriptionKey"
+      primaryColumnLabelKey="career.highlights.columns.player"
+      [valueColumnLabelKey]="mostTeamsPlayedState().valueColumnLabelKey"
+      [rows]="mostTeamsPlayedState().rows"
+      [loading]="mostTeamsPlayedState().loading"
+      [apiError]="mostTeamsPlayedState().apiError"
+      [skip]="mostTeamsPlayedState().skip"
+      [take]="mostTeamsPlayedState().take"
+      [total]="mostTeamsPlayedState().total"
+      (previousPageRequested)="loadPreviousPage('most-teams-played')"
+      (nextPageRequested)="loadNextPage('most-teams-played')"
+    />
+
+    <app-table-card
+      [titleKey]="sameTeamSeasonsPlayedState().titleKey"
+      [descriptionKey]="sameTeamSeasonsPlayedState().descriptionKey"
+      primaryColumnLabelKey="career.highlights.columns.player"
+      [valueColumnLabelKey]="sameTeamSeasonsPlayedState().valueColumnLabelKey"
+      [rows]="sameTeamSeasonsPlayedState().rows"
+      [loading]="sameTeamSeasonsPlayedState().loading"
+      [apiError]="sameTeamSeasonsPlayedState().apiError"
+      [skip]="sameTeamSeasonsPlayedState().skip"
+      [take]="sameTeamSeasonsPlayedState().take"
+      [total]="sameTeamSeasonsPlayedState().total"
+      (previousPageRequested)="loadPreviousPage('same-team-seasons-played')"
+      (nextPageRequested)="loadNextPage('same-team-seasons-played')"
+    />
+  </div>
+</section>

--- a/src/app/career/highlights/career-highlights.component.scss
+++ b/src/app/career/highlights/career-highlights.component.scss
@@ -1,0 +1,21 @@
+:host {
+  display: block;
+}
+
+.career-highlights {
+  width: 100%;
+}
+
+.career-highlights-grid {
+  display: grid;
+  margin: 24px;
+  gap: 20px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  align-items: stretch;
+}
+
+@media (max-width: 900px) {
+  .career-highlights-grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}

--- a/src/app/career/highlights/career-highlights.component.scss
+++ b/src/app/career/highlights/career-highlights.component.scss
@@ -19,3 +19,10 @@
     grid-template-columns: minmax(0, 1fr);
   }
 }
+
+@media (max-width: 480px) {
+  .career-highlights-grid {
+    margin: 12px 8px;
+    gap: 12px;
+  }
+}

--- a/src/app/career/highlights/career-highlights.component.spec.ts
+++ b/src/app/career/highlights/career-highlights.component.spec.ts
@@ -5,26 +5,33 @@ import { of, throwError } from 'rxjs';
 import { ApiService, CareerHighlightType } from '@services/api.service';
 import { FooterVisibilityService } from '@services/footer-visibility.service';
 import {
+  mostTeamsOwnedHighlightsPage0Fixture,
   mostTeamsPlayedHighlightsPage0Fixture,
   mostTeamsPlayedHighlightsPage1Fixture,
   provideDisabledMaterialAnimations,
+  sameTeamSeasonsOwnedHighlightsPage0Fixture,
   sameTeamSeasonsHighlightsPage0Fixture,
 } from '../../testing/behavior-test-utils';
 import { CareerHighlightsComponent } from './career-highlights.component';
 
 describe('CareerHighlightsComponent', () => {
-  it('renders both highlight cards and pages the first card forward', async () => {
+  it('renders all configured highlight cards and pages the first card forward', async () => {
     const getCareerHighlights = vi.fn(
       (type: CareerHighlightType, skip = 0) => {
-        if (type === 'most-teams-played') {
-          return of(
-            skip >= 10
-              ? mostTeamsPlayedHighlightsPage1Fixture
-              : mostTeamsPlayedHighlightsPage0Fixture
-          );
+        switch (type) {
+          case 'most-teams-played':
+            return of(
+              skip >= 10
+                ? mostTeamsPlayedHighlightsPage1Fixture
+                : mostTeamsPlayedHighlightsPage0Fixture
+            );
+          case 'most-teams-owned':
+            return of(mostTeamsOwnedHighlightsPage0Fixture);
+          case 'same-team-seasons-played':
+            return of(sameTeamSeasonsHighlightsPage0Fixture);
+          case 'same-team-seasons-owned':
+            return of(sameTeamSeasonsOwnedHighlightsPage0Fixture);
         }
-
-        return of(sameTeamSeasonsHighlightsPage0Fixture);
       }
     );
 
@@ -47,17 +54,32 @@ describe('CareerHighlightsComponent', () => {
     ).toBeInTheDocument();
     expect(
       screen.getByRole('heading', {
+        name: 'career.highlights.cards.mostTeamsOwned.title',
+      })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', {
         name: 'career.highlights.cards.sameTeamSeasonsPlayed.title',
+      })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', {
+        name: 'career.highlights.cards.sameTeamSeasonsOwned.title',
       })
     ).toBeInTheDocument();
     const mostTeamsCardTitle = screen.getByRole('heading', {
       name: 'career.highlights.cards.mostTeamsPlayed.title',
     });
+    const sameTeamPlayedCardTitle = screen.getByRole('heading', {
+      name: 'career.highlights.cards.sameTeamSeasonsPlayed.title',
+    });
     const mostTeamsCard = mostTeamsCardTitle.closest('mat-card') as HTMLElement | null;
+    const sameTeamPlayedCard = sameTeamPlayedCardTitle.closest('mat-card') as HTMLElement | null;
 
     expect(mostTeamsCard).not.toBeNull();
+    expect(sameTeamPlayedCard).not.toBeNull();
     expect(within(mostTeamsCard!).getByText('F Jamie Benn')).toBeInTheDocument();
-    expect(screen.getByText('D Victor Hedman')).toBeInTheDocument();
+    expect(within(sameTeamPlayedCard!).getByText('D Victor Hedman')).toBeInTheDocument();
 
     fireEvent.click(screen.getAllByRole('button', { name: 'tableCard.nextPage' })[0]);
 
@@ -66,7 +88,7 @@ describe('CareerHighlightsComponent', () => {
     expect(getCareerHighlights).toHaveBeenCalledWith('most-teams-played', 10, 10);
   });
 
-  it('shows an error state for a failing card without hiding the successful card', async () => {
+  it('shows an error state for a failing card without hiding the successful cards', async () => {
     await render(CareerHighlightsComponent, {
       imports: [TranslateModule.forRoot()],
       providers: [
@@ -76,15 +98,39 @@ describe('CareerHighlightsComponent', () => {
           provide: ApiService,
           useValue: {
             getCareerHighlights: (type: CareerHighlightType) =>
-              type === 'same-team-seasons-played'
-                ? throwError(() => new Error('same team highlights failed'))
-                : of(mostTeamsPlayedHighlightsPage0Fixture),
+              type === 'same-team-seasons-owned'
+                ? throwError(() => new Error('same team owned highlights failed'))
+                : of(
+                  type === 'most-teams-owned'
+                    ? mostTeamsOwnedHighlightsPage0Fixture
+                    : type === 'same-team-seasons-played'
+                      ? sameTeamSeasonsHighlightsPage0Fixture
+                      : mostTeamsPlayedHighlightsPage0Fixture
+                ),
           },
         },
       ],
     });
 
-    expect(await screen.findByText('F Jamie Benn')).toBeInTheDocument();
-    expect(screen.getByText('tableCard.apiUnavailable')).toBeInTheDocument();
+    const mostTeamsPlayedCardTitle = await screen.findByRole('heading', {
+      name: 'career.highlights.cards.mostTeamsPlayed.title',
+    });
+    const mostTeamsOwnedCardTitle = screen.getByRole('heading', {
+      name: 'career.highlights.cards.mostTeamsOwned.title',
+    });
+    const sameTeamOwnedCardTitle = screen.getByRole('heading', {
+      name: 'career.highlights.cards.sameTeamSeasonsOwned.title',
+    });
+
+    const mostTeamsPlayedCard = mostTeamsPlayedCardTitle.closest('mat-card') as HTMLElement | null;
+    const mostTeamsOwnedCard = mostTeamsOwnedCardTitle.closest('mat-card') as HTMLElement | null;
+    const sameTeamOwnedCard = sameTeamOwnedCardTitle.closest('mat-card') as HTMLElement | null;
+
+    expect(mostTeamsPlayedCard).not.toBeNull();
+    expect(mostTeamsOwnedCard).not.toBeNull();
+    expect(sameTeamOwnedCard).not.toBeNull();
+    expect(within(mostTeamsPlayedCard!).getByText('F Jamie Benn')).toBeInTheDocument();
+    expect(within(mostTeamsOwnedCard!).getByText('G Andrei Vasilevskiy')).toBeInTheDocument();
+    expect(within(sameTeamOwnedCard!).getByText('tableCard.apiUnavailable')).toBeInTheDocument();
   });
 });

--- a/src/app/career/highlights/career-highlights.component.spec.ts
+++ b/src/app/career/highlights/career-highlights.component.spec.ts
@@ -1,0 +1,90 @@
+import { fireEvent, render, screen, within } from '@testing-library/angular';
+import { TranslateModule } from '@ngx-translate/core';
+import { of, throwError } from 'rxjs';
+
+import { ApiService, CareerHighlightType } from '@services/api.service';
+import { FooterVisibilityService } from '@services/footer-visibility.service';
+import {
+  mostTeamsPlayedHighlightsPage0Fixture,
+  mostTeamsPlayedHighlightsPage1Fixture,
+  provideDisabledMaterialAnimations,
+  sameTeamSeasonsHighlightsPage0Fixture,
+} from '../../testing/behavior-test-utils';
+import { CareerHighlightsComponent } from './career-highlights.component';
+
+describe('CareerHighlightsComponent', () => {
+  it('renders both highlight cards and pages the first card forward', async () => {
+    const getCareerHighlights = vi.fn(
+      (type: CareerHighlightType, skip = 0) => {
+        if (type === 'most-teams-played') {
+          return of(
+            skip >= 10
+              ? mostTeamsPlayedHighlightsPage1Fixture
+              : mostTeamsPlayedHighlightsPage0Fixture
+          );
+        }
+
+        return of(sameTeamSeasonsHighlightsPage0Fixture);
+      }
+    );
+
+    await render(CareerHighlightsComponent, {
+      imports: [TranslateModule.forRoot()],
+      providers: [
+        provideDisabledMaterialAnimations(),
+        FooterVisibilityService,
+        {
+          provide: ApiService,
+          useValue: {
+            getCareerHighlights,
+          },
+        },
+      ],
+    });
+
+    expect(
+      await screen.findByRole('heading', { name: 'career.highlights.cards.mostTeamsPlayed.title' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', {
+        name: 'career.highlights.cards.sameTeamSeasonsPlayed.title',
+      })
+    ).toBeInTheDocument();
+    const mostTeamsCardTitle = screen.getByRole('heading', {
+      name: 'career.highlights.cards.mostTeamsPlayed.title',
+    });
+    const mostTeamsCard = mostTeamsCardTitle.closest('mat-card') as HTMLElement | null;
+
+    expect(mostTeamsCard).not.toBeNull();
+    expect(within(mostTeamsCard!).getByText('F Jamie Benn')).toBeInTheDocument();
+    expect(screen.getByText('D Victor Hedman')).toBeInTheDocument();
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'tableCard.nextPage' })[0]);
+
+    expect(await within(mostTeamsCard!).findByText('F Anthony Duclair')).toBeInTheDocument();
+    expect(within(mostTeamsCard!).queryByText('F Jamie Benn')).not.toBeInTheDocument();
+    expect(getCareerHighlights).toHaveBeenCalledWith('most-teams-played', 10, 10);
+  });
+
+  it('shows an error state for a failing card without hiding the successful card', async () => {
+    await render(CareerHighlightsComponent, {
+      imports: [TranslateModule.forRoot()],
+      providers: [
+        provideDisabledMaterialAnimations(),
+        FooterVisibilityService,
+        {
+          provide: ApiService,
+          useValue: {
+            getCareerHighlights: (type: CareerHighlightType) =>
+              type === 'same-team-seasons-played'
+                ? throwError(() => new Error('same team highlights failed'))
+                : of(mostTeamsPlayedHighlightsPage0Fixture),
+          },
+        },
+      ],
+    });
+
+    expect(await screen.findByText('F Jamie Benn')).toBeInTheDocument();
+    expect(screen.getByText('tableCard.apiUnavailable')).toBeInTheDocument();
+  });
+});

--- a/src/app/career/highlights/career-highlights.component.ts
+++ b/src/app/career/highlights/career-highlights.component.ts
@@ -1,4 +1,13 @@
-import { ChangeDetectionStrategy, Component, DestroyRef, OnInit, WritableSignal, inject, signal } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  DestroyRef,
+  OnInit,
+  WritableSignal,
+  computed,
+  inject,
+  signal,
+} from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { TranslateModule } from '@ngx-translate/core';
 
@@ -13,7 +22,7 @@ import { FooterVisibilityService } from '@services/footer-visibility.service';
 import { TableCardComponent } from '@shared/table-card/table-card.component';
 import { TableCardRow } from '@shared/table-card/table-card.types';
 
-import { CareerHighlightCardState } from './career-highlights.types';
+import { CareerHighlightCardState, CareerHighlightCardView } from './career-highlights.types';
 
 const PAGE_SIZE = 10;
 
@@ -37,6 +46,27 @@ const SAME_TEAM_SEASONS_PLAYED_CONFIG: HighlightCardConfig = {
   descriptionKey: 'career.highlights.cards.sameTeamSeasonsPlayed.description',
   valueColumnLabelKey: 'career.highlights.columns.seasonCount',
 };
+
+const MOST_TEAMS_OWNED_CONFIG: HighlightCardConfig = {
+  type: 'most-teams-owned',
+  titleKey: 'career.highlights.cards.mostTeamsOwned.title',
+  descriptionKey: 'career.highlights.cards.mostTeamsOwned.description',
+  valueColumnLabelKey: 'career.highlights.columns.teamCount',
+};
+
+const SAME_TEAM_SEASONS_OWNED_CONFIG: HighlightCardConfig = {
+  type: 'same-team-seasons-owned',
+  titleKey: 'career.highlights.cards.sameTeamSeasonsOwned.title',
+  descriptionKey: 'career.highlights.cards.sameTeamSeasonsOwned.description',
+  valueColumnLabelKey: 'career.highlights.columns.seasonCount',
+};
+
+const HIGHLIGHT_CARD_CONFIGS: readonly HighlightCardConfig[] = [
+  MOST_TEAMS_PLAYED_CONFIG,
+  MOST_TEAMS_OWNED_CONFIG,
+  SAME_TEAM_SEASONS_PLAYED_CONFIG,
+  SAME_TEAM_SEASONS_OWNED_CONFIG,
+];
 
 function createInitialCardState(config: HighlightCardConfig): CareerHighlightCardState {
   return {
@@ -64,11 +94,21 @@ export class CareerHighlightsComponent implements OnInit {
   private readonly destroyRef = inject(DestroyRef);
   private readonly footerVisibilityService = inject(FooterVisibilityService);
 
-  readonly mostTeamsPlayedState = signal(
-    createInitialCardState(MOST_TEAMS_PLAYED_CONFIG),
-  );
-  readonly sameTeamSeasonsPlayedState = signal(
-    createInitialCardState(SAME_TEAM_SEASONS_PLAYED_CONFIG),
+  private readonly cardSignals: Record<
+    CareerHighlightType,
+    WritableSignal<CareerHighlightCardState>
+  > = {
+    'most-teams-played': signal(createInitialCardState(MOST_TEAMS_PLAYED_CONFIG)),
+    'most-teams-owned': signal(createInitialCardState(MOST_TEAMS_OWNED_CONFIG)),
+    'same-team-seasons-played': signal(createInitialCardState(SAME_TEAM_SEASONS_PLAYED_CONFIG)),
+    'same-team-seasons-owned': signal(createInitialCardState(SAME_TEAM_SEASONS_OWNED_CONFIG)),
+  };
+
+  readonly cards = computed<readonly CareerHighlightCardView[]>(() =>
+    HIGHLIGHT_CARD_CONFIGS.map((config) => ({
+      type: config.type,
+      state: this.cardSignals[config.type](),
+    })),
   );
 
   private footerVisibilityCycle = 0;
@@ -76,10 +116,11 @@ export class CareerHighlightsComponent implements OnInit {
 
   ngOnInit(): void {
     this.footerVisibilityCycle = this.footerVisibilityService.currentCycle();
-    this.pendingInitialLoads = 2;
+    this.pendingInitialLoads = HIGHLIGHT_CARD_CONFIGS.length;
 
-    this.loadCard(MOST_TEAMS_PLAYED_CONFIG.type, 0, true);
-    this.loadCard(SAME_TEAM_SEASONS_PLAYED_CONFIG.type, 0, true);
+    for (const config of HIGHLIGHT_CARD_CONFIGS) {
+      this.loadCard(config.type, 0, true);
+    }
   }
 
   loadPreviousPage(type: CareerHighlightType): void {
@@ -183,9 +224,7 @@ export class CareerHighlightsComponent implements OnInit {
   }
 
   private getCardSignal(type: CareerHighlightType): WritableSignal<CareerHighlightCardState> {
-    return type === MOST_TEAMS_PLAYED_CONFIG.type
-      ? this.mostTeamsPlayedState
-      : this.sameTeamSeasonsPlayedState;
+    return this.cardSignals[type];
   }
 
   private markInitialLoadReady(initialLoad: boolean): void {

--- a/src/app/career/highlights/career-highlights.component.ts
+++ b/src/app/career/highlights/career-highlights.component.ts
@@ -1,0 +1,201 @@
+import { ChangeDetectionStrategy, Component, DestroyRef, OnInit, WritableSignal, inject, signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { TranslateModule } from '@ngx-translate/core';
+
+import {
+  ApiService,
+  CareerHighlightPage,
+  CareerSameTeamHighlightPage,
+  CareerTeamCountHighlightPage,
+  CareerHighlightType,
+} from '@services/api.service';
+import { FooterVisibilityService } from '@services/footer-visibility.service';
+import { TableCardComponent } from '@shared/table-card/table-card.component';
+import { TableCardRow } from '@shared/table-card/table-card.types';
+
+import { CareerHighlightCardState } from './career-highlights.types';
+
+const PAGE_SIZE = 10;
+
+type HighlightCardConfig = Pick<
+  CareerHighlightCardState,
+  'titleKey' | 'descriptionKey' | 'valueColumnLabelKey'
+> & {
+  readonly type: CareerHighlightType;
+};
+
+const MOST_TEAMS_PLAYED_CONFIG: HighlightCardConfig = {
+  type: 'most-teams-played',
+  titleKey: 'career.highlights.cards.mostTeamsPlayed.title',
+  descriptionKey: 'career.highlights.cards.mostTeamsPlayed.description',
+  valueColumnLabelKey: 'career.highlights.columns.teamCount',
+};
+
+const SAME_TEAM_SEASONS_PLAYED_CONFIG: HighlightCardConfig = {
+  type: 'same-team-seasons-played',
+  titleKey: 'career.highlights.cards.sameTeamSeasonsPlayed.title',
+  descriptionKey: 'career.highlights.cards.sameTeamSeasonsPlayed.description',
+  valueColumnLabelKey: 'career.highlights.columns.seasonCount',
+};
+
+function createInitialCardState(config: HighlightCardConfig): CareerHighlightCardState {
+  return {
+    titleKey: config.titleKey,
+    descriptionKey: config.descriptionKey,
+    valueColumnLabelKey: config.valueColumnLabelKey,
+    rows: [],
+    loading: true,
+    apiError: false,
+    skip: 0,
+    take: PAGE_SIZE,
+    total: 0,
+  };
+}
+
+@Component({
+  selector: 'app-career-highlights',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [TableCardComponent, TranslateModule],
+  templateUrl: './career-highlights.component.html',
+  styleUrl: './career-highlights.component.scss',
+})
+export class CareerHighlightsComponent implements OnInit {
+  private readonly apiService = inject(ApiService);
+  private readonly destroyRef = inject(DestroyRef);
+  private readonly footerVisibilityService = inject(FooterVisibilityService);
+
+  readonly mostTeamsPlayedState = signal(
+    createInitialCardState(MOST_TEAMS_PLAYED_CONFIG),
+  );
+  readonly sameTeamSeasonsPlayedState = signal(
+    createInitialCardState(SAME_TEAM_SEASONS_PLAYED_CONFIG),
+  );
+
+  private footerVisibilityCycle = 0;
+  private pendingInitialLoads = 0;
+
+  ngOnInit(): void {
+    this.footerVisibilityCycle = this.footerVisibilityService.currentCycle();
+    this.pendingInitialLoads = 2;
+
+    this.loadCard(MOST_TEAMS_PLAYED_CONFIG.type, 0, true);
+    this.loadCard(SAME_TEAM_SEASONS_PLAYED_CONFIG.type, 0, true);
+  }
+
+  loadPreviousPage(type: CareerHighlightType): void {
+    const current = this.getCardSignal(type)();
+    if (current.loading) {
+      return;
+    }
+
+    const nextSkip = Math.max(0, current.skip - current.take);
+    if (nextSkip === current.skip) {
+      return;
+    }
+
+    this.loadCard(type, nextSkip);
+  }
+
+  loadNextPage(type: CareerHighlightType): void {
+    const current = this.getCardSignal(type)();
+    if (current.loading) {
+      return;
+    }
+
+    const nextSkip = current.skip + current.take;
+    if (nextSkip >= current.total) {
+      return;
+    }
+
+    this.loadCard(type, nextSkip);
+  }
+
+  private loadCard(
+    type: CareerHighlightType,
+    targetSkip: number,
+    initialLoad = false,
+  ): void {
+    const cardSignal = this.getCardSignal(type);
+
+    cardSignal.update((current) => ({
+      ...current,
+      loading: true,
+      apiError: false,
+    }));
+
+    this.apiService
+      .getCareerHighlights(type, targetSkip, cardSignal().take)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (page) => {
+          cardSignal.update((current) => ({
+            ...current,
+            rows: this.normalizeRows(page),
+            loading: false,
+            apiError: false,
+            skip: page.skip,
+            take: page.take,
+            total: page.total,
+          }));
+          this.markInitialLoadReady(initialLoad);
+        },
+        error: () => {
+          cardSignal.update((current) => ({
+            ...current,
+            loading: false,
+            apiError: true,
+          }));
+          this.markInitialLoadReady(initialLoad);
+        },
+      });
+  }
+
+  private normalizeRows(page: CareerHighlightPage): TableCardRow[] {
+    if (this.isTeamCountPage(page)) {
+      return page.items.map((item) => ({
+        key: `${item.id}:${item.teams.map((team) => team.id).join(',')}`,
+        primaryText: `${item.position} ${item.name}`,
+        value: item.teamCount,
+        detailLines: item.teams.map((team) => team.name),
+        detailLabel: item.name,
+      }));
+    }
+
+    if (!this.isSameTeamPage(page)) {
+      return [];
+    }
+
+    return page.items.map((item) => ({
+      key: `${item.id}:${item.team.id}`,
+      primaryText: `${item.position} ${item.name}`,
+      value: item.seasonCount,
+      detailLines: [item.team.name],
+      detailLabel: item.name,
+    }));
+  }
+
+  private isTeamCountPage(page: CareerHighlightPage): page is CareerTeamCountHighlightPage {
+    return page.type === 'most-teams-played' || page.type === 'most-teams-owned';
+  }
+
+  private isSameTeamPage(page: CareerHighlightPage): page is CareerSameTeamHighlightPage {
+    return page.type === 'same-team-seasons-played' || page.type === 'same-team-seasons-owned';
+  }
+
+  private getCardSignal(type: CareerHighlightType): WritableSignal<CareerHighlightCardState> {
+    return type === MOST_TEAMS_PLAYED_CONFIG.type
+      ? this.mostTeamsPlayedState
+      : this.sameTeamSeasonsPlayedState;
+  }
+
+  private markInitialLoadReady(initialLoad: boolean): void {
+    if (!initialLoad) {
+      return;
+    }
+
+    this.pendingInitialLoads -= 1;
+    if (this.pendingInitialLoads === 0) {
+      this.footerVisibilityService.markReady(this.footerVisibilityCycle);
+    }
+  }
+}

--- a/src/app/career/highlights/career-highlights.types.ts
+++ b/src/app/career/highlights/career-highlights.types.ts
@@ -1,0 +1,13 @@
+import { TableCardRow } from '@shared/table-card/table-card.types';
+
+export interface CareerHighlightCardState {
+  readonly titleKey: string;
+  readonly descriptionKey: string;
+  readonly valueColumnLabelKey: string;
+  readonly rows: readonly TableCardRow[];
+  readonly loading: boolean;
+  readonly apiError: boolean;
+  readonly skip: number;
+  readonly take: number;
+  readonly total: number;
+}

--- a/src/app/career/highlights/career-highlights.types.ts
+++ b/src/app/career/highlights/career-highlights.types.ts
@@ -1,4 +1,5 @@
 import { TableCardRow } from '@shared/table-card/table-card.types';
+import { CareerHighlightType } from '@services/api.service';
 
 export interface CareerHighlightCardState {
   readonly titleKey: string;
@@ -10,4 +11,9 @@ export interface CareerHighlightCardState {
   readonly skip: number;
   readonly take: number;
   readonly total: number;
+}
+
+export interface CareerHighlightCardView {
+  readonly type: CareerHighlightType;
+  readonly state: CareerHighlightCardState;
 }

--- a/src/app/services/api.service.spec.ts
+++ b/src/app/services/api.service.spec.ts
@@ -175,6 +175,72 @@ describe('ApiService', () => {
     ]);
   });
 
+  it('requests career highlights with explicit paging params', async () => {
+    const responsePromise = firstValueFrom(
+      service.getCareerHighlights('most-teams-played', 10, 10)
+    );
+
+    const request = httpMock.expectOne((req) =>
+      req.url === 'http://localhost:3000/career/highlights/most-teams-played' &&
+      req.params.get('skip') === '10' &&
+      req.params.get('take') === '10'
+    );
+    expect(request.request.method).toBe('GET');
+    request.flush({
+      type: 'most-teams-played',
+      skip: 10,
+      take: 10,
+      total: 12,
+      items: [],
+    });
+
+    await expect(responsePromise).resolves.toEqual({
+      type: 'most-teams-played',
+      skip: 10,
+      take: 10,
+      total: 12,
+      items: [],
+    });
+  });
+
+  it('caches career highlights by type and paging window', async () => {
+    const firstResponse = firstValueFrom(
+      service.getCareerHighlights('same-team-seasons-played', 0, 10)
+    );
+
+    const request = httpMock.expectOne((req) =>
+      req.url === 'http://localhost:3000/career/highlights/same-team-seasons-played' &&
+      req.params.get('skip') === '0' &&
+      req.params.get('take') === '10'
+    );
+    request.flush({
+      type: 'same-team-seasons-played',
+      skip: 0,
+      take: 10,
+      total: 11,
+      items: [],
+    });
+
+    await expect(firstResponse).resolves.toEqual({
+      type: 'same-team-seasons-played',
+      skip: 0,
+      take: 10,
+      total: 11,
+      items: [],
+    });
+
+    await expect(
+      firstValueFrom(service.getCareerHighlights('same-team-seasons-played', 0, 10))
+    ).resolves.toEqual({
+      type: 'same-team-seasons-played',
+      skip: 0,
+      take: 10,
+      total: 11,
+      items: [],
+    });
+    httpMock.expectNone('http://localhost:3000/career/highlights/same-team-seasons-played');
+  });
+
   it('transforms http errors into a user-friendly error', async () => {
     vi.spyOn(console, 'error').mockImplementation(() => {});
 

--- a/src/app/services/api.service.ts
+++ b/src/app/services/api.service.ts
@@ -18,6 +18,15 @@ export type CareerPlayerListItem    = components['schemas']['CareerPlayerListIte
 export type CareerGoalieListItem    = components['schemas']['CareerGoalieListItem'];
 export type CareerPlayer            = components['schemas']['CareerPlayer'];
 export type CareerGoalie            = components['schemas']['CareerGoalie'];
+export type CareerHighlightType     = components['schemas']['CareerHighlightType'];
+export type CareerHighlightTeam     = components['schemas']['CareerHighlightTeam'];
+export type CareerTeamCountHighlightItem = components['schemas']['CareerTeamCountHighlightItem'];
+export type CareerSameTeamHighlightItem = components['schemas']['CareerSameTeamHighlightItem'];
+export type CareerTeamCountHighlightPage = components['schemas']['CareerTeamCountHighlightPage'];
+export type CareerSameTeamHighlightPage = components['schemas']['CareerSameTeamHighlightPage'];
+export type CareerHighlightPage =
+  | CareerTeamCountHighlightPage
+  | CareerSameTeamHighlightPage;
 
 // Player includes frontend-only augmentation fields not present in the API spec.
 // seasons is made optional to match single-season endpoint usage (spec: CombinedPlayer has required seasons).
@@ -178,6 +187,21 @@ export class ApiService {
     return this.handleRequest<CareerGoalieListItem[]>(
       'career/goalies',
       'career-goalies',
+    );
+  }
+
+  getCareerHighlights(
+    type: CareerHighlightType,
+    skip = 0,
+    take = 10,
+  ): Observable<CareerHighlightPage> {
+    return this.handleRequest<CareerHighlightPage>(
+      `career/highlights/${type}`,
+      `career-highlights-${type}-${skip}-${take}`,
+      {
+        skip: String(skip),
+        take: String(take),
+      },
     );
   }
 

--- a/src/app/services/api.types.generated.ts
+++ b/src/app/services/api.types.generated.ts
@@ -1001,6 +1001,69 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/career/highlights/{type}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Career highlights leaderboard
+         * @description Returns a paged mixed skater + goalie career highlights leaderboard.
+         *     `most-teams-played` and `most-teams-owned` return team-count rows.
+         *     `same-team-seasons-played` and `same-team-seasons-owned` return one row per top team, so the same person can appear multiple times on tied same-team results.
+         */
+        get: {
+            parameters: {
+                query?: {
+                    /** @description Number of rows to skip from the start of the sorted highlight list. Defaults to `0`. */
+                    skip?: components["parameters"]["skip"];
+                    /** @description Number of rows to return from the sorted highlight list. Defaults to `10`. Maximum `100`. */
+                    take?: components["parameters"]["take"];
+                };
+                header?: never;
+                path: {
+                    /** @description Career highlight leaderboard type. */
+                    type: components["schemas"]["CareerHighlightType"];
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Paged career highlight results. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["CareerTeamCountHighlightPage"] | components["schemas"]["CareerSameTeamHighlightPage"];
+                    };
+                };
+                /** @description Invalid highlight type or paging params. */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Missing or invalid API key. */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/leaderboard/playoffs": {
         parameters: {
             query?: never;
@@ -1243,6 +1306,42 @@ export interface components {
             regularGames: number;
             playoffGames: number;
         };
+        /** @enum {string} */
+        CareerHighlightType: "most-teams-played" | "most-teams-owned" | "same-team-seasons-played" | "same-team-seasons-owned";
+        CareerHighlightTeam: {
+            id: string;
+            name: string;
+        };
+        CareerTeamCountHighlightItem: {
+            id: string;
+            name: string;
+            position: string;
+            teamCount: number;
+            teams: components["schemas"]["CareerHighlightTeam"][];
+        };
+        CareerSameTeamHighlightItem: {
+            id: string;
+            name: string;
+            position: string;
+            seasonCount: number;
+            team: components["schemas"]["CareerHighlightTeam"];
+        };
+        CareerTeamCountHighlightPage: {
+            /** @enum {string} */
+            type: "most-teams-played" | "most-teams-owned";
+            skip: number;
+            take: number;
+            total: number;
+            items: components["schemas"]["CareerTeamCountHighlightItem"][];
+        };
+        CareerSameTeamHighlightPage: {
+            /** @enum {string} */
+            type: "same-team-seasons-played" | "same-team-seasons-owned";
+            skip: number;
+            take: number;
+            total: number;
+            items: components["schemas"]["CareerSameTeamHighlightItem"][];
+        };
         CareerGoalie: {
             id: string;
             name: string;
@@ -1272,13 +1371,14 @@ export interface components {
             blocks: number;
             /** @description Composite score (0-100 range). */
             score: number;
-            /** @description Score adjusted by games played. */
+            /** @description Stabilized per-game pace score. */
             scoreAdjustedByGames: number;
             /** @description Per-stat score breakdown. */
             scores?: {
                 [key: string]: number;
             };
             scoreByPosition?: number;
+            /** @description Stabilized per-game pace score compared to the same position only. */
             scoreByPositionAdjustedByGames?: number;
             scoresByPosition?: {
                 [key: string]: number;
@@ -1304,21 +1404,81 @@ export interface components {
             /** @description Save percentage. Omitted for `reportType=both` or when source data only contains a zero placeholder. */
             savePercent?: string;
             score: number;
+            /** @description Stabilized per-game pace score. */
             scoreAdjustedByGames: number;
             scores?: {
                 [key: string]: number;
             };
             scoreByPosition?: number;
+            /** @description Stabilized per-game pace score compared to the same position only. */
             scoreByPositionAdjustedByGames?: number;
             scoresByPosition?: {
                 [key: string]: number;
             };
         };
-        PlayerSeasonData: components["schemas"]["Player"] & {
+        /** @description Per-season row nested under `CombinedPlayer.seasons`. Omits `name` because the combined root object already includes it. */
+        PlayerSeasonData: {
             season: number;
+            /** @description Fantrax player identifier extracted from `*id*` in CSV name field. */
+            id: string;
+            position?: string;
+            games: number;
+            goals: number;
+            assists: number;
+            points: number;
+            plusMinus: number;
+            penalties: number;
+            shots: number;
+            ppp: number;
+            shp: number;
+            hits: number;
+            blocks: number;
+            score: number;
+            /** @description Stabilized per-game pace score. */
+            scoreAdjustedByGames: number;
+            /** @description Per-stat score breakdown. */
+            scores?: {
+                [key: string]: number;
+            };
+            scoreByPosition?: number;
+            /** @description Stabilized per-game pace score compared to the same position only. */
+            scoreByPositionAdjustedByGames?: number;
+            scoresByPosition?: {
+                [key: string]: number;
+            };
         };
-        GoalieSeasonData: components["schemas"]["Goalie"] & {
+        /** @description Per-season row nested under `CombinedGoalie.seasons`. Omits `name` because the combined root object already includes it. */
+        GoalieSeasonData: {
             season: number;
+            /** @description Fantrax goalie identifier extracted from `*id*` in CSV name field. */
+            id: string;
+            position?: string;
+            games: number;
+            goals: number;
+            assists: number;
+            points: number;
+            penalties: number;
+            ppp: number;
+            shp: number;
+            wins: number;
+            saves: number;
+            shutouts: number;
+            /** @description Goals against average. Omitted for `reportType=both` or when source data only contains a zero placeholder. */
+            gaa?: string;
+            /** @description Save percentage. Omitted for `reportType=both` or when source data only contains a zero placeholder. */
+            savePercent?: string;
+            score: number;
+            /** @description Stabilized per-game pace score. */
+            scoreAdjustedByGames: number;
+            scores?: {
+                [key: string]: number;
+            };
+            scoreByPosition?: number;
+            /** @description Stabilized per-game pace score compared to the same position only. */
+            scoreByPositionAdjustedByGames?: number;
+            scoresByPosition?: {
+                [key: string]: number;
+            };
         };
         CombinedPlayer: components["schemas"]["Player"] & {
             seasons: components["schemas"]["PlayerSeasonData"][];
@@ -1398,6 +1558,10 @@ export interface components {
          *     Works with `/seasons`, `/players/combined/*`, and `/goalies/combined/*`.
          */
         startFrom: number;
+        /** @description Number of rows to skip from the start of the sorted highlight list. Defaults to `0`. */
+        skip: number;
+        /** @description Number of rows to return from the sorted highlight list. Defaults to `10`. Maximum `100`. */
+        take: number;
         /** @description Fantrax player or goalie identifier. */
         careerId: string;
     };

--- a/src/app/shared/table-card/table-card.component.html
+++ b/src/app/shared/table-card/table-card.component.html
@@ -1,0 +1,103 @@
+<mat-card class="table-card mat-elevation-z4">
+  <mat-card-header>
+    <h3 mat-card-title>
+      {{ titleKey() | translate }}
+    </h3>
+    <p mat-card-subtitle>
+      {{ descriptionKey() | translate }}
+    </p>
+  </mat-card-header>
+
+  @if (loading() && !hasRows()) {
+  <mat-progress-bar mode="indeterminate" />
+  }
+
+  <mat-card-content>
+    @if (apiError() && !hasRows()) {
+    <p class="card-status-message" role="status">
+      {{ 'tableCard.apiUnavailable' | translate }}
+    </p>
+    } @else if (!hasRows() && !loading()) {
+    <p class="card-status-message" role="status">
+      {{ 'tableCard.noResults' | translate }}
+    </p>
+    } @else {
+    @if (loading() && hasRows()) {
+    <mat-progress-bar mode="indeterminate" />
+    }
+
+    @if (apiError() && hasRows()) {
+    <p class="card-inline-error" role="status">
+      {{ 'tableCard.apiUnavailable' | translate }}
+    </p>
+    }
+
+    <div class="table-shell">
+      <table class="table-card-table">
+        <thead>
+          <tr>
+            <th scope="col" class="name-column">
+              {{ primaryColumnLabelKey() | translate }}
+            </th>
+            <th scope="col" class="value-column">
+              {{ valueColumnLabelKey() | translate }}
+            </th>
+            <th scope="col" class="info-column">
+              <span class="sr-only">
+                {{ 'tableCard.columns.details' | translate }}
+              </span>
+              <mat-icon aria-hidden="true">info</mat-icon>
+            </th>
+          </tr>
+        </thead>
+
+        <tbody>
+          @for (row of rows(); track row.key; let rowIndex = $index) {
+          <tr [attr.data-row-index]="rowIndex" tabindex="-1">
+            <td class="primary-cell">
+              {{ row.primaryText }}
+            </td>
+            <td class="value-column">
+              {{ row.value }}
+            </td>
+            <td class="info-column">
+              <button mat-icon-button type="button" [matTooltip]="getDetailsTooltip(row)"
+                matTooltipClass="table-card-tooltip"
+                [attr.aria-label]="'tableCard.showDetails' | translate : { label: row.detailLabel }">
+                <mat-icon>info_outline</mat-icon>
+              </button>
+            </td>
+          </tr>
+          }
+        </tbody>
+      </table>
+    </div>
+    }
+  </mat-card-content>
+
+  <mat-card-actions class="card-actions">
+    <button mat-stroked-button type="button" (click)="previousPageRequested.emit()"
+      [disabled]="loading() || !hasPreviousPage()" [attr.aria-label]="'tableCard.previousPage' | translate">
+      <mat-icon>chevron_left</mat-icon>
+      {{ 'tableCard.previous' | translate }}
+    </button>
+
+    <div class="page-summary" aria-live="polite">
+      {{
+      'tableCard.paginationSummary'
+      | translate
+      : {
+      start: pageStart(),
+      end: pageEnd(),
+      total: total(),
+      }
+      }}
+    </div>
+
+    <button mat-stroked-button type="button" (click)="nextPageRequested.emit()" [disabled]="loading() || !hasNextPage()"
+      [attr.aria-label]="'tableCard.nextPage' | translate">
+      {{ 'tableCard.next' | translate }}
+      <mat-icon>chevron_right</mat-icon>
+    </button>
+  </mat-card-actions>
+</mat-card>

--- a/src/app/shared/table-card/table-card.component.scss
+++ b/src/app/shared/table-card/table-card.component.scss
@@ -1,0 +1,152 @@
+:host {
+  display: block;
+}
+
+.table-card {
+  height: 100%;
+  border: 1px solid var(--mat-sys-outline-variant);
+  border-radius: 20px;
+  background:
+    linear-gradient(180deg,
+      color-mix(in srgb, var(--mat-sys-surface-container) 88%, transparent) 0%,
+      var(--mat-sys-surface) 100%);
+}
+
+mat-card-header {
+  padding-bottom: 0;
+}
+
+.table-card [mat-card-title] {
+  font-size: 1.1rem;
+  line-height: 1.5;
+  color: var(--mat-sys-on-surface);
+}
+
+.table-card [mat-card-subtitle] {
+  margin: 0;
+  font-size: 0.9rem;
+  font-weight: normal;
+  line-height: 1.5;
+  color: var(--mat-sys-on-surface-variant);
+}
+
+mat-card-header {
+  margin-bottom: 8px;
+}
+
+.card-inline-error,
+.card-status-message {
+  margin: 0;
+  padding: 16px 4px;
+  color: var(--mat-sys-on-surface-variant);
+}
+
+.card-inline-error {
+  padding-top: 0;
+}
+
+.table-shell {
+  overflow-x: none;
+}
+
+.table-card-table {
+  width: 100%;
+  border-collapse: collapse;
+  table-layout: fixed;
+}
+
+.table-card-table th {
+  padding: 0.5rem 0.95rem;
+  border-bottom: 1px solid var(--mat-sys-outline-variant);
+  color: var(--mat-sys-on-surface);
+}
+
+.table-card-table td {
+  padding: 0.1rem 0.95rem;
+  border-bottom: 1px solid var(--mat-sys-outline-variant);
+}
+
+.table-card-table th {
+  background: var(--mat-sys-surface-container);
+  color: var(--mat-sys-on-surface-variant);
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.table-card-table tbody tr:last-child td {
+  border-bottom: 0;
+}
+
+.table-card-table tbody tr:focus {
+  outline: 2px solid var(--mat-sys-primary);
+  outline-offset: -2px;
+  background: var(--mat-sys-primary-container);
+}
+
+.primary-cell {
+  font-size: 0.9rem;
+  font-weight: normal;
+}
+
+.name-column {
+  text-align: left;
+}
+
+.value-column {
+  width: 92px;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.info-column {
+  width: 72px;
+  text-align: center;
+}
+
+.table-card .info-column .mat-mdc-icon-button {
+  color: var(--mat-sys-on-surface-variant);
+}
+
+.table-card .info-column .mat-mdc-icon-button:hover,
+.table-card .info-column .mat-mdc-icon-button:focus-visible {
+  background: color-mix(in srgb, var(--mat-sys-primary) 14%, transparent);
+}
+
+.card-actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding-top: 0;
+}
+
+.table-card .card-actions .mat-mdc-outlined-button:not(:disabled) {
+  color: var(--mat-sys-on-surface);
+  border-color: var(--mat-sys-outline);
+}
+
+.table-card .card-actions .mat-mdc-outlined-button:disabled {
+  color: color-mix(in srgb, var(--mat-sys-on-surface) 38%, transparent);
+  border-color: color-mix(in srgb, var(--mat-sys-on-surface) 12%, transparent);
+}
+
+.page-summary {
+  color: var(--mat-sys-on-surface-variant);
+  font-size: 0.9rem;
+  text-align: center;
+}
+
+@media (max-width: 640px) {
+
+  .card-actions {
+    flex-wrap: wrap;
+    justify-content: center;
+  }
+
+  .page-summary {
+    order: -1;
+    width: 100%;
+  }
+}

--- a/src/app/shared/table-card/table-card.component.scss
+++ b/src/app/shared/table-card/table-card.component.scss
@@ -150,3 +150,11 @@ mat-card-header {
     width: 100%;
   }
 }
+
+@media (max-width: 480px) {
+
+  .value-column,
+  .info-column {
+    width: 42px;
+  }
+}

--- a/src/app/shared/table-card/table-card.component.spec.ts
+++ b/src/app/shared/table-card/table-card.component.spec.ts
@@ -1,0 +1,82 @@
+import { Component } from '@angular/core';
+import { render, screen } from '@testing-library/angular';
+import { TranslateModule } from '@ngx-translate/core';
+
+import {
+  provideDisabledMaterialAnimations,
+} from '../../testing/behavior-test-utils';
+import { TableCardComponent } from './table-card.component';
+import { TableCardRow } from './table-card.types';
+
+@Component({
+  standalone: true,
+  imports: [TableCardComponent],
+  template: `
+    <app-table-card
+      [titleKey]="titleKey"
+      [descriptionKey]="descriptionKey"
+      [primaryColumnLabelKey]="primaryColumnLabelKey"
+      [valueColumnLabelKey]="valueColumnLabelKey"
+      [rows]="rows"
+      [loading]="loading"
+      [apiError]="apiError"
+      [skip]="skip"
+      [take]="take"
+      [total]="total"
+    />
+  `,
+})
+class TableCardHostComponent {
+  titleKey = 'career.highlights.cards.mostTeamsPlayed.title';
+  descriptionKey = 'career.highlights.cards.mostTeamsPlayed.description';
+  primaryColumnLabelKey = 'career.highlights.columns.player';
+  valueColumnLabelKey = 'career.highlights.columns.teamCount';
+  loading = false;
+  apiError = false;
+  skip = 0;
+  take = 10;
+  total = 12;
+  rows: readonly TableCardRow[] = [
+    {
+      key: 'row-1',
+      primaryText: 'F Jamie Benn',
+      value: 5,
+      detailLines: ['Colorado Avalanche', 'Carolina Hurricanes'],
+      detailLabel: 'Jamie Benn',
+    },
+  ];
+}
+
+describe('TableCardComponent', () => {
+  async function setup(componentProperties: Partial<TableCardHostComponent> = {}) {
+    return render(TableCardHostComponent, {
+      imports: [TranslateModule.forRoot()],
+      providers: [provideDisabledMaterialAnimations()],
+      componentProperties,
+    });
+  }
+
+  it('renders semantic headings, rows, and page controls for populated data', async () => {
+    await setup();
+
+    expect(
+      await screen.findByRole('heading', { name: 'career.highlights.cards.mostTeamsPlayed.title' })
+    ).toBeInTheDocument();
+    expect(screen.getByRole('table')).toBeInTheDocument();
+    expect(screen.getByText('F Jamie Benn')).toBeInTheDocument();
+    expect(screen.getByText('5')).toBeInTheDocument();
+    expect(screen.getByText('tableCard.paginationSummary')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'tableCard.previousPage' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'tableCard.nextPage' })).toBeEnabled();
+  });
+
+  it('shows an empty-state message when there are no rows and the card is not loading', async () => {
+    await setup({
+      rows: [],
+      total: 0,
+    });
+
+    expect(await screen.findByText('tableCard.noResults')).toBeInTheDocument();
+    expect(screen.queryByRole('table')).not.toBeInTheDocument();
+  });
+});

--- a/src/app/shared/table-card/table-card.component.ts
+++ b/src/app/shared/table-card/table-card.component.ts
@@ -1,0 +1,49 @@
+import { ChangeDetectionStrategy, Component, computed, input, output } from '@angular/core';
+import { MatButtonModule } from '@angular/material/button';
+import { MatCardModule } from '@angular/material/card';
+import { MatIconModule } from '@angular/material/icon';
+import { MatProgressBarModule } from '@angular/material/progress-bar';
+import { MatTooltipModule } from '@angular/material/tooltip';
+import { TranslateModule } from '@ngx-translate/core';
+
+import { TableCardRow } from './table-card.types';
+
+@Component({
+  selector: 'app-table-card',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [
+    MatButtonModule,
+    MatCardModule,
+    MatIconModule,
+    MatProgressBarModule,
+    MatTooltipModule,
+    TranslateModule,
+  ],
+  templateUrl: './table-card.component.html',
+  styleUrl: './table-card.component.scss',
+})
+export class TableCardComponent {
+  readonly titleKey = input.required<string>();
+  readonly descriptionKey = input.required<string>();
+  readonly primaryColumnLabelKey = input.required<string>();
+  readonly valueColumnLabelKey = input.required<string>();
+  readonly rows = input.required<readonly TableCardRow[]>();
+  readonly loading = input(false);
+  readonly apiError = input(false);
+  readonly skip = input(0);
+  readonly take = input(10);
+  readonly total = input(0);
+
+  readonly previousPageRequested = output<void>();
+  readonly nextPageRequested = output<void>();
+
+  readonly hasRows = computed(() => this.rows().length > 0);
+  readonly hasPreviousPage = computed(() => this.skip() > 0);
+  readonly hasNextPage = computed(() => this.skip() + this.rows().length < this.total());
+  readonly pageStart = computed(() => (this.hasRows() ? this.skip() + 1 : 0));
+  readonly pageEnd = computed(() => (this.hasRows() ? this.skip() + this.rows().length : 0));
+
+  getDetailsTooltip(row: TableCardRow): string {
+    return row.detailLines.join('\n');
+  }
+}

--- a/src/app/shared/table-card/table-card.types.ts
+++ b/src/app/shared/table-card/table-card.types.ts
@@ -1,0 +1,7 @@
+export interface TableCardRow {
+  readonly key: string;
+  readonly primaryText: string;
+  readonly value: number | string;
+  readonly detailLines: readonly string[];
+  readonly detailLabel: string;
+}

--- a/src/app/testing/behavior-test-utils.ts
+++ b/src/app/testing/behavior-test-utils.ts
@@ -9,6 +9,8 @@ import { routes } from '../app.routes';
 import {
   ApiParams,
   ApiService,
+  CareerHighlightPage,
+  CareerHighlightType,
   Goalie,
   LastModifiedResponse,
   Player,
@@ -30,6 +32,10 @@ import playersFixture from '../../../e2e/fixtures/data/players--combined--regula
 import goaliesFixtureData from '../../../e2e/fixtures/data/goalies--combined--regular--startFrom=2012.json';
 import careerPlayersFixtureData from '../../../e2e/fixtures/data/career--players.json';
 import careerGoaliesFixtureData from '../../../e2e/fixtures/data/career--goalies.json';
+import mostTeamsPlayedHighlightsPage0FixtureData from '../../../e2e/fixtures/data/career--highlights--most-teams-played--skip=0--take=10.json';
+import mostTeamsPlayedHighlightsPage1FixtureData from '../../../e2e/fixtures/data/career--highlights--most-teams-played--skip=10--take=10.json';
+import sameTeamSeasonsHighlightsPage0FixtureData from '../../../e2e/fixtures/data/career--highlights--same-team-seasons-played--skip=0--take=10.json';
+import sameTeamSeasonsHighlightsPage1FixtureData from '../../../e2e/fixtures/data/career--highlights--same-team-seasons-played--skip=10--take=10.json';
 
 export const PLAYER_SLICE_COUNT = 12;
 export const GOALIE_SLICE_COUNT = 5;
@@ -39,6 +45,14 @@ export const goaliesFixture = goaliesFixtureData as unknown as Goalie[];
 export const slicedGoalies = goaliesFixture.slice(0, GOALIE_SLICE_COUNT);
 export const careerPlayersFixture = careerPlayersFixtureData as unknown as CareerPlayerListItem[];
 export const careerGoaliesFixture = careerGoaliesFixtureData as unknown as CareerGoalieListItem[];
+export const mostTeamsPlayedHighlightsPage0Fixture =
+  mostTeamsPlayedHighlightsPage0FixtureData as CareerHighlightPage;
+export const mostTeamsPlayedHighlightsPage1Fixture =
+  mostTeamsPlayedHighlightsPage1FixtureData as CareerHighlightPage;
+export const sameTeamSeasonsHighlightsPage0Fixture =
+  sameTeamSeasonsHighlightsPage0FixtureData as CareerHighlightPage;
+export const sameTeamSeasonsHighlightsPage1Fixture =
+  sameTeamSeasonsHighlightsPage1FixtureData as CareerHighlightPage;
 
 export { teamsFixture, lastModifiedFixture, seasonsFixture, playersFixture };
 
@@ -50,6 +64,7 @@ type BehaviorApiErrorKey =
   | 'goalies'
   | 'careerPlayers'
   | 'careerGoalies'
+  | 'careerHighlights'
   | 'leaderboardRegular'
   | 'leaderboardPlayoffs';
 
@@ -61,6 +76,8 @@ export type BehaviorApiMockOptions = {
   goalies?: Goalie[];
   careerPlayers?: CareerPlayerListItem[];
   careerGoalies?: CareerGoalieListItem[];
+  careerHighlightsMostTeamsPlayed?: CareerHighlightPage;
+  careerHighlightsSameTeamSeasonsPlayed?: CareerHighlightPage;
   leaderboardRegular?: RegularLeaderboardEntry[];
   leaderboardPlayoffs?: PlayoffLeaderboardEntry[];
   errorKeys?: BehaviorApiErrorKey[];
@@ -73,6 +90,11 @@ export type BehaviorApiMockOptions = {
   getGoalieData?: (params: ApiParams) => Observable<Goalie[]>;
   getCareerPlayers?: () => Observable<CareerPlayerListItem[]>;
   getCareerGoalies?: () => Observable<CareerGoalieListItem[]>;
+  getCareerHighlights?: (
+    type: CareerHighlightType,
+    skip?: number,
+    take?: number,
+  ) => Observable<CareerHighlightPage>;
 };
 
 export type BehaviorTestConfigOptions = BehaviorApiMockOptions & {
@@ -134,6 +156,25 @@ export function createApiServiceMock(options: BehaviorApiMockOptions = {}) {
       errorKeys.has('careerGoalies')
         ? createApiError()
         : (options.getCareerGoalies?.() ?? of(options.careerGoalies ?? careerGoaliesFixture)),
+    getCareerHighlights: (
+      type: CareerHighlightType,
+      skip = 0,
+      take = 10,
+    ) =>
+      errorKeys.has('careerHighlights')
+        ? createApiError()
+        : (options.getCareerHighlights?.(type, skip, take)
+          ?? of(
+            type === 'most-teams-played'
+              ? (skip >= 10
+                ? (options.careerHighlightsMostTeamsPlayed ?? mostTeamsPlayedHighlightsPage1Fixture)
+                : (options.careerHighlightsMostTeamsPlayed ?? mostTeamsPlayedHighlightsPage0Fixture))
+              : (skip >= 10
+                ? (options.careerHighlightsSameTeamSeasonsPlayed
+                  ?? sameTeamSeasonsHighlightsPage1Fixture)
+                : (options.careerHighlightsSameTeamSeasonsPlayed
+                  ?? sameTeamSeasonsHighlightsPage0Fixture))
+          )),
     getLeaderboardRegular: () =>
       errorKeys.has('leaderboardRegular')
         ? createApiError()

--- a/src/app/testing/behavior-test-utils.ts
+++ b/src/app/testing/behavior-test-utils.ts
@@ -34,8 +34,12 @@ import careerPlayersFixtureData from '../../../e2e/fixtures/data/career--players
 import careerGoaliesFixtureData from '../../../e2e/fixtures/data/career--goalies.json';
 import mostTeamsPlayedHighlightsPage0FixtureData from '../../../e2e/fixtures/data/career--highlights--most-teams-played--skip=0--take=10.json';
 import mostTeamsPlayedHighlightsPage1FixtureData from '../../../e2e/fixtures/data/career--highlights--most-teams-played--skip=10--take=10.json';
+import mostTeamsOwnedHighlightsPage0FixtureData from '../../../e2e/fixtures/data/career--highlights--most-teams-owned--skip=0--take=10.json';
+import mostTeamsOwnedHighlightsPage1FixtureData from '../../../e2e/fixtures/data/career--highlights--most-teams-owned--skip=10--take=10.json';
 import sameTeamSeasonsHighlightsPage0FixtureData from '../../../e2e/fixtures/data/career--highlights--same-team-seasons-played--skip=0--take=10.json';
 import sameTeamSeasonsHighlightsPage1FixtureData from '../../../e2e/fixtures/data/career--highlights--same-team-seasons-played--skip=10--take=10.json';
+import sameTeamSeasonsOwnedHighlightsPage0FixtureData from '../../../e2e/fixtures/data/career--highlights--same-team-seasons-owned--skip=0--take=10.json';
+import sameTeamSeasonsOwnedHighlightsPage1FixtureData from '../../../e2e/fixtures/data/career--highlights--same-team-seasons-owned--skip=10--take=10.json';
 
 export const PLAYER_SLICE_COUNT = 12;
 export const GOALIE_SLICE_COUNT = 5;
@@ -49,10 +53,18 @@ export const mostTeamsPlayedHighlightsPage0Fixture =
   mostTeamsPlayedHighlightsPage0FixtureData as CareerHighlightPage;
 export const mostTeamsPlayedHighlightsPage1Fixture =
   mostTeamsPlayedHighlightsPage1FixtureData as CareerHighlightPage;
+export const mostTeamsOwnedHighlightsPage0Fixture =
+  mostTeamsOwnedHighlightsPage0FixtureData as CareerHighlightPage;
+export const mostTeamsOwnedHighlightsPage1Fixture =
+  mostTeamsOwnedHighlightsPage1FixtureData as CareerHighlightPage;
 export const sameTeamSeasonsHighlightsPage0Fixture =
   sameTeamSeasonsHighlightsPage0FixtureData as CareerHighlightPage;
 export const sameTeamSeasonsHighlightsPage1Fixture =
   sameTeamSeasonsHighlightsPage1FixtureData as CareerHighlightPage;
+export const sameTeamSeasonsOwnedHighlightsPage0Fixture =
+  sameTeamSeasonsOwnedHighlightsPage0FixtureData as CareerHighlightPage;
+export const sameTeamSeasonsOwnedHighlightsPage1Fixture =
+  sameTeamSeasonsOwnedHighlightsPage1FixtureData as CareerHighlightPage;
 
 export { teamsFixture, lastModifiedFixture, seasonsFixture, playersFixture };
 
@@ -77,7 +89,9 @@ export type BehaviorApiMockOptions = {
   careerPlayers?: CareerPlayerListItem[];
   careerGoalies?: CareerGoalieListItem[];
   careerHighlightsMostTeamsPlayed?: CareerHighlightPage;
+  careerHighlightsMostTeamsOwned?: CareerHighlightPage;
   careerHighlightsSameTeamSeasonsPlayed?: CareerHighlightPage;
+  careerHighlightsSameTeamSeasonsOwned?: CareerHighlightPage;
   leaderboardRegular?: RegularLeaderboardEntry[];
   leaderboardPlayoffs?: PlayoffLeaderboardEntry[];
   errorKeys?: BehaviorApiErrorKey[];
@@ -105,6 +119,31 @@ export type BehaviorTestConfigOptions = BehaviorApiMockOptions & {
 
 function createApiError() {
   return throwError(() => new Error('Behavior test API error'));
+}
+
+function getDefaultCareerHighlightsFixture(
+  options: BehaviorApiMockOptions,
+  type: CareerHighlightType,
+  skip: number,
+): CareerHighlightPage {
+  switch (type) {
+    case 'most-teams-played':
+      return skip >= 10
+        ? (options.careerHighlightsMostTeamsPlayed ?? mostTeamsPlayedHighlightsPage1Fixture)
+        : (options.careerHighlightsMostTeamsPlayed ?? mostTeamsPlayedHighlightsPage0Fixture);
+    case 'most-teams-owned':
+      return skip >= 10
+        ? (options.careerHighlightsMostTeamsOwned ?? mostTeamsOwnedHighlightsPage1Fixture)
+        : (options.careerHighlightsMostTeamsOwned ?? mostTeamsOwnedHighlightsPage0Fixture);
+    case 'same-team-seasons-played':
+      return skip >= 10
+        ? (options.careerHighlightsSameTeamSeasonsPlayed ?? sameTeamSeasonsHighlightsPage1Fixture)
+        : (options.careerHighlightsSameTeamSeasonsPlayed ?? sameTeamSeasonsHighlightsPage0Fixture);
+    case 'same-team-seasons-owned':
+      return skip >= 10
+        ? (options.careerHighlightsSameTeamSeasonsOwned ?? sameTeamSeasonsOwnedHighlightsPage1Fixture)
+        : (options.careerHighlightsSameTeamSeasonsOwned ?? sameTeamSeasonsOwnedHighlightsPage0Fixture);
+  }
 }
 
 export function provideDisabledMaterialAnimations(): Provider {
@@ -164,17 +203,7 @@ export function createApiServiceMock(options: BehaviorApiMockOptions = {}) {
       errorKeys.has('careerHighlights')
         ? createApiError()
         : (options.getCareerHighlights?.(type, skip, take)
-          ?? of(
-            type === 'most-teams-played'
-              ? (skip >= 10
-                ? (options.careerHighlightsMostTeamsPlayed ?? mostTeamsPlayedHighlightsPage1Fixture)
-                : (options.careerHighlightsMostTeamsPlayed ?? mostTeamsPlayedHighlightsPage0Fixture))
-              : (skip >= 10
-                ? (options.careerHighlightsSameTeamSeasonsPlayed
-                  ?? sameTeamSeasonsHighlightsPage1Fixture)
-                : (options.careerHighlightsSameTeamSeasonsPlayed
-                  ?? sameTeamSeasonsHighlightsPage0Fixture))
-          )),
+          ?? of(getDefaultCareerHighlightsFixture(options, type, skip))),
     getLeaderboardRegular: () =>
       errorKeys.has('leaderboardRegular')
         ? createApiError()

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -555,6 +555,11 @@ mat-checkbox .mdc-label {
   color: var(--mat-sys-primary);
 }
 
+.table-card-tooltip,
+.table-card-tooltip .mdc-tooltip__surface {
+  white-space: pre-line;
+}
+
 // Shared stats-table and virtual-table shell styles. Keeping the DOM-targeting rules
 // here avoids repeating the same Material overrides in multiple component stylesheets.
 app-stats-table,


### PR DESCRIPTION
## Summary
- Add a new `/career/highlights` route as the third tab under player careers.
- Introduce a reusable shared `TableCardComponent` for compact paged leaderboard cards instead of another virtual table view.
- Implement four career highlight cards with server-side paging:
  - most teams played
  - most teams owned
  - most same-team seasons played
  - most same-team seasons owned
- Normalize the different highlight response shapes into a single table-card row model.
- Keep the highlights layout responsive with a two-column grid that stacks on mobile.
- Add tooltip support for team details and preserve accessible keyboard/focus behavior.
- Update translations, docs, and test fixtures to cover the new highlights experience.
- Tighten repo instructions so `docs/plans/` stays local-only and is never committed unless explicitly requested.

## Testing
- `npx playwright test e2e/specs/career.spec.ts`
- `npm run verify`