### PR TITLE
Addition: Add new career highlight cards

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Live showcase: https://ffhl-stats.vercel.app/
 	- Searchable and sortable, with no stats-page filters or mobile drawer
 	- Virtualized row rendering keeps long lists responsive
 	- Player rows show position inline with name (for example `D Travis Hamonic`) while still sorting alphabetically by player name
-	- `/career/highlights` adds compact paged highlight cards for focused career leaderboard slices such as most teams played/owned and most same-team seasons played/owned, and each card now lazy-loads its dataset as it approaches the viewport
+	- `/career/highlights` adds compact paged highlight cards for focused career leaderboard slices such as most teams played/owned, most Stanley Cups, regular-season grinders without playoff appearances, stash leaders, and most same-team seasons played/owned; each card lazy-loads its dataset as it approaches the viewport
 - 🚦 **Split Route Shells**: Interactive dashboard routes lazy-load their heavier shell (controls, settings drawer, comparison bar, tabs), while career and leaderboard browsing routes stay on a lighter root shell
 - 🗂️ **Global Navigation**: Bottom sheet menu for switching between views (hockey stats, player careers, leaderboards, info/help)
 - 🔗 **Direct Player Links**: Shareable URLs for player/goalie cards

--- a/docs/component-guide.md
+++ b/docs/component-guide.md
@@ -199,7 +199,7 @@ TeamService → PlayerStatsComponent (triggers refetch + adds teamId)
 - Fetch career rows from the dedicated API endpoints
 - Pass column definitions and formatters into the shared virtualized table
 - Keep the player career table sorted by plain `name` while rendering position inline with the displayed player name
-- Normalize paged highlight responses into the shared `TableCardComponent` row shape for the `/career/highlights` route
+- Normalize paged highlight responses into the shared `TableCardComponent` row shape for the `/career/highlights` route, including team-count, same-team, Stanley Cup, stash, and regular-grinder highlight variants
 - Activate highlight-card API loads lazily as each card approaches the viewport instead of requesting every card during route startup
 
 ### TableCardComponent

--- a/docs/project-overview.md
+++ b/docs/project-overview.md
@@ -78,7 +78,7 @@ Accessibility is a core requirement: the UI is designed to remain usable via key
    - Searchable and sortable without the stats-page controls/drawer/comparison bar
    - Player position is rendered inline with player name while sorting still uses the underlying plain `name`
    - Uses a virtualized table implementation to keep large result sets responsive
-   - The highlights tab uses compact paged table cards for focused leaderboard slices such as most teams played/owned and most same-team seasons played/owned
+   - The highlights tab uses compact paged table cards for focused leaderboard slices such as most teams played/owned, most Stanley Cups, regular grinders without playoff appearances, stash leaders, and most same-team seasons played/owned
    - Highlight cards lazy-load their API data as they enter or near the viewport so the route scales better as more cards are added
 
 7. **Data Management**

