### PR TITLE
Feature: Add transfers leaderboard tab

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,3 +18,5 @@ If a proposed change would alter user-visible application behavior or semantics,
 In every task, include a user review phase before final verify. After review is accepted and verify passes, you can commit. After each user-accepted and verified batch, you may commit if useful as a checkpoint. Offer PR notes as a copy-pasteable code block only when the branch is fully implemented and ready for PR; user will handle the rest.
 
 If using Playwright MCP during a task, close the browser after you are done with it and no longer need it. Do not leave Playwright browser sessions open across unrelated steps or future sessions.
+
+For local Playwright E2E runs, the user controls the backend on `localhost:3000`. If it is not running, ask the user to start it instead of switching to CI-mode mocking as a workaround.

--- a/README.md
+++ b/README.md
@@ -27,9 +27,10 @@ Live showcase: https://ffhl-stats.vercel.app/
 	- 🎯 Radar chart view showing 0-100 normalized score breakdown for individual stats, toggleable with line charts
 	- 🏆 Career bests highlighted in By Season tab with tooltip showing stat name (only for players with 2+ seasons)
 	- ⬅️➡️ Navigate between players/goalies without closing the card: keyboard arrows (←/→), touch swipe (mobile), or trackpad two-finger swipe (laptop). Wraps circularly with screen reader announcements. Active row in the stats table stays in sync. Direction-aware slide transition provides visual feedback
-- 🏆 **All-Time Leaderboards**: Standalone `/leaderboards` route with two ranking tables — regular season (Runkosarja) and playoffs — showing all-time team standings with tie-rank position logic and column sorting
+- 🏆 **All-Time Leaderboards**: Standalone `/leaderboards` route with three ranking tables — regular season (Runkosarja), playoffs, and transfers (Siirrot) — showing all-time team standings and transaction activity with column sorting
 	- Expand/collapse per-team season breakdown by clicking the team row (multiple rows can stay open)
-	- Season details show `🏆` markers for winner/championship seasons (regular + playoffs)
+	- Regular/playoffs keep blank tied ranks, while transfers always show incremental positions
+	- Season details show `🏆` markers for winner/championship seasons (regular + playoffs) and `🤝 | 🟢 | 🔴` summaries for transfers
 - 📚 **Career Listings**: Standalone `/career/players` and `/career/goalies` routes for all-time player and goalie career tables
 	- Searchable and sortable, with no stats-page filters or mobile drawer
 	- Virtualized row rendering keeps long lists responsive
@@ -178,7 +179,7 @@ For planning-heavy changes, save the approved implementation plan locally under 
 E2E tests are organized into feature-based specs under `e2e/specs/`:
 - `smoke.spec.ts` — Core page rendering and navigation
 - `career.spec.ts` — Career players/goalies/highlights tabs, search, paging, and route shell behavior
-- `leaderboards.spec.ts` — Leaderboards redirect, table data, tab navigation, position tie logic, expandable season details
+- `leaderboards.spec.ts` — Leaderboards redirect, regular/playoff/transfers tabs, tie-rank vs incremental position logic, and expandable season details
 - `player-card.spec.ts` — Player card dialog (open/close, tabs, graphs, direct URLs)
 - `team-switching.spec.ts` — Team selector and filter reset behavior
 - `filters.spec.ts` — Report type, season, position, stats-per-game, and min games filters
