### PR TITLE
Feature: Defer career highlights card loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Live showcase: https://ffhl-stats.vercel.app/
 	- Searchable and sortable, with no stats-page filters or mobile drawer
 	- Virtualized row rendering keeps long lists responsive
 	- Player rows show position inline with name (for example `D Travis Hamonic`) while still sorting alphabetically by player name
-	- `/career/highlights` adds compact paged highlight cards for focused career leaderboard slices such as most teams played/owned and most same-team seasons played/owned
+	- `/career/highlights` adds compact paged highlight cards for focused career leaderboard slices such as most teams played/owned and most same-team seasons played/owned, and each card now lazy-loads its dataset as it approaches the viewport
 - 🚦 **Split Route Shells**: Interactive dashboard routes lazy-load their heavier shell (controls, settings drawer, comparison bar, tabs), while career and leaderboard browsing routes stay on a lighter root shell
 - 🗂️ **Global Navigation**: Bottom sheet menu for switching between views (hockey stats, player careers, leaderboards, info/help)
 - 🔗 **Direct Player Links**: Shareable URLs for player/goalie cards

--- a/docs/codebase-structure.md
+++ b/docs/codebase-structure.md
@@ -89,11 +89,13 @@ Route shell and smart components for career listings:
 - Handles `/career/players`, `/career/goalies`, and `/career/highlights`
 - Renders tab navigation between career skaters, goalies, and highlights
 - Uses dedicated backend endpoints and either a virtualized read-only table or compact paged table cards
+- Defers each highlight card's API request until the card nears the viewport
 - Loads under the lighter root shell without dashboard-only controls, comparison bar, or mobile settings drawer
 
 ### `/src/app/shared/table-card/`
 Reusable card-based read-only table presentation:
 - Semantic HTML table inside a Material card container
+- Supports a deferred placeholder before viewport-activated cards fetch their data
 - Server-side paging controls for compact leaderboard/highlight lists
 - Shared loading, empty, and API-error states for paged card views
 

--- a/docs/component-guide.md
+++ b/docs/component-guide.md
@@ -200,6 +200,7 @@ TeamService → PlayerStatsComponent (triggers refetch + adds teamId)
 - Pass column definitions and formatters into the shared virtualized table
 - Keep the player career table sorted by plain `name` while rendering position inline with the displayed player name
 - Normalize paged highlight responses into the shared `TableCardComponent` row shape for the `/career/highlights` route
+- Activate highlight-card API loads lazily as each card approaches the viewport instead of requesting every card during route startup
 
 ### TableCardComponent
 
@@ -212,6 +213,7 @@ TeamService → PlayerStatsComponent (triggers refetch + adds teamId)
 **Responsibilities**:
 
 - Show title/description copy, a semantic HTML table, and previous/next paging controls
+- Support a deferred placeholder before a card has been activated by viewport visibility
 - Keep tooltip buttons and pagination controls keyboard accessible
 - Reuse shared loading, empty, and API-error states for compact card views
 

--- a/docs/project-overview.md
+++ b/docs/project-overview.md
@@ -79,6 +79,7 @@ Accessibility is a core requirement: the UI is designed to remain usable via key
    - Player position is rendered inline with player name while sorting still uses the underlying plain `name`
    - Uses a virtualized table implementation to keep large result sets responsive
    - The highlights tab uses compact paged table cards for focused leaderboard slices such as most teams played/owned and most same-team seasons played/owned
+   - Highlight cards lazy-load their API data as they enter or near the viewport so the route scales better as more cards are added
 
 7. **Data Management**
    - Caching service to reduce API calls

