### PR TITLE
Fix: Adjust Stanley Cup highlight year formatting

### DIFF
--- a/src/app/career/highlights/career-highlights.component.ts
+++ b/src/app/career/highlights/career-highlights.component.ts
@@ -23,7 +23,7 @@ import {
 import { FooterVisibilityService } from '@services/footer-visibility.service';
 import { TableCardComponent } from '@shared/table-card/table-card.component';
 import { TableCardRow } from '@shared/table-card/table-card.types';
-import { formatSeasonDisplay } from '@shared/utils/season.utils';
+import { formatPlayoffYear } from '@shared/utils/season.utils';
 
 import { ActivateOnViewportDirective } from './activate-on-viewport.directive';
 import {
@@ -276,7 +276,7 @@ export class CareerHighlightsComponent implements OnInit {
         primaryText: `${item.position} ${item.name}`,
         value: item.cupCount,
         detailLines: item.cups.map(
-          (cup) => `${formatSeasonDisplay(cup.season)} ${cup.team.name}`,
+          (cup) => `${formatPlayoffYear(cup.season)} ${cup.team.name}`,
         ),
         detailLabel: item.name,
       }));

--- a/src/app/shared/utils/season.utils.spec.ts
+++ b/src/app/shared/utils/season.utils.spec.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+
+import { formatPlayoffYear, formatSeasonDisplay, formatSeasonShort } from './season.utils';
+
+describe('season.utils', () => {
+  it('formats season display values using start and end year', () => {
+    expect(formatSeasonDisplay(2013)).toBe('2013-14');
+    expect(formatSeasonDisplay(2022)).toBe('2022-23');
+  });
+
+  it('formats playoff year values using the season end year', () => {
+    expect(formatPlayoffYear(2013)).toBe('2014');
+    expect(formatPlayoffYear(2015)).toBe('2016');
+    expect(formatPlayoffYear(2022)).toBe('2023');
+  });
+
+  it('formats short season values using two-digit years', () => {
+    expect(formatSeasonShort(2013)).toBe('13-14');
+    expect(formatSeasonShort(2022)).toBe('22-23');
+  });
+});

--- a/src/app/shared/utils/season.utils.ts
+++ b/src/app/shared/utils/season.utils.ts
@@ -15,6 +15,14 @@ export function formatSeasonDisplay(year: number): string {
 }
 
 /**
+ * Formats a season start year into the calendar year when that season's playoffs ended.
+ * Example: 2013 season -> "2014".
+ */
+export function formatPlayoffYear(year: number): string {
+  return String(year + 1);
+}
+
+/**
  * Formats a season year (e.g. 2023) into a short display string (e.g. "23-24").
  */
 export function formatSeasonShort(year: number): string {


### PR DESCRIPTION
## Summary
- change Stanley Cup highlight tooltip rows to show the playoff-winning calendar year instead of the season label
- add a shared `formatPlayoffYear()` helper for that display rule
- cover the new formatter with focused unit tests

## Testing
- npm run verify
