### PR TITLE
Feature: Transactions career highlights

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,8 @@ If documentation includes clearly bad decisions, challenge them and propose bett
 - Default workflow is a user-created branch (not `main`).
 - If currently on `main`, ask user to create a branch before implementing task changes.
 - If considering `git worktree`, always ask explicitly first and explain why worktree would help.
-- In every task, include a user review phase before final verify. After review is accepted and verify passes, you can commit. After each user-accepted and verified batch, you may commit if useful as a checkpoint. Offer PR notes as a copy-pasteable code block only when the branch is fully implemented and ready for PR; user will handle the rest.
+- In every task, include a user review phase before final verify. After implementation, pause and hand the work to the user for review before running the final `npm run verify` or creating a commit.
+- Do not run the final verification gate and do not commit until the user has explicitly accepted the review phase for that batch. After review is accepted and verify passes, you can commit. After each user-accepted and verified batch, you may commit if useful as a checkpoint. Offer PR notes as a copy-pasteable code block only when the branch is fully implemented and ready for PR; user will handle the rest.
 - Before any commit, `npm run verify` must pass. Targeted tests are not a substitute for the full verification gate.
 - Commit message prefixes should use capitalized conventional labels.
 - New features must use the prefix `Feature: `.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,15 +7,22 @@ Update `README.md` and files under `docs/` after every task when needed.
 
 If documentation includes clearly bad decisions, challenge them and propose better alternatives. User decides whether to apply changes.
 
-Always ask explicitly (with explanation) whether to use git worktree instead of a user-created branch before the first mutating step of a new implementation task or approved plan. Do not ask again between batches, review rounds, verify runs, or commits within the same plan unless the user asks to revisit the workflow or circumstances materially change.
+## Git Workflow Rules
+- Default workflow is a user-created branch (not `main`).
+- If currently on `main`, ask user to create a branch before implementing task changes.
+- If considering `git worktree`, always ask explicitly first and explain why worktree would help.
+- In every task, include a user review phase before final verify. After review is accepted and verify passes, you can commit. After each user-accepted and verified batch, you may commit if useful as a checkpoint. Offer PR notes as a copy-pasteable code block only when the branch is fully implemented and ready for PR; user will handle the rest.
+- Before any commit, `npm run verify` must pass. Targeted tests are not a substitute for the full verification gate.
+- Commit message prefixes should use capitalized conventional labels.
+- New features must use the prefix `Feature: `.
+- Non-feature commits should use a capitalized prefix such as `Fix:`, `Docs:`, `Chore:`, etc.
+- Use sentence-style capitalization after the colon: capitalize the first word, but do not title-case the whole message unless normal capitalization requires it. Example: `Feature: Add career player and goalie listings`.
 
 For planning-heavy tasks, save the approved plan first under `docs/plans/` using a dated filename before implementation starts. Plans in `docs/plans/` are intentionally gitignored local working files and must not be committed unless the user explicitly asks for that.
 
 For an approved multi-batch plan, treat all batches as part of the same task until the user declares the plan complete or redirects to a different task.
 
 If a proposed change would alter user-visible application behavior or semantics, stop and confirm with the user before implementing it. Do not make behavior-changing production edits based only on inference from a plan or coverage goal.