--- a/e2e/fixtures/data/career--highlights--most-stanley-cups--skip=0--take=10.json
+++ b/e2e/fixtures/data/career--highlights--most-stanley-cups--skip=0--take=10.json
@@ -1,0 +1,59 @@
+{
+  "type": "most-stanley-cups",
+  "skip": 0,
+  "take": 10,
+  "total": 2,
+  "items": [
+    {
+      "id": "cup-1",
+      "name": "Patrick Maroon",
+      "position": "F",
+      "cupCount": 3,
+      "cups": [
+        {
+          "season": 2018,
+          "team": {
+            "id": "1",
+            "name": "Colorado Avalanche"
+          }
+        },
+        {
+          "season": 2020,
+          "team": {
+            "id": "2",
+            "name": "Dallas Stars"
+          }
+        },
+        {
+          "season": 2021,
+          "team": {
+            "id": "3",
+            "name": "Tampa Bay Lightning"
+          }
+        }
+      ]
+    },
+    {
+      "id": "cup-2",
+      "name": "Pat Maroon",
+      "position": "F",
+      "cupCount": 2,
+      "cups": [
+        {
+          "season": 2018,
+          "team": {
+            "id": "1",
+            "name": "Colorado Avalanche"
+          }
+        },
+        {
+          "season": 2020,
+          "team": {
+            "id": "2",
+            "name": "Dallas Stars"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/e2e/fixtures/data/career--highlights--regular-grinder-without-playoffs--skip=0--take=10.json
+++ b/e2e/fixtures/data/career--highlights--regular-grinder-without-playoffs--skip=0--take=10.json
@@ -1,0 +1,36 @@
+{
+  "type": "regular-grinder-without-playoffs",
+  "skip": 0,
+  "take": 10,
+  "total": 2,
+  "items": [
+    {
+      "id": "grinder-1",
+      "name": "Radek Faksa",
+      "position": "F",
+      "regularGames": 512,
+      "teams": [
+        {
+          "id": "2",
+          "name": "Dallas Stars"
+        },
+        {
+          "id": "4",
+          "name": "Carolina Hurricanes"
+        }
+      ]
+    },
+    {
+      "id": "grinder-2",
+      "name": "Jack Johnson",
+      "position": "D",
+      "regularGames": 484,
+      "teams": [
+        {
+          "id": "1",
+          "name": "Colorado Avalanche"
+        }
+      ]
+    }
+  ]
+}

--- a/e2e/fixtures/data/career--highlights--stash-king--skip=0--take=10.json
+++ b/e2e/fixtures/data/career--highlights--stash-king--skip=0--take=10.json
@@ -1,0 +1,28 @@
+{
+  "type": "stash-king",
+  "skip": 0,
+  "take": 10,
+  "total": 2,
+  "items": [
+    {
+      "id": "stash-1",
+      "name": "Anton Khudobin",
+      "position": "G",
+      "seasonCount": 11,
+      "team": {
+        "id": "2",
+        "name": "Dallas Stars"
+      }
+    },
+    {
+      "id": "stash-2",
+      "name": "Mark Pysyk",
+      "position": "D",
+      "seasonCount": 10,
+      "team": {
+        "id": "4",
+        "name": "Carolina Hurricanes"
+      }
+    }
+  ]
+}

--- a/e2e/page-objects/PlayerCardDialog.ts
+++ b/e2e/page-objects/PlayerCardDialog.ts
@@ -149,13 +149,17 @@ export class PlayerCardDialog {
    * Navigate to next player via ArrowRight
    */
   async navigateNext(): Promise<void> {
-    await this.page.keyboard.press('ArrowRight');
+    const closeButton = this.dialog.getByRole('button', { name: 'Sulje pelaajakortti' });
+    await closeButton.focus();
+    await closeButton.press('ArrowRight');
   }
 
   /**
    * Navigate to previous player via ArrowLeft
    */
   async navigatePrevious(): Promise<void> {
-    await this.page.keyboard.press('ArrowLeft');
+    const closeButton = this.dialog.getByRole('button', { name: 'Sulje pelaajakortti' });
+    await closeButton.focus();
+    await closeButton.press('ArrowLeft');
   }
 }

--- a/e2e/scripts/capture-fixtures.ts
+++ b/e2e/scripts/capture-fixtures.ts
@@ -100,10 +100,13 @@ async function buildFixtureList(): Promise<FixtureEntry[]> {
     { path: 'career/highlights/most-teams-played', params: { skip: '10', take: '10' } },
     { path: 'career/highlights/most-teams-owned', params: { skip: '0', take: '10' } },
     { path: 'career/highlights/most-teams-owned', params: { skip: '10', take: '10' } },
+    { path: 'career/highlights/most-stanley-cups', params: { skip: '0', take: '10' } },
+    { path: 'career/highlights/regular-grinder-without-playoffs', params: { skip: '0', take: '10' } },
     { path: 'career/highlights/same-team-seasons-played', params: { skip: '0', take: '10' } },
     { path: 'career/highlights/same-team-seasons-played', params: { skip: '10', take: '10' } },
     { path: 'career/highlights/same-team-seasons-owned', params: { skip: '0', take: '10' } },
     { path: 'career/highlights/same-team-seasons-owned', params: { skip: '10', take: '10' } },
+    { path: 'career/highlights/stash-king', params: { skip: '0', take: '10' } },
   ];
 
   return entries;

--- a/e2e/specs/career.spec.ts
+++ b/e2e/specs/career.spec.ts
@@ -1,3 +1,5 @@
+import { Locator } from '@playwright/test';
+
 import { test, expect } from '../fixtures/test-fixture';
 import { TAB_LABELS } from '../config/test-data';
 
@@ -24,7 +26,7 @@ test.describe('Career listings', () => {
     await expect(page).toHaveURL(/\/career\/highlights$/);
     await expect(highlightsTab).toHaveAttribute('aria-selected', 'true');
     const highlightCards = page.locator('app-table-card');
-    await expect(highlightCards).toHaveCount(4);
+    await expect(highlightCards).toHaveCount(7);
     await expect(highlightCards.first().getByRole('table')).toBeVisible();
     await highlightCards.nth(1).scrollIntoViewIfNeeded();
     await expect(highlightCards.nth(1).getByRole('table')).toBeVisible();
@@ -32,13 +34,34 @@ test.describe('Career listings', () => {
     await expect(highlightCards.nth(2).getByRole('table')).toBeVisible();
     await highlightCards.nth(3).scrollIntoViewIfNeeded();
     await expect(highlightCards.nth(3).getByRole('table')).toBeVisible();
+    await highlightCards.nth(4).scrollIntoViewIfNeeded();
+    await expect(highlightCards.nth(4).getByRole('table')).toBeVisible();
+    await highlightCards.nth(5).scrollIntoViewIfNeeded();
+    await expect(highlightCards.nth(5).getByRole('table')).toBeVisible();
+    await highlightCards.nth(6).scrollIntoViewIfNeeded();
+    await expect(highlightCards.nth(6).getByRole('table')).toBeVisible();
 
-    const mostTeamsCard = highlightCards.first();
-    await mostTeamsCard.scrollIntoViewIfNeeded();
-    const firstMostTeamsRow = mostTeamsCard.locator('tbody tr').first();
-    const firstMostTeamsRowText = (await firstMostTeamsRow.textContent())?.trim() ?? '';
-    await mostTeamsCard.getByRole('button', { name: 'Näytä seuraavat rivit' }).click();
-    await expect(firstMostTeamsRow).not.toHaveText(firstMostTeamsRowText);
+    const nextPageButtons = page.getByRole('button', { name: 'Näytä seuraavat rivit' });
+    let pagedCard: Locator | null = null;
+    let pagedCardFirstRow: Locator | null = null;
+
+    for (let index = 0; index < await nextPageButtons.count(); index += 1) {
+      const button = nextPageButtons.nth(index);
+      if (!(await button.isEnabled())) {
+        continue;
+      }
+
+      pagedCard = button.locator('xpath=ancestor::app-table-card[1]');
+      pagedCardFirstRow = pagedCard.locator('tbody tr').first();
+      const firstRowText = (await pagedCardFirstRow.textContent())?.trim() ?? '';
+
+      await button.click();
+      await expect(pagedCardFirstRow).not.toHaveText(firstRowText);
+      break;
+    }
+
+    expect(pagedCard).not.toBeNull();
+    expect(pagedCardFirstRow).not.toBeNull();
 
     const goalieTab = page.getByRole('tab', { name: TAB_LABELS.CAREER_GOALIES });
     await goalieTab.click();

--- a/public/i18n/fi.json
+++ b/public/i18n/fi.json
@@ -23,7 +23,8 @@
       "columns": {
         "player": "Pelaaja",
         "teamCount": "Seurat",
-        "seasonCount": "Kaudet"
+        "seasonCount": "Kaudet",
+        "games": "Ott."
       },
       "cards": {
         "mostTeamsPlayed": {
@@ -41,6 +42,18 @@
         "sameTeamSeasonsOwned": {
           "title": "Eniten edustuskausia - sama seura",
           "description": "Väh. 10 kautta samassa seurassa käyneet."
+        },
+        "mostStanleyCups": {
+          "title": "Eniten Stanley Cup -sormuksia",
+          "description": "Väh. 2 mestaruutta FFHL-uran aikana."
+        },
+        "regularGrinderWithoutPlayoffs": {
+          "title": "Runkosarjajyrät",
+          "description": "Eniten otteluita ilman playoffseja."
+        },
+        "stashKing": {
+          "title": "Eniten farmikausia - sama seura",
+          "description": "Väh. 10 kautta joukkueessa pelaamatta."
         }
       }
     }
@@ -209,10 +222,7 @@
       },
       {
         "type": "ul",
-        "items": [
-          "/ - kohdista hakukenttä",
-          "? - avaa tämä ohje"
-        ]
+        "items": ["/ - kohdista hakukenttä", "? - avaa tämä ohje"]
       },
       {
         "type": "h2",

--- a/src/app/app.component.mobile.spec.ts
+++ b/src/app/app.component.mobile.spec.ts
@@ -276,12 +276,23 @@ describe('AppComponent — mobile frontpage', { timeout: 60_000 }, () => {
       screen.getByRole('heading', { name: 'career.highlights.cards.mostTeamsOwned.title' })
     ).toBeInTheDocument();
     expect(
+      screen.getByRole('heading', { name: 'career.highlights.cards.mostStanleyCups.title' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', {
+        name: 'career.highlights.cards.regularGrinderWithoutPlayoffs.title',
+      })
+    ).toBeInTheDocument();
+    expect(
       screen.getByRole('heading', { name: 'career.highlights.cards.sameTeamSeasonsPlayed.title' })
     ).toBeInTheDocument();
     expect(
       screen.getByRole('heading', { name: 'career.highlights.cards.sameTeamSeasonsOwned.title' })
     ).toBeInTheDocument();
-    expect(screen.getAllByRole('heading', { level: 3 })).toHaveLength(5);
+    expect(
+      screen.getByRole('heading', { name: 'career.highlights.cards.stashKing.title' })
+    ).toBeInTheDocument();
+    expect(screen.getAllByRole('heading', { level: 3 })).toHaveLength(8);
 
     fireEvent.click(screen.getByRole('tab', { name: 'career.tabs.goalies' }));
 

--- a/src/app/career/highlights/career-highlights.component.spec.ts
+++ b/src/app/career/highlights/career-highlights.component.spec.ts
@@ -5,10 +5,13 @@ import { of, throwError } from 'rxjs';
 import { ApiService, CareerHighlightType } from '@services/api.service';
 import { FooterVisibilityService } from '@services/footer-visibility.service';
 import {
+  mostStanleyCupsHighlightsPage0Fixture,
   mostTeamsOwnedHighlightsPage0Fixture,
   mostTeamsPlayedHighlightsPage0Fixture,
   mostTeamsPlayedHighlightsPage1Fixture,
   provideDisabledMaterialAnimations,
+  regularGrinderWithoutPlayoffsHighlightsPage0Fixture,
+  stashKingHighlightsPage0Fixture,
   sameTeamSeasonsOwnedHighlightsPage0Fixture,
   sameTeamSeasonsHighlightsPage0Fixture,
 } from '../../testing/behavior-test-utils';
@@ -90,6 +93,14 @@ describe('CareerHighlightsComponent', () => {
             return of(sameTeamSeasonsHighlightsPage0Fixture);
           case 'same-team-seasons-owned':
             return of(sameTeamSeasonsOwnedHighlightsPage0Fixture);
+          case 'most-stanley-cups':
+            return of(mostStanleyCupsHighlightsPage0Fixture);
+          case 'regular-grinder-without-playoffs':
+            return of(regularGrinderWithoutPlayoffsHighlightsPage0Fixture);
+          case 'stash-king':
+            return of(stashKingHighlightsPage0Fixture);
+          case 'reunion-king':
+            throw new Error('reunion-king should not be requested by the UI');
         }
       }
     );
@@ -118,6 +129,16 @@ describe('CareerHighlightsComponent', () => {
     ).toBeInTheDocument();
     expect(
       screen.getByRole('heading', {
+        name: 'career.highlights.cards.mostStanleyCups.title',
+      })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', {
+        name: 'career.highlights.cards.regularGrinderWithoutPlayoffs.title',
+      })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', {
         name: 'career.highlights.cards.sameTeamSeasonsPlayed.title',
       })
     ).toBeInTheDocument();
@@ -126,41 +147,54 @@ describe('CareerHighlightsComponent', () => {
         name: 'career.highlights.cards.sameTeamSeasonsOwned.title',
       })
     ).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', {
+        name: 'career.highlights.cards.stashKing.title',
+      })
+    ).toBeInTheDocument();
 
     await vi.waitFor(() => {
-      expect(FakeIntersectionObserver.instances).toHaveLength(4);
+      expect(FakeIntersectionObserver.instances).toHaveLength(7);
     });
 
     expect(getCareerHighlights).not.toHaveBeenCalled();
-    expect(screen.getAllByText('tableCard.loadWhenVisible')).toHaveLength(4);
+    expect(screen.getAllByText('tableCard.loadWhenVisible')).toHaveLength(7);
 
     FakeIntersectionObserver.instances[0]?.trigger();
-    FakeIntersectionObserver.instances[1]?.trigger();
+    FakeIntersectionObserver.instances[2]?.trigger();
 
     const mostTeamsCardTitle = screen.getByRole('heading', {
       name: 'career.highlights.cards.mostTeamsPlayed.title',
     });
+    const stanleyCupCardTitle = screen.getByRole('heading', {
+      name: 'career.highlights.cards.mostStanleyCups.title',
+    });
+    const mostTeamsCard = mostTeamsCardTitle.closest('mat-card') as HTMLElement | null;
+    const stanleyCupCard = stanleyCupCardTitle.closest('mat-card') as HTMLElement | null;
+
+    expect(mostTeamsCard).not.toBeNull();
+    expect(stanleyCupCard).not.toBeNull();
+    expect(await within(mostTeamsCard!).findByText('F Jamie Benn')).toBeInTheDocument();
+    expect(await within(stanleyCupCard!).findByText('F Patrick Maroon')).toBeInTheDocument();
+    expect(getCareerHighlights).toHaveBeenCalledTimes(2);
+    expect(getCareerHighlights).toHaveBeenNthCalledWith(1, 'most-stanley-cups', 0, 10);
+    expect(getCareerHighlights).toHaveBeenNthCalledWith(2, 'most-teams-played', 0, 10);
+    expect(within(stanleyCupCard!).getByText('💍')).toBeInTheDocument();
+    expect(within(stanleyCupCard!).getByText('3')).toBeInTheDocument();
+    expect(within(stanleyCupCard!).queryByText('D Victor Hedman')).not.toBeInTheDocument();
+
+    FakeIntersectionObserver.instances[4]?.trigger();
+
     const sameTeamPlayedCardTitle = screen.getByRole('heading', {
       name: 'career.highlights.cards.sameTeamSeasonsPlayed.title',
     });
-    const mostTeamsCard = mostTeamsCardTitle.closest('mat-card') as HTMLElement | null;
     const sameTeamPlayedCard = sameTeamPlayedCardTitle.closest('mat-card') as HTMLElement | null;
 
-    expect(mostTeamsCard).not.toBeNull();
     expect(sameTeamPlayedCard).not.toBeNull();
-    expect(await within(mostTeamsCard!).findByText('F Jamie Benn')).toBeInTheDocument();
-    expect(screen.getByText('G Andrei Vasilevskiy')).toBeInTheDocument();
-    expect(getCareerHighlights).toHaveBeenCalledTimes(2);
-    expect(getCareerHighlights).toHaveBeenNthCalledWith(1, 'most-teams-played', 0, 10);
-    expect(getCareerHighlights).toHaveBeenNthCalledWith(2, 'most-teams-owned', 0, 10);
-    expect(within(sameTeamPlayedCard!).queryByText('D Victor Hedman')).not.toBeInTheDocument();
-
-    FakeIntersectionObserver.instances[2]?.trigger();
-
     expect(await within(sameTeamPlayedCard!).findByText('D Victor Hedman')).toBeInTheDocument();
     expect(getCareerHighlights).toHaveBeenCalledWith('same-team-seasons-played', 0, 10);
 
-    fireEvent.click(screen.getAllByRole('button', { name: 'tableCard.nextPage' })[0]);
+    fireEvent.click(within(mostTeamsCard!).getByRole('button', { name: 'tableCard.nextPage' }));
 
     expect(await within(mostTeamsCard!).findByText('F Anthony Duclair')).toBeInTheDocument();
     expect(within(mostTeamsCard!).queryByText('F Jamie Benn')).not.toBeInTheDocument();
@@ -182,6 +216,12 @@ describe('CareerHighlightsComponent', () => {
                 : of(
                   type === 'most-teams-owned'
                     ? mostTeamsOwnedHighlightsPage0Fixture
+                    : type === 'most-stanley-cups'
+                      ? mostStanleyCupsHighlightsPage0Fixture
+                      : type === 'regular-grinder-without-playoffs'
+                        ? regularGrinderWithoutPlayoffsHighlightsPage0Fixture
+                        : type === 'stash-king'
+                          ? stashKingHighlightsPage0Fixture
                     : type === 'same-team-seasons-played'
                       ? sameTeamSeasonsHighlightsPage0Fixture
                       : mostTeamsPlayedHighlightsPage0Fixture
@@ -192,11 +232,11 @@ describe('CareerHighlightsComponent', () => {
     });
 
     await vi.waitFor(() => {
-      expect(FakeIntersectionObserver.instances).toHaveLength(4);
+      expect(FakeIntersectionObserver.instances).toHaveLength(7);
     });
 
-    FakeIntersectionObserver.instances[0]?.trigger();
-    FakeIntersectionObserver.instances[3]?.trigger();
+    FakeIntersectionObserver.instances[2]?.trigger();
+    FakeIntersectionObserver.instances[5]?.trigger();
 
     const mostTeamsPlayedCardTitle = await screen.findByRole('heading', {
       name: 'career.highlights.cards.mostTeamsPlayed.title',

--- a/src/app/career/highlights/career-highlights.component.ts
+++ b/src/app/career/highlights/career-highlights.component.ts
@@ -14,16 +14,23 @@ import { TranslateModule } from '@ngx-translate/core';
 import {
   ApiService,
   CareerHighlightPage,
+  CareerRegularGrinderHighlightPage,
   CareerSameTeamHighlightPage,
+  CareerStashHighlightPage,
+  CareerStanleyCupHighlightPage,
   CareerTeamCountHighlightPage,
-  CareerHighlightType,
 } from '@services/api.service';
 import { FooterVisibilityService } from '@services/footer-visibility.service';
 import { TableCardComponent } from '@shared/table-card/table-card.component';
 import { TableCardRow } from '@shared/table-card/table-card.types';
+import { formatSeasonDisplay } from '@shared/utils/season.utils';
 
 import { ActivateOnViewportDirective } from './activate-on-viewport.directive';
-import { CareerHighlightCardState, CareerHighlightCardView } from './career-highlights.types';
+import {
+  CareerHighlightCardState,
+  CareerHighlightCardView,
+  CareerHighlightsUiType,
+} from './career-highlights.types';
 
 const PAGE_SIZE = 10;
 
@@ -31,7 +38,7 @@ type HighlightCardConfig = Pick<
   CareerHighlightCardState,
   'titleKey' | 'descriptionKey' | 'valueColumnLabelKey'
 > & {
-  readonly type: CareerHighlightType;
+  readonly type: CareerHighlightsUiType;
 };
 
 const MOST_TEAMS_PLAYED_CONFIG: HighlightCardConfig = {
@@ -55,6 +62,21 @@ const MOST_TEAMS_OWNED_CONFIG: HighlightCardConfig = {
   valueColumnLabelKey: 'career.highlights.columns.teamCount',
 };
 
+const MOST_STANLEY_CUPS_CONFIG: HighlightCardConfig = {
+  type: 'most-stanley-cups',
+  titleKey: 'career.highlights.cards.mostStanleyCups.title',
+  descriptionKey: 'career.highlights.cards.mostStanleyCups.description',
+  valueColumnLabelKey: '💍',
+};
+
+const REGULAR_GRINDER_WITHOUT_PLAYOFFS_CONFIG: HighlightCardConfig = {
+  type: 'regular-grinder-without-playoffs',
+  titleKey: 'career.highlights.cards.regularGrinderWithoutPlayoffs.title',
+  descriptionKey:
+    'career.highlights.cards.regularGrinderWithoutPlayoffs.description',
+  valueColumnLabelKey: 'career.highlights.columns.games',
+};
+
 const SAME_TEAM_SEASONS_OWNED_CONFIG: HighlightCardConfig = {
   type: 'same-team-seasons-owned',
   titleKey: 'career.highlights.cards.sameTeamSeasonsOwned.title',
@@ -62,14 +84,26 @@ const SAME_TEAM_SEASONS_OWNED_CONFIG: HighlightCardConfig = {
   valueColumnLabelKey: 'career.highlights.columns.seasonCount',
 };
 
+const STASH_KING_CONFIG: HighlightCardConfig = {
+  type: 'stash-king',
+  titleKey: 'career.highlights.cards.stashKing.title',
+  descriptionKey: 'career.highlights.cards.stashKing.description',
+  valueColumnLabelKey: 'career.highlights.columns.seasonCount',
+};
+
 const HIGHLIGHT_CARD_CONFIGS: readonly HighlightCardConfig[] = [
+  MOST_STANLEY_CUPS_CONFIG,
+  REGULAR_GRINDER_WITHOUT_PLAYOFFS_CONFIG,
   MOST_TEAMS_PLAYED_CONFIG,
   MOST_TEAMS_OWNED_CONFIG,
   SAME_TEAM_SEASONS_PLAYED_CONFIG,
   SAME_TEAM_SEASONS_OWNED_CONFIG,
+  STASH_KING_CONFIG,
 ];
 
-function createInitialCardState(config: HighlightCardConfig): CareerHighlightCardState {
+function createInitialCardState(
+  config: HighlightCardConfig,
+): CareerHighlightCardState {
   return {
     titleKey: config.titleKey,
     descriptionKey: config.descriptionKey,
@@ -97,13 +131,26 @@ export class CareerHighlightsComponent implements OnInit {
   private readonly footerVisibilityService = inject(FooterVisibilityService);
 
   private readonly cardSignals: Record<
-    CareerHighlightType,
+    CareerHighlightsUiType,
     WritableSignal<CareerHighlightCardState>
   > = {
-    'most-teams-played': signal(createInitialCardState(MOST_TEAMS_PLAYED_CONFIG)),
+    'most-teams-played': signal(
+      createInitialCardState(MOST_TEAMS_PLAYED_CONFIG),
+    ),
     'most-teams-owned': signal(createInitialCardState(MOST_TEAMS_OWNED_CONFIG)),
-    'same-team-seasons-played': signal(createInitialCardState(SAME_TEAM_SEASONS_PLAYED_CONFIG)),
-    'same-team-seasons-owned': signal(createInitialCardState(SAME_TEAM_SEASONS_OWNED_CONFIG)),
+    'most-stanley-cups': signal(
+      createInitialCardState(MOST_STANLEY_CUPS_CONFIG),
+    ),
+    'regular-grinder-without-playoffs': signal(
+      createInitialCardState(REGULAR_GRINDER_WITHOUT_PLAYOFFS_CONFIG),
+    ),
+    'same-team-seasons-played': signal(
+      createInitialCardState(SAME_TEAM_SEASONS_PLAYED_CONFIG),
+    ),
+    'same-team-seasons-owned': signal(
+      createInitialCardState(SAME_TEAM_SEASONS_OWNED_CONFIG),
+    ),
+    'stash-king': signal(createInitialCardState(STASH_KING_CONFIG)),
   };
 
   readonly cards = computed<readonly CareerHighlightCardView[]>(() =>
@@ -120,7 +167,7 @@ export class CareerHighlightsComponent implements OnInit {
     this.footerVisibilityCycle = this.footerVisibilityService.currentCycle();
   }
 
-  loadPreviousPage(type: CareerHighlightType): void {
+  loadPreviousPage(type: CareerHighlightsUiType): void {
     const current = this.getCardSignal(type)();
     if (!current.activated || current.loading) {
       return;
@@ -134,7 +181,7 @@ export class CareerHighlightsComponent implements OnInit {
     this.loadCard(type, nextSkip);
   }
 
-  loadNextPage(type: CareerHighlightType): void {
+  loadNextPage(type: CareerHighlightsUiType): void {
     const current = this.getCardSignal(type)();
     if (!current.activated || current.loading) {
       return;
@@ -148,7 +195,7 @@ export class CareerHighlightsComponent implements OnInit {
     this.loadCard(type, nextSkip);
   }
 
-  activateCard(type: CareerHighlightType): void {
+  activateCard(type: CareerHighlightsUiType): void {
     const cardSignal = this.getCardSignal(type);
     if (cardSignal().activated) {
       return;
@@ -163,7 +210,7 @@ export class CareerHighlightsComponent implements OnInit {
   }
 
   private loadCard(
-    type: CareerHighlightType,
+    type: CareerHighlightsUiType,
     targetSkip: number,
     initialLoad = false,
   ): void {
@@ -213,28 +260,89 @@ export class CareerHighlightsComponent implements OnInit {
       }));
     }
 
-    if (!this.isSameTeamPage(page)) {
-      return [];
+    if (this.isSameTeamPage(page)) {
+      return page.items.map((item) => ({
+        key: `${item.id}:${item.team.id}`,
+        primaryText: `${item.position} ${item.name}`,
+        value: item.seasonCount,
+        detailLines: [item.team.name],
+        detailLabel: item.name,
+      }));
     }
 
-    return page.items.map((item) => ({
-      key: `${item.id}:${item.team.id}`,
-      primaryText: `${item.position} ${item.name}`,
-      value: item.seasonCount,
-      detailLines: [item.team.name],
-      detailLabel: item.name,
-    }));
+    if (this.isStanleyCupPage(page)) {
+      return page.items.map((item) => ({
+        key: item.id,
+        primaryText: `${item.position} ${item.name}`,
+        value: item.cupCount,
+        detailLines: item.cups.map(
+          (cup) => `${formatSeasonDisplay(cup.season)} ${cup.team.name}`,
+        ),
+        detailLabel: item.name,
+      }));
+    }
+
+    if (this.isRegularGrinderPage(page)) {
+      return page.items.map((item) => ({
+        key: item.id,
+        primaryText: `${item.position} ${item.name}`,
+        value: item.regularGames,
+        detailLines: item.teams.map((team) => team.name),
+        detailLabel: item.name,
+      }));
+    }
+
+    if (this.isStashPage(page)) {
+      return page.items.map((item) => ({
+        key: `${item.id}:${item.team.id}`,
+        primaryText: `${item.position} ${item.name}`,
+        value: item.seasonCount,
+        detailLines: [item.team.name],
+        detailLabel: item.name,
+      }));
+    }
+
+    return [];
   }
 
-  private isTeamCountPage(page: CareerHighlightPage): page is CareerTeamCountHighlightPage {
-    return page.type === 'most-teams-played' || page.type === 'most-teams-owned';
+  private isTeamCountPage(
+    page: CareerHighlightPage,
+  ): page is CareerTeamCountHighlightPage {
+    return (
+      page.type === 'most-teams-played' || page.type === 'most-teams-owned'
+    );
   }
 
-  private isSameTeamPage(page: CareerHighlightPage): page is CareerSameTeamHighlightPage {
-    return page.type === 'same-team-seasons-played' || page.type === 'same-team-seasons-owned';
+  private isSameTeamPage(
+    page: CareerHighlightPage,
+  ): page is CareerSameTeamHighlightPage {
+    return (
+      page.type === 'same-team-seasons-played' ||
+      page.type === 'same-team-seasons-owned'
+    );
   }
 
-  private getCardSignal(type: CareerHighlightType): WritableSignal<CareerHighlightCardState> {
+  private isStanleyCupPage(
+    page: CareerHighlightPage,
+  ): page is CareerStanleyCupHighlightPage {
+    return page.type === 'most-stanley-cups';
+  }
+
+  private isRegularGrinderPage(
+    page: CareerHighlightPage,
+  ): page is CareerRegularGrinderHighlightPage {
+    return page.type === 'regular-grinder-without-playoffs';
+  }
+
+  private isStashPage(
+    page: CareerHighlightPage,
+  ): page is CareerStashHighlightPage {
+    return page.type === 'stash-king';
+  }
+
+  private getCardSignal(
+    type: CareerHighlightsUiType,
+  ): WritableSignal<CareerHighlightCardState> {
     return this.cardSignals[type];
   }
 

--- a/src/app/career/highlights/career-highlights.types.ts
+++ b/src/app/career/highlights/career-highlights.types.ts
@@ -1,5 +1,7 @@
-import { TableCardRow } from '@shared/table-card/table-card.types';
 import { CareerHighlightType } from '@services/api.service';
+import { TableCardRow } from '@shared/table-card/table-card.types';
+
+export type CareerHighlightsUiType = Exclude<CareerHighlightType, 'reunion-king'>;
 
 export interface CareerHighlightCardState {
   readonly titleKey: string;
@@ -15,6 +17,6 @@ export interface CareerHighlightCardState {
 }
 
 export interface CareerHighlightCardView {
-  readonly type: CareerHighlightType;
+  readonly type: CareerHighlightsUiType;
   readonly state: CareerHighlightCardState;
 }

--- a/src/app/services/api.service.ts
+++ b/src/app/services/api.service.ts
@@ -22,11 +22,22 @@ export type CareerHighlightType     = components['schemas']['CareerHighlightType
 export type CareerHighlightTeam     = components['schemas']['CareerHighlightTeam'];
 export type CareerTeamCountHighlightItem = components['schemas']['CareerTeamCountHighlightItem'];
 export type CareerSameTeamHighlightItem = components['schemas']['CareerSameTeamHighlightItem'];
+export type CareerStanleyCupHighlightItem = components['schemas']['CareerStanleyCupHighlightItem'];
+export type CareerStashHighlightItem = components['schemas']['CareerStashHighlightItem'];
+export type CareerRegularGrinderHighlightItem =
+  components['schemas']['CareerRegularGrinderHighlightItem'];
 export type CareerTeamCountHighlightPage = components['schemas']['CareerTeamCountHighlightPage'];
 export type CareerSameTeamHighlightPage = components['schemas']['CareerSameTeamHighlightPage'];
+export type CareerStanleyCupHighlightPage = components['schemas']['CareerStanleyCupHighlightPage'];
+export type CareerStashHighlightPage = components['schemas']['CareerStashHighlightPage'];
+export type CareerRegularGrinderHighlightPage =
+  components['schemas']['CareerRegularGrinderHighlightPage'];
 export type CareerHighlightPage =
   | CareerTeamCountHighlightPage
-  | CareerSameTeamHighlightPage;
+  | CareerSameTeamHighlightPage
+  | CareerStanleyCupHighlightPage
+  | CareerStashHighlightPage
+  | CareerRegularGrinderHighlightPage;
 
 // Player includes frontend-only augmentation fields not present in the API spec.
 // seasons is made optional to match single-season endpoint usage (spec: CombinedPlayer has required seasons).

--- a/src/app/services/api.types.generated.ts
+++ b/src/app/services/api.types.generated.ts
@@ -1013,6 +1013,19 @@ export interface paths {
          * @description Returns a paged mixed skater + goalie career highlights leaderboard.
          *     `most-teams-played` and `most-teams-owned` return team-count rows.
          *     `same-team-seasons-played` and `same-team-seasons-owned` return one row per top team, so the same person can appear multiple times on tied same-team results.
+         *     `most-stanley-cups` returns one row per player/goalie with cup seasons and fantasy teams.
+         *     `reunion-king` returns one row per top reunion team, so the same person can appear multiple
+         *     times on tied reunion results, and includes stint ranges for each return.
+         *     `stash-king` returns the top same-team zero-game season counts, similar to
+         *     `same-team-seasons-owned` but counting only team seasons where both regular and playoff
+         *     games stayed at zero.
+         *     `regular-grinder-without-playoffs` returns total regular-season games plus the played fantasy teams
+         *     for players/goalies who never recorded a playoff appearance.
+         *     Minimum cutoffs are 4 teams for `most-teams-played`, 5 teams for `most-teams-owned`,
+         *     8 same-team seasons for `same-team-seasons-played`, 10 same-team seasons for
+         *     `same-team-seasons-owned`, 2 cups for `most-stanley-cups`, 2 reunion stints for
+         *     `reunion-king`, 10 stash counts for `stash-king`, and 60 games for
+         *     `regular-grinder-without-playoffs`.
          */
         get: {
             parameters: {
@@ -1037,7 +1050,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["CareerTeamCountHighlightPage"] | components["schemas"]["CareerSameTeamHighlightPage"];
+                        "application/json": components["schemas"]["CareerTeamCountHighlightPage"] | components["schemas"]["CareerSameTeamHighlightPage"] | components["schemas"]["CareerStanleyCupHighlightPage"] | components["schemas"]["CareerReunionHighlightPage"] | components["schemas"]["CareerStashHighlightPage"] | components["schemas"]["CareerRegularGrinderHighlightPage"];
                     };
                 };
                 /** @description Invalid highlight type or paging params. */
@@ -1307,7 +1320,7 @@ export interface components {
             playoffGames: number;
         };
         /** @enum {string} */
-        CareerHighlightType: "most-teams-played" | "most-teams-owned" | "same-team-seasons-played" | "same-team-seasons-owned";
+        CareerHighlightType: "most-teams-played" | "most-teams-owned" | "same-team-seasons-played" | "same-team-seasons-owned" | "most-stanley-cups" | "reunion-king" | "stash-king" | "regular-grinder-without-playoffs";
         CareerHighlightTeam: {
             id: string;
             name: string;
@@ -1326,6 +1339,43 @@ export interface components {
             seasonCount: number;
             team: components["schemas"]["CareerHighlightTeam"];
         };
+        CareerStanleyCupHighlightCup: {
+            season: number;
+            team: components["schemas"]["CareerHighlightTeam"];
+        };
+        CareerStanleyCupHighlightItem: {
+            id: string;
+            name: string;
+            position: string;
+            cupCount: number;
+            cups: components["schemas"]["CareerStanleyCupHighlightCup"][];
+        };
+        CareerReunionHighlightItem: {
+            id: string;
+            name: string;
+            position: string;
+            reunionCount: number;
+            team: components["schemas"]["CareerHighlightTeam"];
+            stints: components["schemas"]["CareerReunionHighlightStint"][];
+        };
+        CareerReunionHighlightStint: {
+            fromSeason: number;
+            toSeason: number;
+        };
+        CareerStashHighlightItem: {
+            id: string;
+            name: string;
+            position: string;
+            seasonCount: number;
+            team: components["schemas"]["CareerHighlightTeam"];
+        };
+        CareerRegularGrinderHighlightItem: {
+            id: string;
+            name: string;
+            position: string;
+            regularGames: number;
+            teams: components["schemas"]["CareerHighlightTeam"][];
+        };
         CareerTeamCountHighlightPage: {
             /** @enum {string} */
             type: "most-teams-played" | "most-teams-owned";
@@ -1341,6 +1391,38 @@ export interface components {
             take: number;
             total: number;
             items: components["schemas"]["CareerSameTeamHighlightItem"][];
+        };
+        CareerStanleyCupHighlightPage: {
+            /** @enum {string} */
+            type: "most-stanley-cups";
+            skip: number;
+            take: number;
+            total: number;
+            items: components["schemas"]["CareerStanleyCupHighlightItem"][];
+        };
+        CareerReunionHighlightPage: {
+            /** @enum {string} */
+            type: "reunion-king";
+            skip: number;
+            take: number;
+            total: number;
+            items: components["schemas"]["CareerReunionHighlightItem"][];
+        };
+        CareerStashHighlightPage: {
+            /** @enum {string} */
+            type: "stash-king";
+            skip: number;
+            take: number;
+            total: number;
+            items: components["schemas"]["CareerStashHighlightItem"][];
+        };
+        CareerRegularGrinderHighlightPage: {
+            /** @enum {string} */
+            type: "regular-grinder-without-playoffs";
+            skip: number;
+            take: number;
+            total: number;
+            items: components["schemas"]["CareerRegularGrinderHighlightItem"][];
         };
         CareerGoalie: {
             id: string;

--- a/src/app/shared/table-card/table-card.component.spec.ts
+++ b/src/app/shared/table-card/table-card.component.spec.ts
@@ -93,4 +93,12 @@ describe('TableCardComponent', () => {
     expect(screen.queryByRole('table')).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'tableCard.nextPage' })).not.toBeInTheDocument();
   });
+
+  it('renders a literal value column label when the provided label is not a translation key', async () => {
+    await setup({
+      valueColumnLabelKey: '💍',
+    });
+
+    expect(await screen.findByText('💍')).toBeInTheDocument();
+  });
 });

--- a/src/app/testing/behavior-test-utils.ts
+++ b/src/app/testing/behavior-test-utils.ts
@@ -65,6 +65,97 @@ export const sameTeamSeasonsOwnedHighlightsPage0Fixture =
   sameTeamSeasonsOwnedHighlightsPage0FixtureData as CareerHighlightPage;
 export const sameTeamSeasonsOwnedHighlightsPage1Fixture =
   sameTeamSeasonsOwnedHighlightsPage1FixtureData as CareerHighlightPage;
+export const mostStanleyCupsHighlightsPage0Fixture = {
+  type: 'most-stanley-cups',
+  skip: 0,
+  take: 10,
+  total: 2,
+  items: [
+    {
+      id: 'cup-1',
+      name: 'Patrick Maroon',
+      position: 'F',
+      cupCount: 3,
+      cups: [
+        {
+          season: 2018,
+          team: { id: '1', name: 'Colorado Avalanche' },
+        },
+        {
+          season: 2020,
+          team: { id: '2', name: 'Dallas Stars' },
+        },
+        {
+          season: 2021,
+          team: { id: '3', name: 'Tampa Bay Lightning' },
+        },
+      ],
+    },
+    {
+      id: 'cup-2',
+      name: 'Pat Maroon',
+      position: 'F',
+      cupCount: 2,
+      cups: [
+        {
+          season: 2018,
+          team: { id: '1', name: 'Colorado Avalanche' },
+        },
+        {
+          season: 2020,
+          team: { id: '2', name: 'Dallas Stars' },
+        },
+      ],
+    },
+  ],
+} as CareerHighlightPage;
+export const regularGrinderWithoutPlayoffsHighlightsPage0Fixture = {
+  type: 'regular-grinder-without-playoffs',
+  skip: 0,
+  take: 10,
+  total: 2,
+  items: [
+    {
+      id: 'grinder-1',
+      name: 'Radek Faksa',
+      position: 'F',
+      regularGames: 512,
+      teams: [
+        { id: '2', name: 'Dallas Stars' },
+        { id: '4', name: 'Carolina Hurricanes' },
+      ],
+    },
+    {
+      id: 'grinder-2',
+      name: 'Jack Johnson',
+      position: 'D',
+      regularGames: 484,
+      teams: [{ id: '1', name: 'Colorado Avalanche' }],
+    },
+  ],
+} as CareerHighlightPage;
+export const stashKingHighlightsPage0Fixture = {
+  type: 'stash-king',
+  skip: 0,
+  take: 10,
+  total: 2,
+  items: [
+    {
+      id: 'stash-1',
+      name: 'Anton Khudobin',
+      position: 'G',
+      seasonCount: 11,
+      team: { id: '2', name: 'Dallas Stars' },
+    },
+    {
+      id: 'stash-2',
+      name: 'Mark Pysyk',
+      position: 'D',
+      seasonCount: 10,
+      team: { id: '4', name: 'Carolina Hurricanes' },
+    },
+  ],
+} as CareerHighlightPage;
 
 export { teamsFixture, lastModifiedFixture, seasonsFixture, playersFixture };
 
@@ -92,6 +183,9 @@ export type BehaviorApiMockOptions = {
   careerHighlightsMostTeamsOwned?: CareerHighlightPage;
   careerHighlightsSameTeamSeasonsPlayed?: CareerHighlightPage;
   careerHighlightsSameTeamSeasonsOwned?: CareerHighlightPage;
+  careerHighlightsMostStanleyCups?: CareerHighlightPage;
+  careerHighlightsRegularGrinderWithoutPlayoffs?: CareerHighlightPage;
+  careerHighlightsStashKing?: CareerHighlightPage;
   leaderboardRegular?: RegularLeaderboardEntry[];
   leaderboardPlayoffs?: PlayoffLeaderboardEntry[];
   errorKeys?: BehaviorApiErrorKey[];
@@ -143,6 +237,15 @@ function getDefaultCareerHighlightsFixture(
       return skip >= 10
         ? (options.careerHighlightsSameTeamSeasonsOwned ?? sameTeamSeasonsOwnedHighlightsPage1Fixture)
         : (options.careerHighlightsSameTeamSeasonsOwned ?? sameTeamSeasonsOwnedHighlightsPage0Fixture);
+    case 'most-stanley-cups':
+      return options.careerHighlightsMostStanleyCups ?? mostStanleyCupsHighlightsPage0Fixture;
+    case 'regular-grinder-without-playoffs':
+      return options.careerHighlightsRegularGrinderWithoutPlayoffs
+        ?? regularGrinderWithoutPlayoffsHighlightsPage0Fixture;
+    case 'stash-king':
+      return options.careerHighlightsStashKing ?? stashKingHighlightsPage0Fixture;
+    case 'reunion-king':
+      throw new Error('Behavior test mock for reunion-king is not configured.');
   }
 }
 


### PR DESCRIPTION
## Summary
- add the new career highlight cards for Stanley Cups, regular grinders without playoff appearances, and stash leaders
- keep `reunion-king` typed in the API layer but intentionally excluded from the UI for now
- align the career highlights route, behavior fixtures, and mobile/spec coverage with the accepted card order
- update Finnish copy and docs to reflect the expanded highlights set

## Testing
- npm run verify