@@ -188,7 +189,25 @@ E2E tests are organized into feature-based specs under `e2e/specs/`:
 **Local:** Backend API must be running on `localhost:3000` (see [node-fantrax-stats-parser](https://github.com/maestor/node-fantrax-stats-parser)).
 **CI:** E2E tests run without a backend — API responses are served from JSON fixtures via Playwright's `page.route()` mocking.
 
-Local Playwright runs against `http://localhost:4200` and starts `npm start` via Playwright `webServer` when needed.
+Local Playwright runs against `http://localhost:4200`. The Playwright `webServer` starts `npm start` automatically when needed, or reuses an already-running frontend on port `4200`.
+
+Recommended local flow:
+
+```bash
+# 1. Start the backend separately on http://localhost:3000
+
+# 2. Run all E2E tests
+npm run e2e
+
+# or run one spec while iterating
+npx playwright test e2e/specs/leaderboards.spec.ts
+```
+
+Important:
+
+- Do not use `CI=true` for normal local E2E runs. In this repo that switches Playwright into the fixture-backed CI flow, which is meant for CI and explicit offline debugging, not routine local verification against your real backend.
+- `npx playwright test --headed` still uses the same `webServer` config. It does not disable server startup by itself; it simply opens the browser UI while Playwright starts or reuses the frontend.
+- If the backend on `localhost:3000` is not running during a paired session, ask the user to start it. Do not silently swap to CI-mode mocking for routine local verification.
 
 ### Test Coverage Summary
 
@@ -260,7 +279,7 @@ src/
 │   ├── goalie-stats/      # Goalie stats page
 │   ├── dashboard-shell/   # Lazy shell for dashboard routes
 │   ├── career/            # Career listings + highlights (/career/players, /career/goalies, /career/highlights)
-│   ├── leaderboards/      # All-time leaderboards (/leaderboards/regular, /leaderboards/playoffs)
+│   ├── leaderboards/      # All-time leaderboards (/leaderboards/regular, /leaderboards/playoffs, /leaderboards/transfers)
 │   ├── player-route/      # Direct player card route handler
 │   ├── goalie-route/      # Direct goalie card route handler
 │   ├── utils/             # Utility functions (slug generation)

--- a/docs/codebase-structure.md
+++ b/docs/codebase-structure.md
@@ -20,9 +20,10 @@ fantrax-stats-parser-ui/
 │   │   ├── dashboard-shell/   # Lazy route shell for interactive dashboard routes
 │   │   ├── goalie-stats/     # Goalie stats page
 │   │   ├── goalie-route/     # Direct goalie card route handler
-│   │   ├── leaderboards/     # Leaderboards feature (shell + regular and playoffs child components)
+│   │   ├── leaderboards/     # Leaderboards feature (shell + regular, playoffs, and transfers child components)
 │   │   │   ├── regular/      # Regular season leaderboard table
-│   │   │   └── playoffs/     # Playoffs leaderboard table
+│   │   │   ├── playoffs/     # Playoffs leaderboard table
+│   │   │   └── transfers/    # Transfers leaderboard table
 │   │   ├── player-stats/     # Player stats page
 │   │   ├── player-route/     # Direct player card route handler
 │   │   ├── utils/            # Utility functions (slug generation)

--- a/docs/component-guide.md
+++ b/docs/component-guide.md
@@ -223,7 +223,7 @@ TeamService → PlayerStatsComponent (triggers refetch + adds teamId)
 
 **Type**: Feature Wrapper Component
 
-**Purpose**: Reusable leaderboard shell that fetches leaderboard rows and feeds the read-only expandable stats table used by the regular-season and playoffs leaderboard views.
+**Purpose**: Reusable leaderboard shell that fetches leaderboard rows and feeds the read-only expandable stats table used by the regular-season, playoffs, and transfers leaderboard views.
 
 **Inputs**:
 
@@ -237,6 +237,7 @@ readonly expandedRowsFor = input.required<(row: LeaderboardRow) => ExpandedRowVi
 readonly expandToggleAriaLabel = input.required<
   (row: LeaderboardRow, expanded: boolean) => string
 >();
+readonly blankTieRanks = input(true);
 readonly expandedHeaderLabels = input.required<{
   season: string;
   primary: string;
@@ -247,8 +248,24 @@ readonly expandedHeaderLabels = input.required<{
 **Behavior**:
 
 - `formatCell` remains optional because only the regular-season leaderboard currently custom-formats percentage columns
-- All other inputs are required because both concrete leaderboard parents always provide them
-- Fetches rows once on init, derives tied-position display values, and forwards expansion callbacks into `StatsTableComponent`
+- `blankTieRanks` defaults to `true` so regular/playoff views preserve blank tied positions, while the transfers view can opt into always-numbered ranks
+- All other inputs are required because every concrete leaderboard parent provides them
+- Fetches rows once on init, derives position display values, and forwards expansion callbacks into `StatsTableComponent`
+
+### LeaderboardTransfersComponent
+
+**Location**: `src/app/leaderboards/transfers/`
+
+**Type**: Smart Component (Container)
+
+**Purpose**: Render the `/leaderboards/transfers` view with all-time trade, claim, and drop totals plus expandable season-by-season transfer summaries.
+
+**Responsibilities**:
+
+- Fetch the transaction leaderboard from `ApiService`
+- Keep the main table column order as position, team, trades, claims, drops
+- Force incremental ranking even when the backend marks a tie
+- Format expanded season rows as emoji-prefixed transfer summaries (`🤝`, `🟢`, `🔴`)
 
 ---
 

--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -187,6 +187,23 @@ npx playwright test
 - Runs Playwright E2E tests
 - Headless by default
 - Results in `test-results/`
+- Requires the backend API on `http://localhost:3000`
+- Playwright starts `npm start` automatically when needed, or reuses an existing frontend on `http://localhost:4200`
+- Do not use `CI=true` for routine local runs; that switches to the repo's fixture-backed CI flow instead of using your live local backend
+- If the backend is not running during a collaborative session, ask the user to start it before trying fallback approaches
+
+Useful local variants:
+
+```bash
+# Full suite
+npm run e2e
+
+# Single spec while iterating
+npx playwright test e2e/specs/leaderboards.spec.ts
+
+# Headed browser run
+npx playwright test --headed
+```
 
 ### Angular CLI Commands
 ```bash

--- a/docs/project-overview.md
+++ b/docs/project-overview.md
@@ -68,10 +68,11 @@ Accessibility is a core requirement: the UI is designed to remain usable via key
 5. **Team Leaderboards** (`/leaderboards`)
    - All-time regular season ranking table: position, wins, points, win percentage, regular season titles
    - All-time playoffs ranking table: position, championships, finals, conference finals, round results, appearances
-   - Tab navigation between Runkosarja and Playoffs views (default: Playoffs)
-   - Column sorting via `mat-sort`; position ties handled correctly (first tied team shows number, subsequent show blank)
-   - Expandable season breakdown rows per team (regular and playoffs) by clicking a team row, with multiple expanded rows allowed
-   - Season breakdown rows can show trophy markers for winner/championship seasons
+   - All-time transfers ranking table: position, team, trades, claims, drops
+   - Tab navigation between Runkosarja, Playoffs, and Siirrot views (default route: Runkosarja)
+   - Column sorting via `mat-sort`; regular/playoff position ties stay blank after the first tied team, while transfers always show incremental positions
+   - Expandable season breakdown rows per team (regular, playoffs, and transfers) by clicking a team row, with multiple expanded rows allowed
+   - Season breakdown rows can show trophy markers for winner/championship seasons or emoji-prefixed transfer counts per season
 
 6. **Career Listings & Highlights** (`/career/players`, `/career/goalies`, `/career/highlights`)
    - Dedicated all-time career tables for players and goalies
@@ -133,6 +134,7 @@ Accessibility is a core requirement: the UI is designed to remain usable via key
      - `/career/highlights` - Compact career highlight cards
      - `/leaderboards/regular` - Regular season all-time ranking table
      - `/leaderboards/playoffs` - Playoffs all-time ranking table
+     - `/leaderboards/transfers` - Transfer leaderboard with trades, claims, and drops
 
 ## Data Flow
 

--- a/docs/project-testing.md
+++ b/docs/project-testing.md
@@ -206,24 +206,44 @@ The Playwright config is defined in `playwright.config.ts` and:
 - In CI: serves the production build via `npx serve dist/fantrax-stats-parser-ui/browser -s -l 4200`
 - Runs tests against Chromium only
 
+**Recommended local flow:**
+
+1. Start the backend separately on `http://localhost:3000`
+2. Run `npm run e2e` for the full suite, or `npx playwright test e2e/specs/<spec>.ts` while iterating
+3. Let Playwright start the frontend itself, or keep `http://localhost:4200` already running and let Playwright reuse it
+
+Local rule of thumb:
+
+- Prefer normal local mode against the live backend
+- Do **not** set `CI=true` for routine local verification
+- Use the CI/fixture mode only when you intentionally want the mocked CI behavior
+- If the backend on `localhost:3000` is not running in a paired session, ask the user to start it instead of swapping local verification over to CI-mode fixtures
+
 **Basic commands:**
 
 ```bash
 # Run all E2E tests (headless, Chromium) — requires backend on :3000
 npx playwright test
 
-# Run against an already-running frontend without starting Playwright webServer
+# Run headed locally (still starts or reuses the frontend via Playwright webServer)
 npx playwright test --headed
 
 # Run specific test file
 npx playwright test e2e/specs/smoke.spec.ts
 
-# Run with API mocking (simulates CI mode)
+# Run with API mocking (CI or explicit fixture-debugging only; not normal local usage)
 CI=true npx playwright test
 
 # Capture/update API fixtures from live backend
 npm run e2e:capture-fixtures
 ```
+
+**Troubleshooting local runs**
+
+- If Playwright waits for `webServer`, first check that `CI=true` is not set accidentally in your shell.
+- If you already have the frontend open on `http://localhost:4200`, Playwright should reuse it locally because `reuseExistingServer` is enabled.
+- If the backend is down, local E2E runs will fail even if the frontend starts correctly.
+- In this repo, the user may control the local backend separately. If it is down, ask them to start it before treating the run as blocked.
 
 #### Test Organization
 
@@ -263,6 +283,12 @@ E2E tests are organized into feature-based spec files under `e2e/specs/`:
   - Search and sort behavior in the virtualized career table
   - Server-paged highlight card behavior
   - Route-specific shell behavior (no stats controls/drawer)
+
+- **leaderboards.spec.ts** - Leaderboard routes and expandable team breakdowns
+  - Redirect from `/leaderboards` to the default regular-season tab
+  - Regular/playoff/transfers tab switching
+  - Tie-rank handling for regular/playoffs and incremental ranks for transfers
+  - Expanded season detail rows for trophies and transfer summaries
 
 **Supporting files:**
 

--- a/e2e/config/test-data.ts
+++ b/e2e/config/test-data.ts
@@ -40,6 +40,7 @@ export const TAB_LABELS = {
   PLAYER_CARD_GRAPHS: 'Graafit',
   LEADERBOARD_REGULAR: 'Runkosarja',
   LEADERBOARD_PLAYOFFS: 'Playoffs',
+  LEADERBOARD_TRANSFERS: 'Siirrot',
 };
 
 export const NAV_LABELS = {
@@ -49,4 +50,5 @@ export const NAV_LABELS = {
 export const LEADERBOARD_LABELS = {
   REGULAR: 'Runkosarja',
   PLAYOFFS: 'Playoffs',
+  TRANSFERS: 'Siirrot',
 };

--- a/e2e/fixtures/data/leaderboard--transactions.json
+++ b/e2e/fixtures/data/leaderboard--transactions.json
@@ -1,0 +1,41 @@
+[
+  {
+    "teamId": "1",
+    "teamName": "Colorado Avalanche",
+    "claims": 42,
+    "drops": 39,
+    "trades": 18,
+    "tieRank": false,
+    "seasons": [
+      { "season": 2024, "claims": 15, "drops": 13, "trades": 7 },
+      { "season": 2023, "claims": 14, "drops": 13, "trades": 6 },
+      { "season": 2022, "claims": 13, "drops": 13, "trades": 5 }
+    ]
+  },
+  {
+    "teamId": "2",
+    "teamName": "Dallas Stars",
+    "claims": 42,
+    "drops": 39,
+    "trades": 18,
+    "tieRank": true,
+    "seasons": [
+      { "season": 2024, "claims": 16, "drops": 15, "trades": 8 },
+      { "season": 2023, "claims": 14, "drops": 13, "trades": 6 },
+      { "season": 2022, "claims": 12, "drops": 11, "trades": 4 }
+    ]
+  },
+  {
+    "teamId": "3",
+    "teamName": "Edmonton Oilers",
+    "claims": 29,
+    "drops": 25,
+    "trades": 11,
+    "tieRank": false,
+    "seasons": [
+      { "season": 2024, "claims": 12, "drops": 10, "trades": 5 },
+      { "season": 2023, "claims": 9, "drops": 8, "trades": 4 },
+      { "season": 2022, "claims": 8, "drops": 7, "trades": 2 }
+    ]
+  }
+]

--- a/e2e/specs/leaderboards.spec.ts
+++ b/e2e/specs/leaderboards.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from '../fixtures/test-fixture';
 import { LEADERBOARD_LABELS } from '../config/test-data';
 
 test.describe('Leaderboards', () => {
-  test('full flow: redirect, regular table with position tie logic, tab switch, playoffs table', async ({ page }) => {
+  test('full flow: redirect, regular table with position tie logic, tab switch, playoffs table, and transfers table', async ({ page }) => {
     // /leaderboards redirects to regular
     await page.goto('/leaderboards');
     await expect(page).toHaveURL(/\/leaderboards\/regular/);
@@ -58,11 +58,36 @@ test.describe('Leaderboards', () => {
     const trophyCount = await trophyMarkers.count();
     expect(trophyCount).toBeGreaterThan(0);
     expect(playoffRowsCount).toBeGreaterThan(trophyCount);
+
+    // switch to Transfers tab
+    const transfersTab = page.getByRole('tab', { name: LEADERBOARD_LABELS.TRANSFERS });
+    await transfersTab.click();
+    await expect(page).toHaveURL(/\/leaderboards\/transfers/);
+    await expect(transfersTab).toHaveAttribute('aria-selected', 'true');
+
+    // transfers table has data and uses incremental positions even when API marks a tie
+    await rows.first().waitFor({ state: 'visible', timeout: 10000 });
+    expect(await rows.count()).toBeGreaterThan(0);
+
+    const transferPositions = page.locator('tr[mat-row] td:first-child');
+    await expect(transferPositions.nth(0)).toHaveText('1');
+    await expect(transferPositions.nth(1)).toHaveText('2');
+    await expect(transferPositions.nth(2)).toHaveText('3');
+
+    const transferRows = page.locator('tr[mat-row]:not(.expanded-detail-row)');
+    await transferRows.nth(1).click();
+    await expect(page.locator('.expanded-season-row').first()).toContainText('🤝');
   });
 
   test('direct URL /leaderboards/regular loads without redirect', async ({ page }) => {
     await page.goto('/leaderboards/regular');
     await expect(page).toHaveURL(/\/leaderboards\/regular/);
+    await page.locator('tr[mat-row]').first().waitFor({ state: 'visible', timeout: 10000 });
+  });
+
+  test('direct URL /leaderboards/transfers loads without redirect', async ({ page }) => {
+    await page.goto('/leaderboards/transfers');
+    await expect(page).toHaveURL(/\/leaderboards\/transfers/);
     await page.locator('tr[mat-row]').first().waitFor({ state: 'visible', timeout: 10000 });
   });
 });

--- a/public/i18n/fi.json
+++ b/public/i18n/fi.json
@@ -61,13 +61,17 @@
   "leaderboards": {
     "tabs": {
       "regular": "Runkosarja",
-      "playoffs": "Playoffs"
+      "playoffs": "Playoffs",
+      "transfers": "Siirrot"
     },
     "columns": {
       "position": "#",
       "team": "Joukkue",
       "regularTrophies": "Runkosarjavoitot",
       "championships": "Mestaruudet",
+      "trades": "Treidit",
+      "claims": "Claimit",
+      "drops": "Dropit",
       "points": "Pisteet",
       "wins": "Voitot",
       "ties": "Tasapelit",
@@ -91,6 +95,7 @@
       "season": "Kausi",
       "regularStats": "Tilastot",
       "playoffResult": "Tulos",
+      "transfers": "Siirrot",
       "trophy": "🏆"
     },
     "noSeasonBreakdown": "Ei kausierittelyä saatavilla",
@@ -175,7 +180,7 @@
         "items": [
           "Pelaajatilastot: joukkuekohtaiset kenttäpelaaja- ja maalivahtitilastot, suodattimet, vertailu ja pelaajakortit",
           "Pelaajaurat: kaikkien aikojen urataulukot kenttäpelaajille ja maalivahdeille sekä uranostot",
-          "Maratontaulukot: joukkueiden kaikkien aikojen runkosarja- ja playoff-menestys kausierittelyineen"
+          "Maratontaulukot: joukkueiden kaikkien aikojen runkosarja-, playoff- ja siirtotaulukot kausierittelyineen"
         ]
       },
       {
@@ -214,7 +219,7 @@
       },
       {
         "type": "p",
-        "text": "Maratontaulukot kokoavat joukkueiden kaikkien aikojen runkosarja- ja playoff-menestyksen omille välilehdilleen. Joukkueen riviä avaamalla näet kausierittelyn, jossa näkyvät myös runkosarjavoitot ja mestaruudet."
+        "text": "Maratontaulukot kokoavat joukkueiden kaikkien aikojen runkosarja-, playoff- ja siirtomenestyksen omille välilehdilleen. Joukkueen riviä avaamalla näet kausierittelyn, jossa näkyvät myös runkosarjavoitot, mestaruudet tai siirtotapahtumien määrät."
       },
       {
         "type": "h2",
@@ -313,6 +318,9 @@
     "teamName": "Joukkue",
     "regularTrophies": "Runkosarjavoitot",
     "championships": "Mestaruudet",
+    "trades": "Treidit",
+    "claims": "Claimit",
+    "drops": "Dropit",
     "ties": "Tasapelit",
     "losses": "Häviöt",
     "pointsPercent": "Piste-%",
@@ -361,6 +369,9 @@
     "teamName": "Joukkue",
     "regularTrophies": "RSV",
     "championships": "Mest.",
+    "trades": "Treidit",
+    "claims": "Claimit",
+    "drops": "Dropit",
     "ties": "T",
     "losses": "H",
     "pointsPercent": "P-%",

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -27,6 +27,13 @@ export const routes: Routes = [
             (m) => m.LeaderboardPlayoffsComponent
           ),
       },
+      {
+        path: 'transfers',
+        loadComponent: () =>
+          import('./leaderboards/transfers/leaderboard-transfers.component').then(
+            (m) => m.LeaderboardTransfersComponent
+          ),
+      },
     ],
   },
   {

--- a/src/app/leaderboards/leaderboard/leaderboard-expansion.spec.ts
+++ b/src/app/leaderboards/leaderboard/leaderboard-expansion.spec.ts
@@ -7,6 +7,7 @@ import { ViewportService } from '@services/viewport.service';
 import { provideDisabledMaterialAnimations } from '../../testing/behavior-test-utils';
 import { LeaderboardPlayoffsComponent } from '../playoffs/leaderboard-playoffs.component';
 import { LeaderboardRegularComponent } from '../regular/leaderboard-regular.component';
+import { LeaderboardTransfersComponent } from '../transfers/leaderboard-transfers.component';
 
 describe('Leaderboard expansion behavior', () => {
   it('renders regular season expansion with percent formatting and trophy mapping', async () => {
@@ -222,5 +223,82 @@ describe('Leaderboard expansion behavior', () => {
     expect(firstRank).toBe('1');
     expect(secondRank).toBe('');
     expect(thirdRank).toBe('3');
+  });
+
+  it('renders transfers expansion with incremental ranks even when the API marks a tie', async () => {
+    await render(LeaderboardTransfersComponent, {
+      imports: [TranslateModule.forRoot()],
+      providers: [
+        provideDisabledMaterialAnimations(),
+        {
+          provide: ViewportService,
+          useValue: {
+            isMobile$: of(false),
+          },
+        },
+        {
+          provide: ApiService,
+          useValue: {
+            getLeaderboardRegular: () => of([]),
+            getLeaderboardPlayoffs: () => of([]),
+            getLeaderboardTransactions: () => of([
+              {
+                teamId: '1',
+                teamName: 'Colorado Avalanche',
+                trades: 18,
+                claims: 42,
+                drops: 39,
+                tieRank: false,
+                seasons: [
+                  { season: 2024, trades: 7, claims: 15, drops: 13 },
+                  { season: 2023, trades: 6, claims: 14, drops: 13 },
+                ],
+              },
+              {
+                teamId: '2',
+                teamName: 'Dallas Stars',
+                trades: 18,
+                claims: 42,
+                drops: 39,
+                tieRank: true,
+                seasons: [
+                  { season: 2024, trades: 8, claims: 16, drops: 15 },
+                ],
+              },
+              {
+                teamId: '3',
+                teamName: 'Edmonton Oilers',
+                trades: 11,
+                claims: 29,
+                drops: 25,
+                tieRank: false,
+                seasons: [
+                  { season: 2024, trades: 5, claims: 12, drops: 10 },
+                ],
+              },
+            ]),
+          },
+        },
+      ],
+    });
+
+    await screen.findByText('Colorado Avalanche');
+
+    const rows = screen.getAllByRole('row').slice(1);
+    expect(rows).toHaveLength(3);
+
+    const [firstRank, secondRank, thirdRank] = rows.map((row) =>
+      within(row).getAllByRole('cell')[0]?.textContent?.trim() ?? ''
+    );
+
+    expect(firstRank).toBe('1');
+    expect(secondRank).toBe('2');
+    expect(thirdRank).toBe('3');
+
+    const team = screen.getByText('Dallas Stars');
+    fireEvent.click(team.closest('tr') as HTMLElement);
+
+    await screen.findByText('2024-25');
+    expect(screen.getByText('🤝 8 | 🟢 16 | 🔴 15')).toBeInTheDocument();
   });
 });

--- a/src/app/leaderboards/leaderboard/leaderboard-expansion.utils.ts
+++ b/src/app/leaderboards/leaderboard/leaderboard-expansion.utils.ts
@@ -1,9 +1,14 @@
-import { PlayoffLeaderboardEntry, RegularLeaderboardEntry } from '@services/api.service';
+import {
+  PlayoffLeaderboardEntry,
+  RegularLeaderboardEntry,
+  TransactionLeaderboardEntry,
+} from '@services/api.service';
 import { ExpandedRowViewModel } from '@shared/table-row-expansion.types';
 import { formatSeasonDisplay, formatSeasonShort } from '@shared/utils/season.utils';
 
 type PlayoffSeason = PlayoffLeaderboardEntry['seasons'][number];
 type RegularSeason = RegularLeaderboardEntry['seasons'][number];
+type TransactionSeason = TransactionLeaderboardEntry['seasons'][number];
 type SeasonLabelOptions = { shortSeasonLabel?: boolean };
 
 export const PLAYOFF_ROUND_TRANSLATION_KEY: Record<PlayoffSeason['key'], string> = {
@@ -45,5 +50,18 @@ export function mapPlayoffLeaderboardSeasons(
       seasonLabel: formatSeason(season.season),
       primary: roundLabel(season.key),
       secondary: season.key === 'championship' ? '🏆' : undefined,
+    }));
+}
+
+export function mapTransactionLeaderboardSeasons(
+  seasons: TransactionLeaderboardEntry['seasons'],
+  options: SeasonLabelOptions = {},
+): ExpandedRowViewModel[] {
+  const formatSeason = options.shortSeasonLabel ? formatSeasonShort : formatSeasonDisplay;
+  return [...seasons]
+    .sort((a, b) => b.season - a.season)
+    .map((season: TransactionSeason) => ({
+      seasonLabel: formatSeason(season.season),
+      primary: `🤝 ${season.trades} | 🟢 ${season.claims} | 🔴 ${season.drops}`,
     }));
 }

--- a/src/app/leaderboards/leaderboard/leaderboard.component.ts
+++ b/src/app/leaderboards/leaderboard/leaderboard.component.ts
@@ -5,10 +5,17 @@ import { StatsTableComponent, TableRow } from '@shared/stats-table/stats-table.c
 import { Column } from '@shared/column.types';
 import { ExpandedRowViewModel } from '@shared/table-row-expansion.types';
 import { derivePositions } from '@shared/utils/position.utils';
-import { RegularLeaderboardEntry, PlayoffLeaderboardEntry } from '@services/api.service';
+import {
+  RegularLeaderboardEntry,
+  PlayoffLeaderboardEntry,
+  TransactionLeaderboardEntry,
+} from '@services/api.service';
 import { FooterVisibilityService } from '@services/footer-visibility.service';
 
-type LeaderboardEntry = RegularLeaderboardEntry | PlayoffLeaderboardEntry;
+type LeaderboardEntry =
+  | RegularLeaderboardEntry
+  | PlayoffLeaderboardEntry
+  | TransactionLeaderboardEntry;
 type LeaderboardRow = LeaderboardEntry & { displayPosition: string };
 
 @Component({
@@ -48,6 +55,7 @@ export class LeaderboardComponent implements OnInit {
   readonly expandToggleAriaLabel = input.required<
     (row: LeaderboardRow, expanded: boolean) => string
   >();
+  readonly blankTieRanks = input(true);
   readonly expandedHeaderLabels = input.required<{
     season: string;
     primary: string;
@@ -77,7 +85,9 @@ export class LeaderboardComponent implements OnInit {
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
         next: (data) => {
-          this.data = derivePositions(data);
+          this.data = derivePositions(data, {
+            blankTieRanks: this.blankTieRanks(),
+          });
           this.loading = false;
           this.footerVisibilityService.markReady(this.footerVisibilityCycle);
         },

--- a/src/app/leaderboards/leaderboards.component.spec.ts
+++ b/src/app/leaderboards/leaderboards.component.spec.ts
@@ -33,10 +33,10 @@ describe('LeaderboardsComponent', () => {
 
     expect(component.activeLink).toBe('/leaderboards/regular');
 
-    router.url = '/leaderboards/playoffs?bar=1';
+    router.url = '/leaderboards/transfers?bar=1';
     events$.next({});
 
-    expect(component.activeLink).toBe('/leaderboards/playoffs');
+    expect(component.activeLink).toBe('/leaderboards/transfers');
     expect(detectChanges).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/app/leaderboards/leaderboards.component.ts
+++ b/src/app/leaderboards/leaderboards.component.ts
@@ -20,6 +20,7 @@ export class LeaderboardsComponent implements OnInit {
   readonly tabs = [
     { label: 'leaderboards.tabs.regular', path: '/leaderboards/regular' },
     { label: 'leaderboards.tabs.playoffs', path: '/leaderboards/playoffs' },
+    { label: 'leaderboards.tabs.transfers', path: '/leaderboards/transfers' },
   ];
 
   ngOnInit(): void {

--- a/src/app/leaderboards/transfers/leaderboard-transfers.component.ts
+++ b/src/app/leaderboards/transfers/leaderboard-transfers.component.ts
@@ -1,0 +1,72 @@
+import { Component, DestroyRef, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { TranslateService } from '@ngx-translate/core';
+
+import { ApiService, TransactionLeaderboardEntry } from '@services/api.service';
+import { ViewportService } from '@services/viewport.service';
+import { Column } from '@shared/column.types';
+import { LeaderboardComponent } from '../leaderboard/leaderboard.component';
+import { mapTransactionLeaderboardSeasons } from '../leaderboard/leaderboard-expansion.utils';
+
+@Component({
+  selector: 'app-leaderboard-transfers',
+  imports: [LeaderboardComponent],
+  template: `<app-leaderboard
+    [fetchFn]="fetchFn"
+    [columns]="columns"
+    [rowKey]="rowKey"
+    [isRowExpandable]="isRowExpandable"
+    [expandedRowsFor]="expandedRowsFor"
+    [expandToggleAriaLabel]="expandToggleAriaLabel"
+    [blankTieRanks]="false"
+    [expandedHeaderLabels]="expandedHeaderLabels"
+  />`,
+})
+export class LeaderboardTransfersComponent {
+  private apiService = inject(ApiService);
+  private translate = inject(TranslateService);
+  private viewportService = inject(ViewportService);
+  private destroyRef = inject(DestroyRef);
+  private isMobile = false;
+
+  constructor() {
+    this.viewportService.isMobile$
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((isMobile) => {
+        this.isMobile = isMobile;
+      });
+  }
+
+  readonly fetchFn = () => this.apiService.getLeaderboardTransactions();
+  readonly columns: Column[] = [
+    { field: 'displayPosition', align: 'left', sortable: false },
+    { field: 'teamName', align: 'left', initialSortDirection: 'asc' },
+    { field: 'trades' },
+    { field: 'claims' },
+    { field: 'drops' },
+  ];
+
+  readonly rowKey = (row: { teamId: string }) => row.teamId;
+  readonly isRowExpandable = () => true;
+  readonly expandedRowsFor = (row: { seasons?: unknown }) => {
+    const seasons = (row.seasons as TransactionLeaderboardEntry['seasons'] | undefined) ?? [];
+    if (!Array.isArray(seasons) || seasons.length === 0) {
+      return [{
+        seasonLabel: '-',
+        primary: this.translate.instant('leaderboards.noSeasonBreakdown'),
+      }];
+    }
+    return mapTransactionLeaderboardSeasons(seasons, { shortSeasonLabel: this.isMobile });
+  };
+  readonly expandToggleAriaLabel = (
+    row: { teamName: string },
+    expanded: boolean,
+  ): string => this.translate.instant(
+    expanded ? 'a11y.collapseSeasonDetails' : 'a11y.expandSeasonDetails',
+    { name: row.teamName },
+  );
+  readonly expandedHeaderLabels = {
+    season: this.translate.instant('leaderboards.detailHeader.season'),
+    primary: this.translate.instant('leaderboards.detailHeader.transfers'),
+  };
+}

--- a/src/app/services/api.service.spec.ts
+++ b/src/app/services/api.service.spec.ts
@@ -175,6 +175,18 @@ describe('ApiService', () => {
     ]);
   });
 
+  it('requests transactions leaderboard data from the transactions endpoint', async () => {
+    const responsePromise = firstValueFrom(service.getLeaderboardTransactions());
+
+    const request = httpMock.expectOne('http://localhost:3000/leaderboard/transactions');
+    expect(request.request.method).toBe('GET');
+    request.flush([{ teamId: '1', teamName: 'Colorado Avalanche', trades: 3 }]);
+
+    await expect(responsePromise).resolves.toEqual([
+      { teamId: '1', teamName: 'Colorado Avalanche', trades: 3 },
+    ]);
+  });
+
   it('requests career highlights with explicit paging params', async () => {
     const responsePromise = firstValueFrom(
       service.getCareerHighlights('most-teams-played', 10, 10)

--- a/src/app/services/api.service.ts
+++ b/src/app/services/api.service.ts
@@ -14,6 +14,7 @@ export type GoalieSeasonStats       = components['schemas']['GoalieSeasonData'];
 export type Team                    = components['schemas']['Team'];
 export type RegularLeaderboardEntry = components['schemas']['RegularLeaderboardEntry'];
 export type PlayoffLeaderboardEntry = components['schemas']['PlayoffLeaderboardEntry'];
+export type TransactionLeaderboardEntry = components['schemas']['TransactionLeaderboardEntry'];
 export type CareerPlayerListItem    = components['schemas']['CareerPlayerListItem'];
 export type CareerGoalieListItem    = components['schemas']['CareerGoalieListItem'];
 export type CareerPlayer            = components['schemas']['CareerPlayer'];
@@ -135,6 +136,14 @@ export class ApiService {
     return this.handleRequest<PlayoffLeaderboardEntry[]>(
       "leaderboard/playoffs",
       "leaderboard-playoffs",
+    );
+  }
+
+  // Fetching transaction leaderboard data
+  getLeaderboardTransactions(): Observable<TransactionLeaderboardEntry[]> {
+    return this.handleRequest<TransactionLeaderboardEntry[]>(
+      "leaderboard/transactions",
+      "leaderboard-transactions",
     );
   }
 

--- a/src/app/services/api.types.generated.ts
+++ b/src/app/services/api.types.generated.ts
@@ -1172,6 +1172,53 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/leaderboard/transactions": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * All-time transaction leaderboard
+         * @description Returns each team's total claim, drop, and trade counts with a per-season breakdown.
+         *     Trade totals count distinct team participations by `season + occurred_at`.
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Transaction leaderboard entries. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["TransactionLeaderboardEntry"][];
+                    };
+                };
+                /** @description Missing or invalid API key. */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -1622,6 +1669,24 @@ export interface components {
             winPercent: number;
             divWinPercent: number;
             pointsPercent: number;
+        };
+        TransactionLeaderboardEntry: {
+            teamId: string;
+            teamName: string;
+            claims: number;
+            drops: number;
+            /** @description Count of distinct trade participations by `season + occurred_at`. */
+            trades: number;
+            seasons: components["schemas"]["TransactionLeaderboardSeason"][];
+            /** @description True when this entry's record matches the previous entry's record. */
+            tieRank: boolean;
+        };
+        TransactionLeaderboardSeason: {
+            season: number;
+            claims: number;
+            drops: number;
+            /** @description Count of distinct trade participations by `season + occurred_at`. */
+            trades: number;
         };
     };
     responses: never;

--- a/src/app/shared/stats-table/stats-table.component.ts
+++ b/src/app/shared/stats-table/stats-table.component.ts
@@ -30,6 +30,7 @@ import {
   Goalie,
   RegularLeaderboardEntry,
   PlayoffLeaderboardEntry,
+  TransactionLeaderboardEntry,
   CareerPlayerListItem,
   CareerGoalieListItem,
 } from '@services/api.service';
@@ -85,6 +86,7 @@ export type TableRow =
   | Goalie
   | RegularLeaderboardEntry
   | PlayoffLeaderboardEntry
+  | TransactionLeaderboardEntry
   | CareerPlayerListItem
   | CareerGoalieListItem
   | ({ playerPosition: string } & CareerPlayerListItem);

--- a/src/app/shared/utils/position.utils.ts
+++ b/src/app/shared/utils/position.utils.ts
@@ -1,9 +1,15 @@
+type DerivePositionsOptions = {
+  blankTieRanks?: boolean;
+};
+
 export function derivePositions<T extends { tieRank: boolean }>(
-  entries: T[]
+  entries: T[],
+  options: DerivePositionsOptions = {},
 ): (T & { displayPosition: string })[] {
+  const blankTieRanks = options.blankTieRanks ?? true;
   let counter = 1;
   return entries.map((entry) => {
-    if (entry.tieRank) {
+    if (entry.tieRank && blankTieRanks) {
       const result = { ...entry, displayPosition: '' };
       counter++;
       return result;

--- a/src/app/testing/behavior-test-utils.ts
+++ b/src/app/testing/behavior-test-utils.ts
@@ -18,6 +18,7 @@ import {
   CareerPlayerListItem,
   PlayoffLeaderboardEntry,
   RegularLeaderboardEntry,
+  TransactionLeaderboardEntry,
   ReportType,
   Season,
   Team,
@@ -40,6 +41,7 @@ import sameTeamSeasonsHighlightsPage0FixtureData from '../../../e2e/fixtures/dat
 import sameTeamSeasonsHighlightsPage1FixtureData from '../../../e2e/fixtures/data/career--highlights--same-team-seasons-played--skip=10--take=10.json';
 import sameTeamSeasonsOwnedHighlightsPage0FixtureData from '../../../e2e/fixtures/data/career--highlights--same-team-seasons-owned--skip=0--take=10.json';
 import sameTeamSeasonsOwnedHighlightsPage1FixtureData from '../../../e2e/fixtures/data/career--highlights--same-team-seasons-owned--skip=10--take=10.json';
+import leaderboardTransactionsFixtureData from '../../../e2e/fixtures/data/leaderboard--transactions.json';
 
 export const PLAYER_SLICE_COUNT = 12;
 export const GOALIE_SLICE_COUNT = 5;
@@ -65,6 +67,8 @@ export const sameTeamSeasonsOwnedHighlightsPage0Fixture =
   sameTeamSeasonsOwnedHighlightsPage0FixtureData as CareerHighlightPage;
 export const sameTeamSeasonsOwnedHighlightsPage1Fixture =
   sameTeamSeasonsOwnedHighlightsPage1FixtureData as CareerHighlightPage;
+export const leaderboardTransactionsFixture =
+  leaderboardTransactionsFixtureData as TransactionLeaderboardEntry[];
 export const mostStanleyCupsHighlightsPage0Fixture = {
   type: 'most-stanley-cups',
   skip: 0,
@@ -169,7 +173,8 @@ type BehaviorApiErrorKey =
   | 'careerGoalies'
   | 'careerHighlights'
   | 'leaderboardRegular'
-  | 'leaderboardPlayoffs';
+  | 'leaderboardPlayoffs'
+  | 'leaderboardTransactions';
 
 export type BehaviorApiMockOptions = {
   teams?: Team[];
@@ -188,6 +193,7 @@ export type BehaviorApiMockOptions = {
   careerHighlightsStashKing?: CareerHighlightPage;
   leaderboardRegular?: RegularLeaderboardEntry[];
   leaderboardPlayoffs?: PlayoffLeaderboardEntry[];
+  leaderboardTransactions?: TransactionLeaderboardEntry[];
   errorKeys?: BehaviorApiErrorKey[];
   getSeasons?: (
     reportType?: ReportType,
@@ -315,6 +321,10 @@ export function createApiServiceMock(options: BehaviorApiMockOptions = {}) {
       errorKeys.has('leaderboardPlayoffs')
         ? createApiError()
         : of(options.leaderboardPlayoffs ?? []),
+    getLeaderboardTransactions: () =>
+      errorKeys.has('leaderboardTransactions')
+        ? createApiError()
+        : of(options.leaderboardTransactions ?? leaderboardTransactionsFixture),
   };
 }
 


### PR DESCRIPTION
## Summary
- add the new `/leaderboards/transfers` route and `Siirrot` tab backed by the `leaderboard/transactions` API
- render transfers with columns `Treidit`, `Claimit`, and `Dropit`, keep transfers ranks incremental even when the API marks ties, and show expandable season rows with `🤝`, `🟢`, and `🔴` transfer summaries
- extend service, behavior, and E2E coverage for the new leaderboard view and update docs for proper local Playwright usage with the user-controlled backend

## Testing
- npm run verify
- npx playwright test e2e/specs/leaderboards.spec.ts