-
-In every task, include a user review phase before final verify. After review is accepted and verify passes, you can commit. After each user-accepted and verified batch, you may commit if useful as a checkpoint. Offer PR notes as a copy-pasteable code block only when the branch is fully implemented and ready for PR; user will handle the rest.
 
 If using Playwright MCP during a task, close the browser after you are done with it and no longer need it. Do not leave Playwright browser sessions open across unrelated steps or future sessions.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,15 @@ Update @README and @docs/* after every task if needed.
 
 If documentation includes clearly bad decisions, challenge them and propose better alternatives. User decides whether to apply changes.
 
-Always ask explicitly (with explanation) whether to use git worktree instead of a user-created branch before the first mutating step of a new implementation task or approved plan. Do not ask again between batches, review rounds, verify runs, or commits within the same plan unless the user asks to revisit the workflow or circumstances materially change.
+## Git Workflow Rules
+- Default workflow is a user-created branch (not `main`).
+- If currently on `main`, ask user to create a branch before implementing task changes.
+- If considering `git worktree`, always ask explicitly first and explain why worktree would help.
+- Before any commit, `npm run verify` must pass. Targeted tests are not a substitute for the full verification gate.
+- Commit message prefixes should use capitalized conventional labels.
+- New features must use the prefix `Feature: `.
+- Non-feature commits should use a capitalized prefix such as `Fix:`, `Docs:`, `Chore:`, etc.
+- Use sentence-style capitalization after the colon: capitalize the first word, but do not title-case the whole message unless normal capitalization requires it. Example: `Feature: Add career player and goalie listings`.
 
 For planning-heavy tasks, save the approved plan first under @docs/plans/ using a dated filename before implementation starts. Plans in @docs/plans/ are intentionally gitignored local working files and must not be committed unless the user explicitly asks for that.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,8 @@ If documentation includes clearly bad decisions, challenge them and propose bett
 - Default workflow is a user-created branch (not `main`).
 - If currently on `main`, ask user to create a branch before implementing task changes.
 - If considering `git worktree`, always ask explicitly first and explain why worktree would help.
+- In every task, include a user review phase before final verify. After implementation, pause and hand the work to the user for review before running the final `npm run verify` or creating a commit.
+- Do not run the final verification gate and do not commit until the user has explicitly accepted the review phase for that batch. After review is accepted and verify passes, you can commit. After each user-accepted and verified batch, you may commit if useful as a checkpoint. Offer PR notes as a copy-pasteable code block only when the branch is fully implemented and ready for PR; user will handle the rest.
 - Before any commit, `npm run verify` must pass. Targeted tests are not a substitute for the full verification gate.
 - Commit message prefixes should use capitalized conventional labels.
 - New features must use the prefix `Feature: `.
@@ -22,7 +24,5 @@ For planning-heavy tasks, save the approved plan first under @docs/plans/ using 
 For an approved multi-batch plan, treat all batches as part of the same task until the user declares the plan complete or redirects to a different task.
 
 If a proposed change would alter user-visible application behavior or semantics, stop and confirm with the user before implementing it. Do not make behavior-changing production edits based only on inference from a plan or coverage goal.
-
-In every task, include a user review phase before final verify. After review is accepted and verify passes, you can commit. After each user-accepted and verified batch, you may commit if useful as a checkpoint. Offer PR notes as a copy-pasteable code block only when the branch is fully implemented and ready for PR; user will handle the rest.
 
 If using Playwright MCP during a task, close the browser after you are done with it and no longer need it. Do not leave Playwright browser sessions open across unrelated steps or future sessions.

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Live showcase: https://ffhl-stats.vercel.app/
 	- Searchable and sortable, with no stats-page filters or mobile drawer
 	- Virtualized row rendering keeps long lists responsive
 	- Player rows show position inline with name (for example `D Travis Hamonic`) while still sorting alphabetically by player name
-	- `/career/highlights` adds compact paged highlight cards for focused career leaderboard slices such as most teams played/owned, most Stanley Cups, regular-season grinders without playoff appearances, stash leaders, and most same-team seasons played/owned; each card lazy-loads its dataset as it approaches the viewport
+	- `/career/highlights` splits compact paged highlight cards into `Sekalaiset` and `Siirrot`, covering the existing general career slices plus transaction leaders for most trades, claims, and drops; each card lazy-loads its dataset as it approaches the viewport
 - 🚦 **Split Route Shells**: Interactive dashboard routes lazy-load their heavier shell (controls, settings drawer, comparison bar, tabs), while career and leaderboard browsing routes stay on a lighter root shell
 - 🗂️ **Global Navigation**: Bottom sheet menu for switching between views (hockey stats, player careers, leaderboards, info/help)
 - 🔗 **Direct Player Links**: Shareable URLs for player/goalie cards
@@ -178,7 +178,7 @@ For planning-heavy changes, save the approved implementation plan locally under 
 
 E2E tests are organized into feature-based specs under `e2e/specs/`:
 - `smoke.spec.ts` — Core page rendering and navigation
-- `career.spec.ts` — Career players/goalies/highlights tabs, search, paging, and route shell behavior
+- `career.spec.ts` — Career players/goalies/highlights tabs, highlight section switching, paging, and route shell behavior
 - `leaderboards.spec.ts` — Leaderboards redirect, regular/playoff/transactions tabs, tie-rank vs incremental position logic, and expandable season details
 - `player-card.spec.ts` — Player card dialog (open/close, tabs, graphs, direct URLs)
 - `team-switching.spec.ts` — Team selector and filter reset behavior

--- a/docs/codebase-structure.md
+++ b/docs/codebase-structure.md
@@ -90,6 +90,7 @@ Route shell and smart components for career listings:
 - Handles `/career/players`, `/career/goalies`, and `/career/highlights`
 - Renders tab navigation between career skaters, goalies, and highlights
 - Uses dedicated backend endpoints and either a virtualized read-only table or compact paged table cards
+- Splits the highlights route into `Sekalaiset` and `Siirrot` card groups while reusing the same paged-card UI
 - Defers each highlight card's API request until the card nears the viewport
 - Loads under the lighter root shell without dashboard-only controls, comparison bar, or mobile settings drawer
 

--- a/docs/component-guide.md
+++ b/docs/component-guide.md
@@ -199,7 +199,8 @@ TeamService → PlayerStatsComponent (triggers refetch + adds teamId)
 - Fetch career rows from the dedicated API endpoints
 - Pass column definitions and formatters into the shared virtualized table
 - Keep the player career table sorted by plain `name` while rendering position inline with the displayed player name
-- Normalize paged highlight responses into the shared `TableCardComponent` row shape for the `/career/highlights` route, including team-count, same-team, Stanley Cup, stash, and regular-grinder highlight variants
+- Normalize paged highlight responses into the shared `TableCardComponent` row shape for the `/career/highlights` route, including the existing general cards plus transaction variants for most trades, claims, and drops
+- Keep the centered `Sekalaiset` / `Siirrot` switch accessible while preserving each card's lazy-loading and paging state
 - Activate highlight-card API loads lazily as each card approaches the viewport instead of requesting every card during route startup
 
 ### TableCardComponent

--- a/docs/project-overview.md
+++ b/docs/project-overview.md
@@ -79,7 +79,7 @@ Accessibility is a core requirement: the UI is designed to remain usable via key
    - Searchable and sortable without the stats-page controls/drawer/comparison bar
    - Player position is rendered inline with player name while sorting still uses the underlying plain `name`
    - Uses a virtualized table implementation to keep large result sets responsive
-   - The highlights tab uses compact paged table cards for focused leaderboard slices such as most teams played/owned, most Stanley Cups, regular grinders without playoff appearances, stash leaders, and most same-team seasons played/owned
+   - The highlights tab splits compact paged table cards into `Sekalaiset` and `Siirrot`, keeping the existing general slices while adding transaction leaders for most trades, claims, and drops
    - Highlight cards lazy-load their API data as they enter or near the viewport so the route scales better as more cards are added
 
 7. **Data Management**

--- a/docs/project-testing.md
+++ b/docs/project-testing.md
@@ -280,6 +280,7 @@ E2E tests are organized into feature-based spec files under `e2e/specs/`:
 - **career.spec.ts** - Career listings and highlights
   - Career route shell and global-navigation entry
   - Player/goalie/highlights tab switching
+  - Highlights section switching between `Sekalaiset` and `Siirrot`
   - Search and sort behavior in the virtualized career table
   - Server-paged highlight card behavior
   - Route-specific shell behavior (no stats controls/drawer)

--- a/e2e/config/test-data.ts
+++ b/e2e/config/test-data.ts
@@ -49,9 +49,9 @@ export const CAREER_HIGHLIGHT_SECTION_LABELS = {
 };
 
 export const CAREER_HIGHLIGHT_CARD_LABELS = {
-  MOST_TRADES: 'Eniten kaupattu',
-  MOST_CLAIMS: 'Eniten nostettu',
-  MOST_DROPS: 'Eniten pudotettu',
+  MOST_TRADES: 'Eniten kaupatut',
+  MOST_CLAIMS: 'Eniten nostetut',
+  MOST_DROPS: 'Eniten pudotetut',
 };
 
 export const NAV_LABELS = {

--- a/e2e/config/test-data.ts
+++ b/e2e/config/test-data.ts
@@ -43,6 +43,17 @@ export const TAB_LABELS = {
   LEADERBOARD_TRANSACTIONS: 'Siirrot',
 };
 
+export const CAREER_HIGHLIGHT_SECTION_LABELS = {
+  GENERAL: 'Sekalaiset',
+  TRANSACTIONS: 'Siirrot',
+};
+
+export const CAREER_HIGHLIGHT_CARD_LABELS = {
+  MOST_TRADES: 'Eniten kaupattu',
+  MOST_CLAIMS: 'Eniten nostettu',
+  MOST_DROPS: 'Eniten pudotettu',
+};
+
 export const NAV_LABELS = {
   PLAYER_CAREERS: 'Pelaajaurat',
 };

--- a/e2e/fixtures/data/career--highlights--most-claims--skip=0--take=10.json
+++ b/e2e/fixtures/data/career--highlights--most-claims--skip=0--take=10.json
@@ -1,0 +1,67 @@
+{
+  "type": "most-claims",
+  "skip": 0,
+  "take": 10,
+  "total": 3,
+  "items": [
+    {
+      "id": "claim-1",
+      "name": "Tyler Johnson",
+      "position": "F",
+      "transactionCount": 5,
+      "teams": [
+        {
+          "id": "3",
+          "name": "Tampa Bay Lightning",
+          "count": 3
+        },
+        {
+          "id": "1",
+          "name": "Colorado Avalanche",
+          "count": 2
+        }
+      ]
+    },
+    {
+      "id": "claim-2",
+      "name": "Jack Johnson",
+      "position": "D",
+      "transactionCount": 4,
+      "teams": [
+        {
+          "id": "1",
+          "name": "Colorado Avalanche",
+          "count": 2
+        },
+        {
+          "id": "8",
+          "name": "Pittsburgh Penguins",
+          "count": 1
+        },
+        {
+          "id": "9",
+          "name": "New York Rangers",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "id": "claim-3",
+      "name": "Casey DeSmith",
+      "position": "G",
+      "transactionCount": 3,
+      "teams": [
+        {
+          "id": "8",
+          "name": "Pittsburgh Penguins",
+          "count": 2
+        },
+        {
+          "id": "4",
+          "name": "Carolina Hurricanes",
+          "count": 1
+        }
+      ]
+    }
+  ]
+}

--- a/e2e/fixtures/data/career--highlights--most-drops--skip=0--take=10.json
+++ b/e2e/fixtures/data/career--highlights--most-drops--skip=0--take=10.json
@@ -1,0 +1,72 @@
+{
+  "type": "most-drops",
+  "skip": 0,
+  "take": 10,
+  "total": 3,
+  "items": [
+    {
+      "id": "drop-1",
+      "name": "Tyler Toffoli",
+      "position": "F",
+      "transactionCount": 6,
+      "teams": [
+        {
+          "id": "2",
+          "name": "Dallas Stars",
+          "count": 3
+        },
+        {
+          "id": "5",
+          "name": "Winnipeg Jets",
+          "count": 2
+        },
+        {
+          "id": "1",
+          "name": "Colorado Avalanche",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "id": "drop-2",
+      "name": "Mark Pysyk",
+      "position": "D",
+      "transactionCount": 4,
+      "teams": [
+        {
+          "id": "4",
+          "name": "Carolina Hurricanes",
+          "count": 2
+        },
+        {
+          "id": "10",
+          "name": "Florida Panthers",
+          "count": 1
+        },
+        {
+          "id": "11",
+          "name": "Buffalo Sabres",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "id": "drop-3",
+      "name": "Chris Driedger",
+      "position": "G",
+      "transactionCount": 3,
+      "teams": [
+        {
+          "id": "10",
+          "name": "Florida Panthers",
+          "count": 2
+        },
+        {
+          "id": "12",
+          "name": "Seattle Kraken",
+          "count": 1
+        }
+      ]
+    }
+  ]
+}

--- a/e2e/fixtures/data/career--highlights--most-trades--skip=0--take=10.json
+++ b/e2e/fixtures/data/career--highlights--most-trades--skip=0--take=10.json
@@ -1,0 +1,72 @@
+{
+  "type": "most-trades",
+  "skip": 0,
+  "take": 10,
+  "total": 3,
+  "items": [
+    {
+      "id": "trade-1",
+      "name": "Mike Hoffman",
+      "position": "F",
+      "transactionCount": 6,
+      "teams": [
+        {
+          "id": "1",
+          "name": "Colorado Avalanche",
+          "count": 3
+        },
+        {
+          "id": "2",
+          "name": "Dallas Stars",
+          "count": 2
+        },
+        {
+          "id": "4",
+          "name": "Carolina Hurricanes",
+          "count": 1
+        }
+      ]
+    },
+    {
+      "id": "trade-2",
+      "name": "Nino Niederreiter",
+      "position": "F",
+      "transactionCount": 5,
+      "teams": [
+        {
+          "id": "3",
+          "name": "Tampa Bay Lightning",
+          "count": 3
+        },
+        {
+          "id": "5",
+          "name": "Winnipeg Jets",
+          "count": 2
+        }
+      ]
+    },
+    {
+      "id": "trade-3",
+      "name": "Anton Khudobin",
+      "position": "G",
+      "transactionCount": 4,
+      "teams": [
+        {
+          "id": "2",
+          "name": "Dallas Stars",
+          "count": 2
+        },
+        {
+          "id": "6",
+          "name": "Boston Bruins",
+          "count": 1
+        },
+        {
+          "id": "7",
+          "name": "Edmonton Oilers",
+          "count": 1
+        }
+      ]
+    }
+  ]
+}

--- a/e2e/scripts/capture-fixtures.ts
+++ b/e2e/scripts/capture-fixtures.ts
@@ -107,6 +107,9 @@ async function buildFixtureList(): Promise<FixtureEntry[]> {
     { path: 'career/highlights/same-team-seasons-owned', params: { skip: '0', take: '10' } },
     { path: 'career/highlights/same-team-seasons-owned', params: { skip: '10', take: '10' } },
     { path: 'career/highlights/stash-king', params: { skip: '0', take: '10' } },
+    { path: 'career/highlights/most-trades', params: { skip: '0', take: '10' } },
+    { path: 'career/highlights/most-claims', params: { skip: '0', take: '10' } },
+    { path: 'career/highlights/most-drops', params: { skip: '0', take: '10' } },
   ];
 
   return entries;

--- a/e2e/specs/career.spec.ts
+++ b/e2e/specs/career.spec.ts
@@ -1,7 +1,11 @@
 import { Locator } from '@playwright/test';
 
 import { test, expect } from '../fixtures/test-fixture';
-import { TAB_LABELS } from '../config/test-data';
+import {
+  CAREER_HIGHLIGHT_CARD_LABELS,
+  CAREER_HIGHLIGHT_SECTION_LABELS,
+  TAB_LABELS,
+} from '../config/test-data';
 
 test.describe('Career listings', () => {
   test('redirects /career to players, renders the table, switches to highlights, and then to goalie careers', async ({ page }) => {
@@ -73,5 +77,39 @@ test.describe('Career listings', () => {
     const goalieRows = page.locator('.virtual-table-row[data-row-index]');
     await goalieRows.first().waitFor({ state: 'visible', timeout: 10000 });
     expect(await goalieRows.count()).toBeGreaterThan(0);
+  });
+
+  test('switches career highlights to transactions and renders the transaction cards', async ({ page }) => {
+    await page.goto('/career/highlights');
+    await expect(page).toHaveURL(/\/career\/highlights$/);
+
+    const generalSection = page.getByRole('radio', {
+      name: CAREER_HIGHLIGHT_SECTION_LABELS.GENERAL,
+    });
+    const transactionsSection = page.getByRole('radio', {
+      name: CAREER_HIGHLIGHT_SECTION_LABELS.TRANSACTIONS,
+    });
+
+    await expect(generalSection).toHaveAttribute('aria-checked', 'true');
+    await transactionsSection.click();
+    await expect(transactionsSection).toHaveAttribute('aria-checked', 'true');
+
+    const highlightCards = page.locator('app-table-card');
+    await expect(highlightCards).toHaveCount(3);
+    await expect(
+      page.getByRole('heading', { name: CAREER_HIGHLIGHT_CARD_LABELS.MOST_TRADES })
+    ).toBeVisible();
+    await expect(
+      page.getByRole('heading', { name: CAREER_HIGHLIGHT_CARD_LABELS.MOST_CLAIMS })
+    ).toBeVisible();
+    await expect(
+      page.getByRole('heading', { name: CAREER_HIGHLIGHT_CARD_LABELS.MOST_DROPS })
+    ).toBeVisible();
+
+    await expect(highlightCards.first().getByRole('table')).toBeVisible();
+    await highlightCards.nth(1).scrollIntoViewIfNeeded();
+    await expect(highlightCards.nth(1).getByRole('table')).toBeVisible();
+    await highlightCards.nth(2).scrollIntoViewIfNeeded();
+    await expect(highlightCards.nth(2).getByRole('table')).toBeVisible();
   });
 });

--- a/public/i18n/fi.json
+++ b/public/i18n/fi.json
@@ -66,16 +66,16 @@
           "description": "Väh. 10 kautta joukkueessa pelaamatta."
         },
         "mostTrades": {
-          "title": "Eniten kaupattu",
-          "description": "Väh. 4 kauppasiirtoa FFHL-uralla."
+          "title": "Eniten kaupatut",
+          "description": "Väh. 4 kaupassa mukana."
         },
         "mostClaims": {
-          "title": "Eniten nostettu",
-          "description": "Väh. 3 nostoa FFHL-uralla."
+          "title": "Eniten nostetut",
+          "description": "Väh. 3 nostoa."
         },
         "mostDrops": {
-          "title": "Eniten pudotettu",
-          "description": "Väh. 3 pudotusta FFHL-uralla."
+          "title": "Eniten pudotetut",
+          "description": "Väh. 3 pudotusta."
         }
       }
     }

--- a/public/i18n/fi.json
+++ b/public/i18n/fi.json
@@ -20,11 +20,21 @@
     },
     "highlights": {
       "sectionTitle": "Uranostot",
+      "sectionSwitcher": {
+        "ariaLabel": "Nostoryhmä"
+      },
+      "sections": {
+        "general": "Sekalaiset",
+        "transactions": "Siirrot"
+      },
       "columns": {
         "player": "Pelaaja",
         "teamCount": "Seurat",
         "seasonCount": "Kaudet",
-        "games": "Ott."
+        "games": "Ott.",
+        "trades": "Kaupat",
+        "claims": "Nostot",
+        "drops": "Pudotukset"
       },
       "cards": {
         "mostTeamsPlayed": {
@@ -54,6 +64,18 @@
         "stashKing": {
           "title": "Eniten farmikausia - sama seura",
           "description": "Väh. 10 kautta joukkueessa pelaamatta."
+        },
+        "mostTrades": {
+          "title": "Eniten kaupattu",
+          "description": "Väh. 4 kauppasiirtoa FFHL-uralla."
+        },
+        "mostClaims": {
+          "title": "Eniten nostettu",
+          "description": "Väh. 3 nostoa FFHL-uralla."
+        },
+        "mostDrops": {
+          "title": "Eniten pudotettu",
+          "description": "Väh. 3 pudotusta FFHL-uralla."
         }
       }
     }

--- a/src/app/app.component.mobile.spec.ts
+++ b/src/app/app.component.mobile.spec.ts
@@ -292,7 +292,30 @@ describe('AppComponent — mobile frontpage', { timeout: 60_000 }, () => {
     expect(
       screen.getByRole('heading', { name: 'career.highlights.cards.stashKing.title' })
     ).toBeInTheDocument();
+    expect(
+      screen.getByRole('radio', { name: 'career.highlights.sections.general' })
+    ).toHaveAttribute('aria-checked', 'true');
+    expect(
+      screen.getByRole('radio', { name: 'career.highlights.sections.transactions' })
+    ).toBeInTheDocument();
     expect(screen.getAllByRole('heading', { level: 3 })).toHaveLength(8);
+
+    fireEvent.click(
+      screen.getByRole('radio', { name: 'career.highlights.sections.transactions' })
+    );
+
+    expect(
+      await screen.findByRole('heading', { name: 'career.highlights.cards.mostTrades.title' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: 'career.highlights.cards.mostClaims.title' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: 'career.highlights.cards.mostDrops.title' })
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('heading', { name: 'career.highlights.cards.mostTeamsPlayed.title' })
+    ).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('tab', { name: 'career.tabs.goalies' }));
 

--- a/src/app/career/highlights/career-highlights.component.html
+++ b/src/app/career/highlights/career-highlights.component.html
@@ -7,6 +7,24 @@
     {{ 'career.highlights.sectionTitle' | translate }}
   </h3>
 
+  <div class="career-highlights-controls">
+    <mat-button-toggle-group
+      class="career-highlights-section-switch"
+      [value]="selectedSection()"
+      (change)="onSectionChange($event)"
+      [attr.aria-label]="
+        'career.highlights.sectionSwitcher.ariaLabel' | translate
+      "
+    >
+      <mat-button-toggle value="general">
+        {{ 'career.highlights.sections.general' | translate }}
+      </mat-button-toggle>
+      <mat-button-toggle value="transactions">
+        {{ 'career.highlights.sections.transactions' | translate }}
+      </mat-button-toggle>
+    </mat-button-toggle-group>
+  </div>
+
   <div class="career-highlights-grid">
     @for (card of cards(); track card.type) {
       <app-table-card

--- a/src/app/career/highlights/career-highlights.component.scss
+++ b/src/app/career/highlights/career-highlights.component.scss
@@ -6,9 +6,21 @@
   width: 100%;
 }
 
+.career-highlights-controls {
+  display: flex;
+  justify-content: center;
+  margin: 24px 24px 0;
+  overflow-x: auto;
+}
+
+.career-highlights-section-switch {
+  flex: 0 0 auto;
+  max-width: 100%;
+}
+
 .career-highlights-grid {
   display: grid;
-  margin: 24px;
+  margin: 20px 24px 24px;
   gap: 20px;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   align-items: stretch;
@@ -25,8 +37,12 @@
 }
 
 @media (max-width: 480px) {
+  .career-highlights-controls {
+    margin: 12px 8px 0;
+  }
+
   .career-highlights-grid {
-    margin: 12px 8px;
+    margin: 12px 8px 8px;
     gap: 12px;
   }
 }

--- a/src/app/career/highlights/career-highlights.component.spec.ts
+++ b/src/app/career/highlights/career-highlights.component.spec.ts
@@ -5,6 +5,9 @@ import { of, throwError } from 'rxjs';
 import { ApiService, CareerHighlightType } from '@services/api.service';
 import { FooterVisibilityService } from '@services/footer-visibility.service';
 import {
+  mostClaimsHighlightsPage0Fixture,
+  mostDropsHighlightsPage0Fixture,
+  mostTradesHighlightsPage0Fixture,
   mostStanleyCupsHighlightsPage0Fixture,
   mostTeamsOwnedHighlightsPage0Fixture,
   mostTeamsPlayedHighlightsPage0Fixture,
@@ -99,6 +102,12 @@ describe('CareerHighlightsComponent', () => {
             return of(regularGrinderWithoutPlayoffsHighlightsPage0Fixture);
           case 'stash-king':
             return of(stashKingHighlightsPage0Fixture);
+          case 'most-trades':
+            return of(mostTradesHighlightsPage0Fixture);
+          case 'most-claims':
+            return of(mostClaimsHighlightsPage0Fixture);
+          case 'most-drops':
+            return of(mostDropsHighlightsPage0Fixture);
           case 'reunion-king':
             throw new Error('reunion-king should not be requested by the UI');
         }
@@ -201,6 +210,104 @@ describe('CareerHighlightsComponent', () => {
     expect(getCareerHighlights).toHaveBeenCalledWith('most-teams-played', 10, 10);
   });
 
+  it('switches to transactions and preserves per-team tooltip lines in API order', async () => {
+    const getCareerHighlights = vi.fn((type: CareerHighlightType) => {
+      switch (type) {
+        case 'most-teams-played':
+          return of(mostTeamsPlayedHighlightsPage0Fixture);
+        case 'most-teams-owned':
+          return of(mostTeamsOwnedHighlightsPage0Fixture);
+        case 'same-team-seasons-played':
+          return of(sameTeamSeasonsHighlightsPage0Fixture);
+        case 'same-team-seasons-owned':
+          return of(sameTeamSeasonsOwnedHighlightsPage0Fixture);
+        case 'most-stanley-cups':
+          return of(mostStanleyCupsHighlightsPage0Fixture);
+        case 'regular-grinder-without-playoffs':
+          return of(regularGrinderWithoutPlayoffsHighlightsPage0Fixture);
+        case 'stash-king':
+          return of(stashKingHighlightsPage0Fixture);
+        case 'most-trades':
+          return of(mostTradesHighlightsPage0Fixture);
+        case 'most-claims':
+          return of(mostClaimsHighlightsPage0Fixture);
+        case 'most-drops':
+          return of(mostDropsHighlightsPage0Fixture);
+        case 'reunion-king':
+          throw new Error('reunion-king should not be requested by the UI');
+      }
+    });
+
+    const view = await render(CareerHighlightsComponent, {
+      imports: [TranslateModule.forRoot()],
+      providers: [
+        provideDisabledMaterialAnimations(),
+        FooterVisibilityService,
+        {
+          provide: ApiService,
+          useValue: {
+            getCareerHighlights,
+          },
+        },
+      ],
+    });
+
+    await vi.waitFor(() => {
+      expect(FakeIntersectionObserver.instances).toHaveLength(7);
+    });
+
+    fireEvent.click(
+      screen.getByRole('radio', {
+        name: 'career.highlights.sections.transactions',
+      }),
+    );
+
+    expect(
+      screen.queryByRole('heading', {
+        name: 'career.highlights.cards.mostTeamsPlayed.title',
+      }),
+    ).not.toBeInTheDocument();
+    expect(
+      await screen.findByRole('heading', {
+        name: 'career.highlights.cards.mostTrades.title',
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', {
+        name: 'career.highlights.cards.mostClaims.title',
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', {
+        name: 'career.highlights.cards.mostDrops.title',
+      }),
+    ).toBeInTheDocument();
+    expect(screen.getAllByText('tableCard.loadWhenVisible')).toHaveLength(3);
+
+    const transactionObservers = FakeIntersectionObserver.instances.slice(-3);
+    transactionObservers[0]?.trigger();
+
+    const tradesCardTitle = screen.getByRole('heading', {
+      name: 'career.highlights.cards.mostTrades.title',
+    });
+    const tradesCard = tradesCardTitle.closest('mat-card') as HTMLElement | null;
+
+    expect(tradesCard).not.toBeNull();
+    expect(await within(tradesCard!).findByText('F Mike Hoffman')).toBeInTheDocument();
+    expect(within(tradesCard!).getByText('6')).toBeInTheDocument();
+    expect(getCareerHighlights).toHaveBeenCalledWith('most-trades', 0, 10);
+
+    const tradesState = view.fixture.componentInstance
+      .cards()
+      .find((card) => card.type === 'most-trades')?.state;
+
+    expect(tradesState?.rows[0]?.detailLines).toEqual([
+      'Colorado Avalanche 3',
+      'Dallas Stars 2',
+      'Carolina Hurricanes 1',
+    ]);
+  });
+
   it('shows an error state for an activated failing card without forcing untouched cards to load', async () => {
     await render(CareerHighlightsComponent, {
       imports: [TranslateModule.forRoot()],
@@ -222,6 +329,12 @@ describe('CareerHighlightsComponent', () => {
                         ? regularGrinderWithoutPlayoffsHighlightsPage0Fixture
                         : type === 'stash-king'
                           ? stashKingHighlightsPage0Fixture
+                          : type === 'most-trades'
+                            ? mostTradesHighlightsPage0Fixture
+                            : type === 'most-claims'
+                              ? mostClaimsHighlightsPage0Fixture
+                              : type === 'most-drops'
+                                ? mostDropsHighlightsPage0Fixture
                     : type === 'same-team-seasons-played'
                       ? sameTeamSeasonsHighlightsPage0Fixture
                       : mostTeamsPlayedHighlightsPage0Fixture

--- a/src/app/career/highlights/career-highlights.component.ts
+++ b/src/app/career/highlights/career-highlights.component.ts
@@ -2,13 +2,17 @@ import {
   ChangeDetectionStrategy,
   Component,
   DestroyRef,
-  OnInit,
   WritableSignal,
+  OnInit,
   computed,
   inject,
   signal,
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import {
+  MatButtonToggleChange,
+  MatButtonToggleModule,
+} from '@angular/material/button-toggle';
 import { TranslateModule } from '@ngx-translate/core';
 
 import {
@@ -19,6 +23,7 @@ import {
   CareerStashHighlightPage,
   CareerStanleyCupHighlightPage,
   CareerTeamCountHighlightPage,
+  CareerTransactionHighlightPage,
 } from '@services/api.service';
 import { FooterVisibilityService } from '@services/footer-visibility.service';
 import { TableCardComponent } from '@shared/table-card/table-card.component';
@@ -29,6 +34,7 @@ import { ActivateOnViewportDirective } from './activate-on-viewport.directive';
 import {
   CareerHighlightCardState,
   CareerHighlightCardView,
+  CareerHighlightSection,
   CareerHighlightsUiType,
 } from './career-highlights.types';
 
@@ -38,10 +44,12 @@ type HighlightCardConfig = Pick<
   CareerHighlightCardState,
   'titleKey' | 'descriptionKey' | 'valueColumnLabelKey'
 > & {
+  readonly section: CareerHighlightSection;
   readonly type: CareerHighlightsUiType;
 };
 
 const MOST_TEAMS_PLAYED_CONFIG: HighlightCardConfig = {
+  section: 'general',
   type: 'most-teams-played',
   titleKey: 'career.highlights.cards.mostTeamsPlayed.title',
   descriptionKey: 'career.highlights.cards.mostTeamsPlayed.description',
@@ -49,6 +57,7 @@ const MOST_TEAMS_PLAYED_CONFIG: HighlightCardConfig = {
 };
 
 const SAME_TEAM_SEASONS_PLAYED_CONFIG: HighlightCardConfig = {
+  section: 'general',
   type: 'same-team-seasons-played',
   titleKey: 'career.highlights.cards.sameTeamSeasonsPlayed.title',
   descriptionKey: 'career.highlights.cards.sameTeamSeasonsPlayed.description',
@@ -56,6 +65,7 @@ const SAME_TEAM_SEASONS_PLAYED_CONFIG: HighlightCardConfig = {
 };
 
 const MOST_TEAMS_OWNED_CONFIG: HighlightCardConfig = {
+  section: 'general',
   type: 'most-teams-owned',
   titleKey: 'career.highlights.cards.mostTeamsOwned.title',
   descriptionKey: 'career.highlights.cards.mostTeamsOwned.description',
@@ -63,6 +73,7 @@ const MOST_TEAMS_OWNED_CONFIG: HighlightCardConfig = {
 };
 
 const MOST_STANLEY_CUPS_CONFIG: HighlightCardConfig = {
+  section: 'general',
   type: 'most-stanley-cups',
   titleKey: 'career.highlights.cards.mostStanleyCups.title',
   descriptionKey: 'career.highlights.cards.mostStanleyCups.description',
@@ -70,6 +81,7 @@ const MOST_STANLEY_CUPS_CONFIG: HighlightCardConfig = {
 };
 
 const REGULAR_GRINDER_WITHOUT_PLAYOFFS_CONFIG: HighlightCardConfig = {
+  section: 'general',
   type: 'regular-grinder-without-playoffs',
   titleKey: 'career.highlights.cards.regularGrinderWithoutPlayoffs.title',
   descriptionKey:
@@ -78,6 +90,7 @@ const REGULAR_GRINDER_WITHOUT_PLAYOFFS_CONFIG: HighlightCardConfig = {
 };
 
 const SAME_TEAM_SEASONS_OWNED_CONFIG: HighlightCardConfig = {
+  section: 'general',
   type: 'same-team-seasons-owned',
   titleKey: 'career.highlights.cards.sameTeamSeasonsOwned.title',
   descriptionKey: 'career.highlights.cards.sameTeamSeasonsOwned.description',
@@ -85,10 +98,35 @@ const SAME_TEAM_SEASONS_OWNED_CONFIG: HighlightCardConfig = {
 };
 
 const STASH_KING_CONFIG: HighlightCardConfig = {
+  section: 'general',
   type: 'stash-king',
   titleKey: 'career.highlights.cards.stashKing.title',
   descriptionKey: 'career.highlights.cards.stashKing.description',
   valueColumnLabelKey: 'career.highlights.columns.seasonCount',
+};
+
+const MOST_TRADES_CONFIG: HighlightCardConfig = {
+  section: 'transactions',
+  type: 'most-trades',
+  titleKey: 'career.highlights.cards.mostTrades.title',
+  descriptionKey: 'career.highlights.cards.mostTrades.description',
+  valueColumnLabelKey: 'career.highlights.columns.trades',
+};
+
+const MOST_CLAIMS_CONFIG: HighlightCardConfig = {
+  section: 'transactions',
+  type: 'most-claims',
+  titleKey: 'career.highlights.cards.mostClaims.title',
+  descriptionKey: 'career.highlights.cards.mostClaims.description',
+  valueColumnLabelKey: 'career.highlights.columns.claims',
+};
+
+const MOST_DROPS_CONFIG: HighlightCardConfig = {
+  section: 'transactions',
+  type: 'most-drops',
+  titleKey: 'career.highlights.cards.mostDrops.title',
+  descriptionKey: 'career.highlights.cards.mostDrops.description',
+  valueColumnLabelKey: 'career.highlights.columns.drops',
 };
 
 const HIGHLIGHT_CARD_CONFIGS: readonly HighlightCardConfig[] = [
@@ -99,6 +137,9 @@ const HIGHLIGHT_CARD_CONFIGS: readonly HighlightCardConfig[] = [
   SAME_TEAM_SEASONS_PLAYED_CONFIG,
   SAME_TEAM_SEASONS_OWNED_CONFIG,
   STASH_KING_CONFIG,
+  MOST_TRADES_CONFIG,
+  MOST_CLAIMS_CONFIG,
+  MOST_DROPS_CONFIG,
 ];
 
 function createInitialCardState(
@@ -121,7 +162,12 @@ function createInitialCardState(
 @Component({
   selector: 'app-career-highlights',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [ActivateOnViewportDirective, TableCardComponent, TranslateModule],
+  imports: [
+    ActivateOnViewportDirective,
+    MatButtonToggleModule,
+    TableCardComponent,
+    TranslateModule,
+  ],
   templateUrl: './career-highlights.component.html',
   styleUrl: './career-highlights.component.scss',
 })
@@ -129,6 +175,8 @@ export class CareerHighlightsComponent implements OnInit {
   private readonly apiService = inject(ApiService);
   private readonly destroyRef = inject(DestroyRef);
   private readonly footerVisibilityService = inject(FooterVisibilityService);
+
+  readonly selectedSection = signal<CareerHighlightSection>('general');
 
   private readonly cardSignals: Record<
     CareerHighlightsUiType,
@@ -151,13 +199,18 @@ export class CareerHighlightsComponent implements OnInit {
       createInitialCardState(SAME_TEAM_SEASONS_OWNED_CONFIG),
     ),
     'stash-king': signal(createInitialCardState(STASH_KING_CONFIG)),
+    'most-trades': signal(createInitialCardState(MOST_TRADES_CONFIG)),
+    'most-claims': signal(createInitialCardState(MOST_CLAIMS_CONFIG)),
+    'most-drops': signal(createInitialCardState(MOST_DROPS_CONFIG)),
   };
 
   readonly cards = computed<readonly CareerHighlightCardView[]>(() =>
-    HIGHLIGHT_CARD_CONFIGS.map((config) => ({
-      type: config.type,
-      state: this.cardSignals[config.type](),
-    })),
+    HIGHLIGHT_CARD_CONFIGS
+      .filter((config) => config.section === this.selectedSection())
+      .map((config) => ({
+        type: config.type,
+        state: this.cardSignals[config.type](),
+      })),
   );
 
   private footerVisibilityCycle = 0;
@@ -165,6 +218,10 @@ export class CareerHighlightsComponent implements OnInit {
 
   ngOnInit(): void {
     this.footerVisibilityCycle = this.footerVisibilityService.currentCycle();
+  }
+
+  onSectionChange(event: MatButtonToggleChange): void {
+    this.selectedSection.set(event.value as CareerHighlightSection);
   }
 
   loadPreviousPage(type: CareerHighlightsUiType): void {
@@ -302,6 +359,16 @@ export class CareerHighlightsComponent implements OnInit {
       }));
     }
 
+    if (this.isTransactionPage(page)) {
+      return page.items.map((item) => ({
+        key: `${page.type}:${item.id}`,
+        primaryText: `${item.position} ${item.name}`,
+        value: item.transactionCount,
+        detailLines: item.teams.map((team) => `${team.name} ${team.count}`),
+        detailLabel: item.name,
+      }));
+    }
+
     return [];
   }
 
@@ -338,6 +405,16 @@ export class CareerHighlightsComponent implements OnInit {
     page: CareerHighlightPage,
   ): page is CareerStashHighlightPage {
     return page.type === 'stash-king';
+  }
+
+  private isTransactionPage(
+    page: CareerHighlightPage,
+  ): page is CareerTransactionHighlightPage {
+    return (
+      page.type === 'most-trades' ||
+      page.type === 'most-claims' ||
+      page.type === 'most-drops'
+    );
   }
 
   private getCardSignal(

--- a/src/app/career/highlights/career-highlights.types.ts
+++ b/src/app/career/highlights/career-highlights.types.ts
@@ -2,6 +2,7 @@ import { CareerHighlightType } from '@services/api.service';
 import { TableCardRow } from '@shared/table-card/table-card.types';
 
 export type CareerHighlightsUiType = Exclude<CareerHighlightType, 'reunion-king'>;
+export type CareerHighlightSection = 'general' | 'transactions';
 
 export interface CareerHighlightCardState {
   readonly titleKey: string;

--- a/src/app/services/api.service.ts
+++ b/src/app/services/api.service.ts
@@ -27,18 +27,23 @@ export type CareerStanleyCupHighlightItem = components['schemas']['CareerStanley
 export type CareerStashHighlightItem = components['schemas']['CareerStashHighlightItem'];
 export type CareerRegularGrinderHighlightItem =
   components['schemas']['CareerRegularGrinderHighlightItem'];
+export type CareerTransactionHighlightItem =
+  components['schemas']['CareerTransactionHighlightItem'];
 export type CareerTeamCountHighlightPage = components['schemas']['CareerTeamCountHighlightPage'];
 export type CareerSameTeamHighlightPage = components['schemas']['CareerSameTeamHighlightPage'];
 export type CareerStanleyCupHighlightPage = components['schemas']['CareerStanleyCupHighlightPage'];
 export type CareerStashHighlightPage = components['schemas']['CareerStashHighlightPage'];
 export type CareerRegularGrinderHighlightPage =
   components['schemas']['CareerRegularGrinderHighlightPage'];
+export type CareerTransactionHighlightPage =
+  components['schemas']['CareerTransactionHighlightPage'];
 export type CareerHighlightPage =
   | CareerTeamCountHighlightPage
   | CareerSameTeamHighlightPage
   | CareerStanleyCupHighlightPage
   | CareerStashHighlightPage
-  | CareerRegularGrinderHighlightPage;
+  | CareerRegularGrinderHighlightPage
+  | CareerTransactionHighlightPage;
 
 // Player includes frontend-only augmentation fields not present in the API spec.
 // seasons is made optional to match single-season endpoint usage (spec: CombinedPlayer has required seasons).

--- a/src/app/services/api.types.generated.ts
+++ b/src/app/services/api.types.generated.ts
@@ -1021,11 +1021,15 @@ export interface paths {
          *     games stayed at zero.
          *     `regular-grinder-without-playoffs` returns total regular-season games plus the played fantasy teams
          *     for players/goalies who never recorded a playoff appearance.
+         *     `most-trades`, `most-claims`, and `most-drops` return total matched player/goalie transaction counts
+         *     plus per-team breakdowns sorted by descending transaction count. Trade counts use the fantasy team that
+         *     traded the player away.
          *     Minimum cutoffs are 4 teams for `most-teams-played`, 5 teams for `most-teams-owned`,
          *     8 same-team seasons for `same-team-seasons-played`, 10 same-team seasons for
          *     `same-team-seasons-owned`, 2 cups for `most-stanley-cups`, 2 reunion stints for
-         *     `reunion-king`, 10 stash counts for `stash-king`, and 60 games for
-         *     `regular-grinder-without-playoffs`.
+         *     `reunion-king`, 10 stash counts for `stash-king`, 60 games for
+         *     `regular-grinder-without-playoffs`, 4 trades for `most-trades`, and 3 claims/drops for
+         *     `most-claims` / `most-drops`.
          */
         get: {
             parameters: {
@@ -1050,7 +1054,7 @@ export interface paths {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": components["schemas"]["CareerTeamCountHighlightPage"] | components["schemas"]["CareerSameTeamHighlightPage"] | components["schemas"]["CareerStanleyCupHighlightPage"] | components["schemas"]["CareerReunionHighlightPage"] | components["schemas"]["CareerStashHighlightPage"] | components["schemas"]["CareerRegularGrinderHighlightPage"];
+                        "application/json": components["schemas"]["CareerTeamCountHighlightPage"] | components["schemas"]["CareerSameTeamHighlightPage"] | components["schemas"]["CareerStanleyCupHighlightPage"] | components["schemas"]["CareerReunionHighlightPage"] | components["schemas"]["CareerStashHighlightPage"] | components["schemas"]["CareerRegularGrinderHighlightPage"] | components["schemas"]["CareerTransactionHighlightPage"];
                     };
                 };
                 /** @description Invalid highlight type or paging params. */
@@ -1367,7 +1371,7 @@ export interface components {
             playoffGames: number;
         };
         /** @enum {string} */
-        CareerHighlightType: "most-teams-played" | "most-teams-owned" | "same-team-seasons-played" | "same-team-seasons-owned" | "most-stanley-cups" | "reunion-king" | "stash-king" | "regular-grinder-without-playoffs";
+        CareerHighlightType: "most-teams-played" | "most-teams-owned" | "same-team-seasons-played" | "same-team-seasons-owned" | "most-stanley-cups" | "reunion-king" | "stash-king" | "regular-grinder-without-playoffs" | "most-trades" | "most-claims" | "most-drops";
         CareerHighlightTeam: {
             id: string;
             name: string;
@@ -1423,6 +1427,18 @@ export interface components {
             regularGames: number;
             teams: components["schemas"]["CareerHighlightTeam"][];
         };
+        CareerTransactionHighlightTeam: {
+            id: string;
+            name: string;
+            count: number;
+        };
+        CareerTransactionHighlightItem: {
+            id: string;
+            name: string;
+            position: string;
+            transactionCount: number;
+            teams: components["schemas"]["CareerTransactionHighlightTeam"][];
+        };
         CareerTeamCountHighlightPage: {
             /** @enum {string} */
             type: "most-teams-played" | "most-teams-owned";
@@ -1470,6 +1486,14 @@ export interface components {
             take: number;
             total: number;
             items: components["schemas"]["CareerRegularGrinderHighlightItem"][];
+        };
+        CareerTransactionHighlightPage: {
+            /** @enum {string} */
+            type: "most-trades" | "most-claims" | "most-drops";
+            skip: number;
+            take: number;
+            total: number;
+            items: components["schemas"]["CareerTransactionHighlightItem"][];
         };
         CareerGoalie: {
             id: string;

--- a/src/app/testing/behavior-test-utils.ts
+++ b/src/app/testing/behavior-test-utils.ts
@@ -41,6 +41,9 @@ import sameTeamSeasonsHighlightsPage0FixtureData from '../../../e2e/fixtures/dat
 import sameTeamSeasonsHighlightsPage1FixtureData from '../../../e2e/fixtures/data/career--highlights--same-team-seasons-played--skip=10--take=10.json';
 import sameTeamSeasonsOwnedHighlightsPage0FixtureData from '../../../e2e/fixtures/data/career--highlights--same-team-seasons-owned--skip=0--take=10.json';
 import sameTeamSeasonsOwnedHighlightsPage1FixtureData from '../../../e2e/fixtures/data/career--highlights--same-team-seasons-owned--skip=10--take=10.json';
+import mostTradesHighlightsPage0FixtureData from '../../../e2e/fixtures/data/career--highlights--most-trades--skip=0--take=10.json';
+import mostClaimsHighlightsPage0FixtureData from '../../../e2e/fixtures/data/career--highlights--most-claims--skip=0--take=10.json';
+import mostDropsHighlightsPage0FixtureData from '../../../e2e/fixtures/data/career--highlights--most-drops--skip=0--take=10.json';
 import leaderboardTransactionsFixtureData from '../../../e2e/fixtures/data/leaderboard--transactions.json';
 
 export const PLAYER_SLICE_COUNT = 12;
@@ -67,6 +70,12 @@ export const sameTeamSeasonsOwnedHighlightsPage0Fixture =
   sameTeamSeasonsOwnedHighlightsPage0FixtureData as CareerHighlightPage;
 export const sameTeamSeasonsOwnedHighlightsPage1Fixture =
   sameTeamSeasonsOwnedHighlightsPage1FixtureData as CareerHighlightPage;
+export const mostTradesHighlightsPage0Fixture =
+  mostTradesHighlightsPage0FixtureData as CareerHighlightPage;
+export const mostClaimsHighlightsPage0Fixture =
+  mostClaimsHighlightsPage0FixtureData as CareerHighlightPage;
+export const mostDropsHighlightsPage0Fixture =
+  mostDropsHighlightsPage0FixtureData as CareerHighlightPage;
 export const leaderboardTransactionsFixture =
   leaderboardTransactionsFixtureData as TransactionLeaderboardEntry[];
 export const mostStanleyCupsHighlightsPage0Fixture = {
@@ -191,6 +200,9 @@ export type BehaviorApiMockOptions = {
   careerHighlightsMostStanleyCups?: CareerHighlightPage;
   careerHighlightsRegularGrinderWithoutPlayoffs?: CareerHighlightPage;
   careerHighlightsStashKing?: CareerHighlightPage;
+  careerHighlightsMostTrades?: CareerHighlightPage;
+  careerHighlightsMostClaims?: CareerHighlightPage;
+  careerHighlightsMostDrops?: CareerHighlightPage;
   leaderboardRegular?: RegularLeaderboardEntry[];
   leaderboardPlayoffs?: PlayoffLeaderboardEntry[];
   leaderboardTransactions?: TransactionLeaderboardEntry[];
@@ -250,6 +262,12 @@ function getDefaultCareerHighlightsFixture(
         ?? regularGrinderWithoutPlayoffsHighlightsPage0Fixture;
     case 'stash-king':
       return options.careerHighlightsStashKing ?? stashKingHighlightsPage0Fixture;
+    case 'most-trades':
+      return options.careerHighlightsMostTrades ?? mostTradesHighlightsPage0Fixture;
+    case 'most-claims':
+      return options.careerHighlightsMostClaims ?? mostClaimsHighlightsPage0Fixture;
+    case 'most-drops':
+      return options.careerHighlightsMostDrops ?? mostDropsHighlightsPage0Fixture;
     case 'reunion-king':
       throw new Error('Behavior test mock for reunion-king is not configured.');
   }


### PR DESCRIPTION
## Summary
- Split `/career/highlights` into two sections with a centered switch: `Sekalaiset` as the default and `Siirrot` for transaction-only highlights.
- Kept the existing highlight cards under `Sekalaiset` and added three new transaction cards under `Siirrot`: most trades, most claims, and most drops.
- Formatted the new card tooltips as `Team name + count`, one team per row, in backend data order.
- Updated Finnish highlight copy and E2E title constants to match the new labels.
- Added/updated behavior tests, mobile route coverage, Playwright coverage, and highlight fixtures.
- Tightened `AGENTS.md` and `CLAUDE.md` so future tasks explicitly pause for user review before final `npm run verify` and commit.

## Testing
- `npm run verify`
- `npx playwright test e2e/specs/career.spec.ts`
- Manual light/dark check on `/career/highlights`