--- a/e2e/specs/career.spec.ts
+++ b/e2e/specs/career.spec.ts
@@ -26,11 +26,15 @@ test.describe('Career listings', () => {
     const highlightCards = page.locator('app-table-card');
     await expect(highlightCards).toHaveCount(4);
     await expect(highlightCards.first().getByRole('table')).toBeVisible();
+    await highlightCards.nth(1).scrollIntoViewIfNeeded();
     await expect(highlightCards.nth(1).getByRole('table')).toBeVisible();
+    await highlightCards.nth(2).scrollIntoViewIfNeeded();
     await expect(highlightCards.nth(2).getByRole('table')).toBeVisible();
+    await highlightCards.nth(3).scrollIntoViewIfNeeded();
     await expect(highlightCards.nth(3).getByRole('table')).toBeVisible();
 
     const mostTeamsCard = highlightCards.first();
+    await mostTeamsCard.scrollIntoViewIfNeeded();
     const firstMostTeamsRow = mostTeamsCard.locator('tbody tr').first();
     const firstMostTeamsRowText = (await firstMostTeamsRow.textContent())?.trim() ?? '';
     await mostTeamsCard.getByRole('button', { name: 'Näytä seuraavat rivit' }).click();

--- a/public/i18n/fi.json
+++ b/public/i18n/fi.json
@@ -103,6 +103,7 @@
       "details": "Lisätiedot"
     },
     "showDetails": "Näytä lisätiedot: {{label}}",
+    "loadWhenVisible": "Kortin data ladataan, kun se tulee näkyviin.",
     "apiUnavailable": "Korttidata ei ole saatavilla juuri nyt. Yritä hetken päästä uudelleen.",
     "noResults": "Ei tuloksia.",
     "previous": "Edelliset",

--- a/src/app/app.component.mobile.spec.ts
+++ b/src/app/app.component.mobile.spec.ts
@@ -281,7 +281,7 @@ describe('AppComponent — mobile frontpage', { timeout: 60_000 }, () => {
     expect(
       screen.getByRole('heading', { name: 'career.highlights.cards.sameTeamSeasonsOwned.title' })
     ).toBeInTheDocument();
-    expect(screen.getAllByRole('table')).toHaveLength(4);
+    expect(screen.getAllByRole('heading', { level: 3 })).toHaveLength(5);
 
     fireEvent.click(screen.getByRole('tab', { name: 'career.tabs.goalies' }));
 

--- a/src/app/career/highlights/activate-on-viewport.directive.spec.ts
+++ b/src/app/career/highlights/activate-on-viewport.directive.spec.ts
@@ -1,0 +1,104 @@
+import { Component } from '@angular/core';
+import { render, screen } from '@testing-library/angular';
+
+import { ActivateOnViewportDirective } from './activate-on-viewport.directive';
+
+class FakeIntersectionObserver {
+  static instances: FakeIntersectionObserver[] = [];
+
+  private target: Element | null = null;
+
+  constructor(
+    private readonly callback: IntersectionObserverCallback,
+    readonly options?: IntersectionObserverInit,
+  ) {
+    FakeIntersectionObserver.instances.push(this);
+  }
+
+  observe(target: Element): void {
+    this.target = target;
+  }
+
+  disconnect(): void {
+    this.target = null;
+  }
+
+  unobserve(target: Element): void {
+    if (this.target === target) {
+      this.target = null;
+    }
+  }
+
+  takeRecords(): IntersectionObserverEntry[] {
+    return [];
+  }
+
+  trigger(visibleHeight: number, targetHeight = 320): void {
+    if (!this.target) {
+      return;
+    }
+
+    this.callback(
+      [
+        {
+          isIntersecting: visibleHeight > 0,
+          intersectionRatio: targetHeight === 0 ? 0 : visibleHeight / targetHeight,
+          intersectionRect: { height: visibleHeight } as DOMRectReadOnly,
+          boundingClientRect: { height: targetHeight } as DOMRectReadOnly,
+          target: this.target,
+        } as IntersectionObserverEntry,
+      ],
+      this as unknown as IntersectionObserver,
+    );
+  }
+}
+
+@Component({
+  standalone: true,
+  imports: [ActivateOnViewportDirective],
+  template: `
+    <div
+      appActivateOnViewport
+      [appActivateOnViewportMinPixels]="minimumVisiblePixels"
+      (appActivateOnViewportVisible)="activations = activations + 1"
+    >
+      Highlight card
+    </div>
+    <p>{{ activations }}</p>
+  `,
+})
+class ActivateOnViewportHostComponent {
+  minimumVisiblePixels = 240;
+  activations = 0;
+}
+
+describe('ActivateOnViewportDirective', () => {
+  beforeEach(() => {
+    FakeIntersectionObserver.instances = [];
+    vi.stubGlobal(
+      'IntersectionObserver',
+      FakeIntersectionObserver as unknown as typeof IntersectionObserver,
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('waits until enough vertical pixels of the element are visible before emitting', async () => {
+    await render(ActivateOnViewportHostComponent);
+
+    expect(await screen.findByText('0')).toBeInTheDocument();
+    expect(FakeIntersectionObserver.instances).toHaveLength(1);
+    expect(Array.isArray(FakeIntersectionObserver.instances[0]?.options?.threshold)).toBe(true);
+
+    FakeIntersectionObserver.instances[0]?.trigger(160);
+    expect(screen.getByText('0')).toBeInTheDocument();
+
+    FakeIntersectionObserver.instances[0]?.trigger(240);
+    expect(await screen.findByText('1')).toBeInTheDocument();
+
+    FakeIntersectionObserver.instances[0]?.trigger(260);
+    expect(screen.getByText('1')).toBeInTheDocument();
+  });
+});

--- a/src/app/career/highlights/activate-on-viewport.directive.ts
+++ b/src/app/career/highlights/activate-on-viewport.directive.ts
@@ -1,0 +1,95 @@
+import { DestroyRef, Directive, ElementRef, afterNextRender, inject, input, output } from '@angular/core';
+
+const DEFAULT_ROOT_MARGIN = '0px';
+const DEFAULT_MINIMUM_VISIBLE_PIXELS = 240;
+const OBSERVER_THRESHOLDS = Array.from({ length: 21 }, (_, index) => index / 20);
+
+@Directive({
+  selector: '[appActivateOnViewport]',
+})
+export class ActivateOnViewportDirective {
+  readonly rootMargin = input(DEFAULT_ROOT_MARGIN, {
+    alias: 'appActivateOnViewportRootMargin',
+  });
+  readonly minimumVisiblePixels = input(DEFAULT_MINIMUM_VISIBLE_PIXELS, {
+    alias: 'appActivateOnViewportMinPixels',
+  });
+  readonly visible = output<void>({ alias: 'appActivateOnViewportVisible' });
+
+  private readonly elementRef = inject(ElementRef<HTMLElement>);
+  private readonly destroyRef = inject(DestroyRef);
+
+  private observer: IntersectionObserver | null = null;
+  private hasEmitted = false;
+
+  constructor() {
+    afterNextRender(() => {
+      this.initializeObserver();
+    });
+
+    this.destroyRef.onDestroy(() => {
+      this.disconnectObserver();
+    });
+  }
+
+  private initializeObserver(): void {
+    if (this.hasEmitted) {
+      return;
+    }
+
+    const minimumVisiblePixels = this.normalizeVisiblePixels(this.minimumVisiblePixels());
+
+    if (typeof IntersectionObserver !== 'function') {
+      this.emitVisible();
+      return;
+    }
+
+    this.observer = new IntersectionObserver(
+      (entries) => {
+        if (!entries.some((entry) => this.meetsVisibilityThreshold(entry, minimumVisiblePixels))) {
+          return;
+        }
+
+        this.emitVisible();
+        this.disconnectObserver();
+      },
+      {
+        rootMargin: this.rootMargin(),
+        threshold: OBSERVER_THRESHOLDS,
+      },
+    );
+
+    this.observer.observe(this.elementRef.nativeElement);
+  }
+
+  private emitVisible(): void {
+    if (this.hasEmitted) {
+      return;
+    }
+
+    this.hasEmitted = true;
+    this.visible.emit();
+  }
+
+  private disconnectObserver(): void {
+    this.observer?.disconnect();
+    this.observer = null;
+  }
+
+  private meetsVisibilityThreshold(
+    entry: IntersectionObserverEntry,
+    minimumVisiblePixels: number,
+  ): boolean {
+    if (!entry.isIntersecting) {
+      return false;
+    }
+
+    const targetHeight = entry.boundingClientRect.height;
+    const requiredVisiblePixels = Math.min(targetHeight, minimumVisiblePixels);
+    return entry.intersectionRect.height >= requiredVisiblePixels;
+  }
+
+  private normalizeVisiblePixels(value: number): number {
+    return Math.max(value, 0);
+  }
+}

--- a/src/app/career/highlights/career-highlights.component.html
+++ b/src/app/career/highlights/career-highlights.component.html
@@ -10,10 +10,14 @@
   <div class="career-highlights-grid">
     @for (card of cards(); track card.type) {
       <app-table-card
+        class="career-highlights-card"
+        appActivateOnViewport
+        (appActivateOnViewportVisible)="activateCard(card.type)"
         [titleKey]="card.state.titleKey"
         [descriptionKey]="card.state.descriptionKey"
         primaryColumnLabelKey="career.highlights.columns.player"
         [valueColumnLabelKey]="card.state.valueColumnLabelKey"
+        [deferred]="!card.state.activated"
         [rows]="card.state.rows"
         [loading]="card.state.loading"
         [apiError]="card.state.apiError"

--- a/src/app/career/highlights/career-highlights.component.scss
+++ b/src/app/career/highlights/career-highlights.component.scss
@@ -14,6 +14,10 @@
   align-items: stretch;
 }
 
+.career-highlights-card {
+  min-width: 0;
+}
+
 @media (max-width: 900px) {
   .career-highlights-grid {
     grid-template-columns: minmax(0, 1fr);

--- a/src/app/career/highlights/career-highlights.component.spec.ts
+++ b/src/app/career/highlights/career-highlights.component.spec.ts
@@ -14,8 +14,67 @@ import {
 } from '../../testing/behavior-test-utils';
 import { CareerHighlightsComponent } from './career-highlights.component';
 
+class FakeIntersectionObserver {
+  static instances: FakeIntersectionObserver[] = [];
+
+  private target: Element | null = null;
+
+  constructor(private readonly callback: IntersectionObserverCallback) {
+    FakeIntersectionObserver.instances.push(this);
+  }
+
+  observe(target: Element): void {
+    this.target = target;
+  }
+
+  disconnect(): void {
+    this.target = null;
+  }
+
+  unobserve(target: Element): void {
+    if (this.target === target) {
+      this.target = null;
+    }
+  }
+
+  takeRecords(): IntersectionObserverEntry[] {
+    return [];
+  }
+
+  trigger(isIntersecting = true, visibleHeight = 260, targetHeight = 320): void {
+    if (!this.target) {
+      return;
+    }
+
+    this.callback(
+      [
+        {
+          isIntersecting,
+          intersectionRatio: isIntersecting ? visibleHeight / targetHeight : 0,
+          intersectionRect: { height: isIntersecting ? visibleHeight : 0 } as DOMRectReadOnly,
+          boundingClientRect: { height: targetHeight } as DOMRectReadOnly,
+          target: this.target,
+        } as IntersectionObserverEntry,
+      ],
+      this as unknown as IntersectionObserver,
+    );
+  }
+}
+
 describe('CareerHighlightsComponent', () => {
-  it('renders all configured highlight cards and pages the first card forward', async () => {
+  beforeEach(() => {
+    FakeIntersectionObserver.instances = [];
+    vi.stubGlobal(
+      'IntersectionObserver',
+      FakeIntersectionObserver as unknown as typeof IntersectionObserver,
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('loads only activated cards first and fetches additional cards when they approach the viewport', async () => {
     const getCareerHighlights = vi.fn(
       (type: CareerHighlightType, skip = 0) => {
         switch (type) {
@@ -67,6 +126,17 @@ describe('CareerHighlightsComponent', () => {
         name: 'career.highlights.cards.sameTeamSeasonsOwned.title',
       })
     ).toBeInTheDocument();
+
+    await vi.waitFor(() => {
+      expect(FakeIntersectionObserver.instances).toHaveLength(4);
+    });
+
+    expect(getCareerHighlights).not.toHaveBeenCalled();
+    expect(screen.getAllByText('tableCard.loadWhenVisible')).toHaveLength(4);
+
+    FakeIntersectionObserver.instances[0]?.trigger();
+    FakeIntersectionObserver.instances[1]?.trigger();
+
     const mostTeamsCardTitle = screen.getByRole('heading', {
       name: 'career.highlights.cards.mostTeamsPlayed.title',
     });
@@ -78,8 +148,17 @@ describe('CareerHighlightsComponent', () => {
 
     expect(mostTeamsCard).not.toBeNull();
     expect(sameTeamPlayedCard).not.toBeNull();
-    expect(within(mostTeamsCard!).getByText('F Jamie Benn')).toBeInTheDocument();
-    expect(within(sameTeamPlayedCard!).getByText('D Victor Hedman')).toBeInTheDocument();
+    expect(await within(mostTeamsCard!).findByText('F Jamie Benn')).toBeInTheDocument();
+    expect(screen.getByText('G Andrei Vasilevskiy')).toBeInTheDocument();
+    expect(getCareerHighlights).toHaveBeenCalledTimes(2);
+    expect(getCareerHighlights).toHaveBeenNthCalledWith(1, 'most-teams-played', 0, 10);
+    expect(getCareerHighlights).toHaveBeenNthCalledWith(2, 'most-teams-owned', 0, 10);
+    expect(within(sameTeamPlayedCard!).queryByText('D Victor Hedman')).not.toBeInTheDocument();
+
+    FakeIntersectionObserver.instances[2]?.trigger();
+
+    expect(await within(sameTeamPlayedCard!).findByText('D Victor Hedman')).toBeInTheDocument();
+    expect(getCareerHighlights).toHaveBeenCalledWith('same-team-seasons-played', 0, 10);
 
     fireEvent.click(screen.getAllByRole('button', { name: 'tableCard.nextPage' })[0]);
 
@@ -88,7 +167,7 @@ describe('CareerHighlightsComponent', () => {
     expect(getCareerHighlights).toHaveBeenCalledWith('most-teams-played', 10, 10);
   });
 
-  it('shows an error state for a failing card without hiding the successful cards', async () => {
+  it('shows an error state for an activated failing card without forcing untouched cards to load', async () => {
     await render(CareerHighlightsComponent, {
       imports: [TranslateModule.forRoot()],
       providers: [
@@ -112,6 +191,13 @@ describe('CareerHighlightsComponent', () => {
       ],
     });
 
+    await vi.waitFor(() => {
+      expect(FakeIntersectionObserver.instances).toHaveLength(4);
+    });
+
+    FakeIntersectionObserver.instances[0]?.trigger();
+    FakeIntersectionObserver.instances[3]?.trigger();
+
     const mostTeamsPlayedCardTitle = await screen.findByRole('heading', {
       name: 'career.highlights.cards.mostTeamsPlayed.title',
     });
@@ -129,8 +215,8 @@ describe('CareerHighlightsComponent', () => {
     expect(mostTeamsPlayedCard).not.toBeNull();
     expect(mostTeamsOwnedCard).not.toBeNull();
     expect(sameTeamOwnedCard).not.toBeNull();
-    expect(within(mostTeamsPlayedCard!).getByText('F Jamie Benn')).toBeInTheDocument();
-    expect(within(mostTeamsOwnedCard!).getByText('G Andrei Vasilevskiy')).toBeInTheDocument();
+    expect(await within(mostTeamsPlayedCard!).findByText('F Jamie Benn')).toBeInTheDocument();
+    expect(within(mostTeamsOwnedCard!).getByText('tableCard.loadWhenVisible')).toBeInTheDocument();
     expect(within(sameTeamOwnedCard!).getByText('tableCard.apiUnavailable')).toBeInTheDocument();
   });
 });

--- a/src/app/career/highlights/career-highlights.component.ts
+++ b/src/app/career/highlights/career-highlights.component.ts
@@ -22,6 +22,7 @@ import { FooterVisibilityService } from '@services/footer-visibility.service';
 import { TableCardComponent } from '@shared/table-card/table-card.component';
 import { TableCardRow } from '@shared/table-card/table-card.types';
 
+import { ActivateOnViewportDirective } from './activate-on-viewport.directive';
 import { CareerHighlightCardState, CareerHighlightCardView } from './career-highlights.types';
 
 const PAGE_SIZE = 10;
@@ -73,8 +74,9 @@ function createInitialCardState(config: HighlightCardConfig): CareerHighlightCar
     titleKey: config.titleKey,
     descriptionKey: config.descriptionKey,
     valueColumnLabelKey: config.valueColumnLabelKey,
+    activated: false,
     rows: [],
-    loading: true,
+    loading: false,
     apiError: false,
     skip: 0,
     take: PAGE_SIZE,
@@ -85,7 +87,7 @@ function createInitialCardState(config: HighlightCardConfig): CareerHighlightCar
 @Component({
   selector: 'app-career-highlights',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [TableCardComponent, TranslateModule],
+  imports: [ActivateOnViewportDirective, TableCardComponent, TranslateModule],
   templateUrl: './career-highlights.component.html',
   styleUrl: './career-highlights.component.scss',
 })
@@ -112,20 +114,15 @@ export class CareerHighlightsComponent implements OnInit {
   );
 
   private footerVisibilityCycle = 0;
-  private pendingInitialLoads = 0;
+  private footerMarkedReady = false;
 
   ngOnInit(): void {
     this.footerVisibilityCycle = this.footerVisibilityService.currentCycle();
-    this.pendingInitialLoads = HIGHLIGHT_CARD_CONFIGS.length;
-
-    for (const config of HIGHLIGHT_CARD_CONFIGS) {
-      this.loadCard(config.type, 0, true);
-    }
   }
 
   loadPreviousPage(type: CareerHighlightType): void {
     const current = this.getCardSignal(type)();
-    if (current.loading) {
+    if (!current.activated || current.loading) {
       return;
     }
 
@@ -139,7 +136,7 @@ export class CareerHighlightsComponent implements OnInit {
 
   loadNextPage(type: CareerHighlightType): void {
     const current = this.getCardSignal(type)();
-    if (current.loading) {
+    if (!current.activated || current.loading) {
       return;
     }
 
@@ -149,6 +146,20 @@ export class CareerHighlightsComponent implements OnInit {
     }
 
     this.loadCard(type, nextSkip);
+  }
+
+  activateCard(type: CareerHighlightType): void {
+    const cardSignal = this.getCardSignal(type);
+    if (cardSignal().activated) {
+      return;
+    }
+
+    cardSignal.update((current) => ({
+      ...current,
+      activated: true,
+    }));
+
+    this.loadCard(type, 0, true);
   }
 
   private loadCard(
@@ -228,13 +239,11 @@ export class CareerHighlightsComponent implements OnInit {
   }
 
   private markInitialLoadReady(initialLoad: boolean): void {
-    if (!initialLoad) {
+    if (!initialLoad || this.footerMarkedReady) {
       return;
     }
 
-    this.pendingInitialLoads -= 1;
-    if (this.pendingInitialLoads === 0) {
-      this.footerVisibilityService.markReady(this.footerVisibilityCycle);
-    }
+    this.footerMarkedReady = true;
+    this.footerVisibilityService.markReady(this.footerVisibilityCycle);
   }
 }

--- a/src/app/career/highlights/career-highlights.types.ts
+++ b/src/app/career/highlights/career-highlights.types.ts
@@ -5,6 +5,7 @@ export interface CareerHighlightCardState {
   readonly titleKey: string;
   readonly descriptionKey: string;
   readonly valueColumnLabelKey: string;
+  readonly activated: boolean;
   readonly rows: readonly TableCardRow[];
   readonly loading: boolean;
   readonly apiError: boolean;

--- a/src/app/shared/table-card/table-card.component.html
+++ b/src/app/shared/table-card/table-card.component.html
@@ -1,4 +1,4 @@
-<mat-card class="table-card mat-elevation-z4">
+<mat-card class="table-card mat-elevation-z4" [class.table-card--deferred]="deferred()">
   <mat-card-header>
     <h3 mat-card-title>
       {{ titleKey() | translate }}
@@ -8,12 +8,16 @@
     </p>
   </mat-card-header>
 
-  @if (loading() && !hasRows()) {
+  @if (loading() && !hasRows() && !deferred()) {
   <mat-progress-bar mode="indeterminate" />
   }
 
   <mat-card-content>
-    @if (apiError() && !hasRows()) {
+    @if (deferred()) {
+    <p class="card-status-message card-status-message--deferred">
+      {{ 'tableCard.loadWhenVisible' | translate }}
+    </p>
+    } @else if (apiError() && !hasRows()) {
     <p class="card-status-message" role="status">
       {{ 'tableCard.apiUnavailable' | translate }}
     </p>
@@ -75,6 +79,7 @@
     }
   </mat-card-content>
 
+  @if (!deferred()) {
   <mat-card-actions class="card-actions">
     <button mat-stroked-button type="button" (click)="previousPageRequested.emit()"
       [disabled]="loading() || !hasPreviousPage()" [attr.aria-label]="'tableCard.previousPage' | translate">
@@ -100,4 +105,5 @@
       <mat-icon>chevron_right</mat-icon>
     </button>
   </mat-card-actions>
+  }
 </mat-card>

--- a/src/app/shared/table-card/table-card.component.scss
+++ b/src/app/shared/table-card/table-card.component.scss
@@ -41,6 +41,14 @@ mat-card-header {
   color: var(--mat-sys-on-surface-variant);
 }
 
+.table-card--deferred .card-status-message--deferred {
+  display: flex;
+  min-height: 15rem;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+}
+
 .card-inline-error {
   padding-top: 0;
 }

--- a/src/app/shared/table-card/table-card.component.spec.ts
+++ b/src/app/shared/table-card/table-card.component.spec.ts
@@ -17,6 +17,7 @@ import { TableCardRow } from './table-card.types';
       [descriptionKey]="descriptionKey"
       [primaryColumnLabelKey]="primaryColumnLabelKey"
       [valueColumnLabelKey]="valueColumnLabelKey"
+      [deferred]="deferred"
       [rows]="rows"
       [loading]="loading"
       [apiError]="apiError"
@@ -31,6 +32,7 @@ class TableCardHostComponent {
   descriptionKey = 'career.highlights.cards.mostTeamsPlayed.description';
   primaryColumnLabelKey = 'career.highlights.columns.player';
   valueColumnLabelKey = 'career.highlights.columns.teamCount';
+  deferred = false;
   loading = false;
   apiError = false;
   skip = 0;
@@ -78,5 +80,17 @@ describe('TableCardComponent', () => {
 
     expect(await screen.findByText('tableCard.noResults')).toBeInTheDocument();
     expect(screen.queryByRole('table')).not.toBeInTheDocument();
+  });
+
+  it('shows a deferred placeholder until the card is activated', async () => {
+    await setup({
+      deferred: true,
+      rows: [],
+      total: 0,
+    });
+
+    expect(await screen.findByText('tableCard.loadWhenVisible')).toBeInTheDocument();
+    expect(screen.queryByRole('table')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'tableCard.nextPage' })).not.toBeInTheDocument();
   });
 });

--- a/src/app/shared/table-card/table-card.component.ts
+++ b/src/app/shared/table-card/table-card.component.ts
@@ -27,6 +27,7 @@ export class TableCardComponent {
   readonly descriptionKey = input.required<string>();
   readonly primaryColumnLabelKey = input.required<string>();
   readonly valueColumnLabelKey = input.required<string>();
+  readonly deferred = input(false);
   readonly rows = input.required<readonly TableCardRow[]>();
   readonly loading = input(false);
   readonly apiError = input(false);


### PR DESCRIPTION
## Summary

- defer `/career/highlights` card data loading until each card has enough visible viewport area instead of requesting every highlight dataset on route startup
- add a small viewport-activation directive and a deferred placeholder state for highlight cards before they load
- keep existing per-card paging behavior intact once a card has been activated
- tighten mobile behavior so later highlight cards load only after a more meaningful scroll position
- update unit/mobile/E2E coverage and related docs for the new loading strategy

## Testing

- `npm test`
- `npm run verify`
