### PR TITLE
Feature: Reunion king career highlight

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,14 +18,15 @@ If documentation includes clearly bad decisions, challenge them and propose bett
   2. Implement the change and run only the minimum iterative checks needed while working.
   3. Pause for user review before final verify.
   4. If review feedback comes in, iterate on that feedback and return to the review pause when needed.
-  5. After the user explicitly accepts the batch, run `npm run verify` unless the accepted batch is documentation-only and cannot affect the verification result.
+  5. After the user explicitly accepts the batch, run `npm run verify` unless the accepted batch is documentation-only or E2E-only and cannot affect the verification result.
   6. If `verify` fails, fix the issues, rerun the necessary checks, and keep going until `verify` passes.
-  7. After `verify` passes, or immediately for documentation-only batches where verify is intentionally skipped, commit when the user has asked for or approved a commit.
+  7. After `verify` passes, or immediately for documentation-only or E2E-only batches where verify is intentionally skipped, commit when the user has asked for or approved a commit.
 - After each user-accepted and verified batch, you may commit if useful as a checkpoint.
 - Documentation-only batches may skip `npm run verify` when the touched files are limited to docs/workflow text such as `README.md`, `docs/**`, or `AGENTS.md` and no code, fixtures, configs, or generated artifacts changed.
+- E2E-only batches may skip `npm run verify` when the touched files are limited to `e2e/**` and optional docs/workflow text, no app/runtime/config/generated artifacts changed, and the relevant Playwright coverage for the batch has been run and reported.
 - After a verified commit, if no further implementation work is queued in the task, automatically provide copy-pasteable PR notes in a code block unless the user explicitly says they do not want them.
 - If PR notes are intentionally omitted because the branch is clearly not PR-ready, say that explicitly instead of silently stopping after the commit.
-- Before any non-documentation-only commit, `npm run verify` must pass. Targeted tests are not a substitute for the full verification gate.
+- Before any batch that can affect the `npm run verify` result, `npm run verify` must pass. Targeted tests are not a substitute for the full verification gate.
 - Commit message prefixes should use capitalized conventional labels.
 - New features must use the prefix `Feature: `.
 - Non-feature commits should use a capitalized prefix such as `Fix:`, `Docs:`, `Chore:`, etc.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,8 +12,20 @@ If documentation includes clearly bad decisions, challenge them and propose bett
 - If currently on `main`, ask user to create a branch before implementing task changes.
 - If considering `git worktree`, always ask explicitly first and explain why worktree would help.
 - In every task, include a user review phase before final verify. After implementation, pause and hand the work to the user for review before running the final `npm run verify` or creating a commit.
-- Do not run the final verification gate and do not commit until the user has explicitly accepted the review phase for that batch. After review is accepted and verify passes, you can commit. After each user-accepted and verified batch, you may commit if useful as a checkpoint. Offer PR notes as a copy-pasteable code block only when the branch is fully implemented and ready for PR; user will handle the rest.
-- Before any commit, `npm run verify` must pass. Targeted tests are not a substitute for the full verification gate.
+- Do not run the final verification gate and do not commit until the user has explicitly accepted the review phase for that batch.
+- Expected batch flow:
+  1. Check workspace/branch state and read the required docs first.
+  2. Implement the change and run only the minimum iterative checks needed while working.
+  3. Pause for user review before final verify.
+  4. If review feedback comes in, iterate on that feedback and return to the review pause when needed.
+  5. After the user explicitly accepts the batch, run `npm run verify` unless the accepted batch is documentation-only and cannot affect the verification result.
+  6. If `verify` fails, fix the issues, rerun the necessary checks, and keep going until `verify` passes.
+  7. After `verify` passes, or immediately for documentation-only batches where verify is intentionally skipped, commit when the user has asked for or approved a commit.
+- After each user-accepted and verified batch, you may commit if useful as a checkpoint.
+- Documentation-only batches may skip `npm run verify` when the touched files are limited to docs/workflow text such as `README.md`, `docs/**`, or `AGENTS.md` and no code, fixtures, configs, or generated artifacts changed.
+- After a verified commit, if no further implementation work is queued in the task, automatically provide copy-pasteable PR notes in a code block unless the user explicitly says they do not want them.
+- If PR notes are intentionally omitted because the branch is clearly not PR-ready, say that explicitly instead of silently stopping after the commit.
+- Before any non-documentation-only commit, `npm run verify` must pass. Targeted tests are not a substitute for the full verification gate.
 - Commit message prefixes should use capitalized conventional labels.
 - New features must use the prefix `Feature: `.
 - Non-feature commits should use a capitalized prefix such as `Fix:`, `Docs:`, `Chore:`, etc.

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Live showcase: https://ffhl-stats.vercel.app/
 	- Searchable and sortable, with no stats-page filters or mobile drawer
 	- Virtualized row rendering keeps long lists responsive
 	- Player rows show position inline with name (for example `D Travis Hamonic`) while still sorting alphabetically by player name
-	- `/career/highlights` splits compact paged highlight cards into `Sekalaiset` and `Siirrot`, covering the existing general career slices plus transaction leaders for most trades, claims, and drops; each card lazy-loads its dataset as it approaches the viewport
+	- `/career/highlights` splits compact paged highlight cards into `Sekalaiset` and `Siirrot`, covering the existing general career slices plus transaction leaders for most trades, claims, drops, and same-team reunions; each card lazy-loads its dataset as it approaches the viewport
 - 🚦 **Split Route Shells**: Interactive dashboard routes lazy-load their heavier shell (controls, settings drawer, comparison bar, tabs), while career and leaderboard browsing routes stay on a lighter root shell
 - 🗂️ **Global Navigation**: Bottom sheet menu for switching between views (hockey stats, player careers, leaderboards, info/help)
 - 🔗 **Direct Player Links**: Shareable URLs for player/goalie cards
@@ -220,6 +220,7 @@ Service-layer note:
 - UI behavior should still be tested through rendered user flows
 - UI tests should keep real app state services in place; only external/platform boundaries such as `ApiService`, `ViewportService`, and `PwaUpdateService` should normally be mocked
 - Lower-level services such as `ApiService`, `CacheService`, and `PwaUpdateService` may use focused `TestBed` specs when the real HTTP/platform pipeline itself is what needs coverage
+- Small UI-only helpers such as formatters or tooltip/view-model builders should normally stay covered through the owning behavior test; use a dedicated helper spec only when there is no realistic behavior/service-layer coverage path
 
 ## Accessibility
 

--- a/README.md
+++ b/README.md
@@ -323,9 +323,9 @@ The application is fully responsive with optimized layouts for all screen sizes:
 When contributing, please ensure:
 
 1. All new/changed code has corresponding tests (aim 100% coverage for the code you touched)
-2. `npm run verify` passes (includes coverage gate + production build)
+2. For non-documentation-only changes, `npm run verify` passes (includes coverage gate + production build)
 3. Follow existing code style and patterns
-4. Run `npm run verify` before committing
+4. Run `npm run verify` before committing non-documentation-only changes
 5. Update documentation when changes affect usage/behavior, scripts/workflows, or project standards
 
 In addition, treat accessibility as a hard requirement for every change. If a feature is not keyboard-accessible and properly labeled, it is not considered done.

--- a/docs/README.md
+++ b/docs/README.md
@@ -33,6 +33,7 @@ Fantrax Stats Parser UI is an Angular 21 application that provides a user interf
 - Component tests use Testing Library (`@testing-library/angular`) with Vitest, following accessible user-centric queries (`getByRole`, `getByText`, etc.) against real user flows.
 - Service-layer tests use Angular `TestBed` directly when HTTP/cache/platform logic needs to be verified without bypassing the real service implementation.
 - UI tests mock only approved external/platform boundaries such as `ApiService`, `ViewportService`, and `PwaUpdateService`; they do not replace stateful UI services just to isolate controls.
+- Behavior coverage is the starting point for new UI code; dedicated helper/unit specs are exceptions for logic that cannot be exercised realistically through behavior or service-layer tests.
 - End-to-end tests are implemented with Playwright in the `e2e` directory and exercise real user flows against a running dev server.
 - Playwright is configured via `playwright.config.ts` to run against `http://localhost:4200` in Chromium only and start `npm start` automatically for local runs.
 - E2E tests are organized into feature-based specs under `e2e/specs/` (smoke, player-card, team-switching, filters, mobile) with page objects and shared helpers.

--- a/docs/codebase-structure.md
+++ b/docs/codebase-structure.md
@@ -186,6 +186,9 @@ Shared SCSS partials used by multiple shells or route families.
 #### `column.types.ts`
 `Column` and `ColumnIcon` type definitions shared by all table consumers
 
+#### `utils/`
+Reusable shared formatting/conversion helpers such as season and date utilities
+
 ## File Naming Conventions
 
 - **Components**: `component-name.component.ts`

--- a/docs/coding-standards.md
+++ b/docs/coding-standards.md
@@ -140,6 +140,31 @@ function calculatePoints(goals, assists) {
 }
 ```
 
+### Date And Time Handling
+
+Handle user-visible dates/times with locale-aware APIs and shared helpers.
+
+- Do not manually build localized date strings by splitting ISO strings or concatenating day/month/year pieces.
+- Prefer shared `Intl.DateTimeFormat`-based helpers under `src/app/shared/utils/` for reusable formatting.
+- Use the active UI language when formatting should follow the app locale:
+  - `translate.currentLang || translate.getFallbackLang()`
+- Choose the timezone intentionally instead of relying on the browser default by accident:
+  - Use a fixed zone such as `Europe/Helsinki` when the product wants a league/app-local clock time.
+  - Use `UTC` when only the calendar date should stay stable across browsers for ISO timestamps/date-times.
+- Validate parsed dates before formatting and return a safe fallback (`null`, hidden field, or original domain value as appropriate) instead of showing `Invalid Date`.
+
+```typescript
+import { formatDateForLocale } from '@shared/utils/date.utils';
+
+const locale = this.translate.currentLang || this.translate.getFallbackLang() || 'fi';
+const label = formatDateForLocale(isoString, locale, {
+  day: 'numeric',
+  month: 'numeric',
+  year: 'numeric',
+  timeZone: 'UTC',
+});
+```
+
 ## RxJS Best Practices
 
 ### Observable Subscriptions
@@ -372,6 +397,8 @@ All tests use **Testing Library** (`@testing-library/angular`) with **Vitest**.
 - **Minimize renders**: Group all assertions for a given scenario into one test with one `render()` call. Use comments to separate logical groups. Do not create separate `it()` blocks that each re-render the same component state
 - **Prefer full behavior paths for UI tests**: Render the real feature/shell flow for controls the user can see and interact with
 - **Mock only approved external boundaries in UI tests**: `ApiService`, `ViewportService`, and `PwaUpdateService` are normal mock points; do not mock stateful UI services like `FilterService`, `SettingsService`, or `TeamService` just to isolate a control
+- **Start with behavior coverage for new UI code**: Small UI-only helpers such as formatters, tooltip builders, or one-feature mapping functions should usually be covered through the owning behavior test first
+- **Write standalone helper specs only as an exception**: Reusable domain logic, multiple unrelated consumers, or no realistic behavior/service-layer coverage path are good reasons
 - **Delete impossible-state branches**: If a branch cannot happen in any real usage path, remove it instead of keeping defensive context checks or dead fallback code
 - **Simplify before adding tests**: For behavior-neutral refactors, prefer deleting unreachable logic over adding narrow tests whose only purpose is to preserve coverage for code the UI can never hit
 - **Clean up after refactors**: When a refactor replaces an implementation, verify whether the old path still has consumers and delete it if it does not

--- a/docs/component-guide.md
+++ b/docs/component-guide.md
@@ -199,7 +199,7 @@ TeamService → PlayerStatsComponent (triggers refetch + adds teamId)
 - Fetch career rows from the dedicated API endpoints
 - Pass column definitions and formatters into the shared virtualized table
 - Keep the player career table sorted by plain `name` while rendering position inline with the displayed player name
-- Normalize paged highlight responses into the shared `TableCardComponent` row shape for the `/career/highlights` route, including the existing general cards plus transaction variants for most trades, claims, and drops
+- Normalize paged highlight responses into the shared `TableCardComponent` row shape for the `/career/highlights` route, including the existing general cards plus transaction variants for most trades, claims, drops, and same-team reunions
 - Keep the centered `Sekalaiset` / `Siirrot` switch accessible while preserving each card's lazy-loading and paging state
 - Activate highlight-card API loads lazily as each card approaches the viewport instead of requesting every card during route startup
 

--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -315,7 +315,7 @@ The API endpoint is configured in the service layer. Check:
 - [ ] Code follows Angular style guide
 - [ ] No console.log statements in production code
 - [ ] Tests updated/added (Testing Library)
-- [ ] `npm run verify` passes (tests + production build)
+- [ ] `npm run verify` passes (tests + production build) for non-documentation-only changes
 - [ ] No TypeScript errors
 - [ ] No `any` types — run `npm run lint` to verify
 - [ ] Components properly typed

--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -220,6 +220,17 @@ npx ng generate <schematic> <name>
 npx ng help
 ```
 
+### Dates and times
+
+When you add or change user-visible date/time formatting:
+
+- Prefer shared `Intl.DateTimeFormat`-based helpers in `src/app/shared/utils/` over manual string splitting.
+- Match the locale to the active UI language unless the feature intentionally uses a fixed locale.
+- Pick the timezone deliberately:
+  - `Europe/Helsinki` for league/app-local timestamps
+  - `UTC` when an ISO timestamp's calendar date must not drift by browser timezone
+- Validate invalid/missing dates and show a safe fallback instead of leaking `Invalid Date`
+
 ## Project Configuration
 
 ### Backend API Endpoint

--- a/docs/project-overview.md
+++ b/docs/project-overview.md
@@ -79,7 +79,7 @@ Accessibility is a core requirement: the UI is designed to remain usable via key
    - Searchable and sortable without the stats-page controls/drawer/comparison bar
    - Player position is rendered inline with player name while sorting still uses the underlying plain `name`
    - Uses a virtualized table implementation to keep large result sets responsive
-   - The highlights tab splits compact paged table cards into `Sekalaiset` and `Siirrot`, keeping the existing general slices while adding transaction leaders for most trades, claims, and drops
+   - The highlights tab splits compact paged table cards into `Sekalaiset` and `Siirrot`, keeping the existing general slices while adding transaction leaders for most trades, claims, drops, and same-team reunions
    - Highlight cards lazy-load their API data as they enter or near the viewport so the route scales better as more cards are added
 
 7. **Data Management**

--- a/docs/project-testing.md
+++ b/docs/project-testing.md
@@ -88,6 +88,8 @@ Interpretation rules:
 - **Approved mock boundaries only**: In UI tests, mock only external/platform boundaries such as `ApiService`, `ViewportService`, and `PwaUpdateService`
 - **Do not mock stateful UI services just to isolate controls**: Avoid mocking services like `FilterService`, `SettingsService`, or `TeamService` when the control is something the user sees and clicks
 - **Minimize renders**: Full-render tests are expensive. Group all assertions for a given scenario into a single test with one `render()` call. Use comments to separate logical assertion groups. Do NOT create separate `it()` blocks that each call `render()` for the same component state
+- **Avoid helper-only specs by default**: For small UI-only helpers such as formatters, tooltip text builders, or one-feature view-model mappers, start by covering them through the owning behavior test instead of adding a separate spec just for coverage
+- **Use dedicated helper specs as an exception, not the baseline**: Good reasons include reusable domain logic, multiple unrelated consumers, or code that cannot be exercised realistically through behavior or service-layer tests
 - **Prefer removing dead logic to covering it**: If a branch cannot be reached through any real user path, delete it instead of adding isolated tests that only exercise internal implementation details
 - **After refactors, remove proven-unused leftovers**: Once the new path is in place, investigate the replaced implementation and delete unused old code instead of preserving it "for safety"
 

--- a/docs/project-testing.md
+++ b/docs/project-testing.md
@@ -220,6 +220,7 @@ Local rule of thumb:
 - Do **not** set `CI=true` for routine local verification
 - Use the CI/fixture mode only when you intentionally want the mocked CI behavior
 - If the backend on `localhost:3000` is not running in a paired session, ask the user to start it instead of swapping local verification over to CI-mode fixtures
+- When Playwright assertions need visible Finnish UI copy, source shared labels from `public/i18n/fi.json` through the E2E config helpers instead of duplicating hard-coded strings in test constants
 
 **Basic commands:**
 

--- a/e2e/config/i18n.ts
+++ b/e2e/config/i18n.ts
@@ -1,0 +1,28 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+type TranslationTree = Record<string, unknown>;
+
+const fiTranslations = JSON.parse(
+  readFileSync(resolve(process.cwd(), 'public/i18n/fi.json'), 'utf8'),
+) as TranslationTree;
+
+export function fi(path: string): string {
+  const value = path.split('.').reduce<unknown>((current, segment) => {
+    if (!current || typeof current !== 'object' || Array.isArray(current)) {
+      throw new Error(`Missing fi translation path: ${path}`);
+    }
+
+    if (!(segment in current)) {
+      throw new Error(`Missing fi translation path: ${path}`);
+    }
+
+    return (current as TranslationTree)[segment];
+  }, fiTranslations);
+
+  if (typeof value !== 'string') {
+    throw new Error(`Fi translation path does not resolve to a string: ${path}`);
+  }
+
+  return value;
+}

--- a/e2e/config/test-data.ts
+++ b/e2e/config/test-data.ts
@@ -52,6 +52,7 @@ export const CAREER_HIGHLIGHT_CARD_LABELS = {
   MOST_TRADES: 'Eniten kaupatut',
   MOST_CLAIMS: 'Eniten nostetut',
   MOST_DROPS: 'Eniten pudotetut',
+  REUNION_KING: 'Eniten paluita samaan seuraan',
 };
 
 export const NAV_LABELS = {

--- a/e2e/config/test-data.ts
+++ b/e2e/config/test-data.ts
@@ -2,6 +2,8 @@
  * Shared test constants and configuration
  */
 
+import { fi } from './i18n';
+
 export const DEFAULT_TEAM = 'Colorado Avalanche';
 
 export const MOBILE_VIEWPORT = {
@@ -17,50 +19,50 @@ export const DESKTOP_VIEWPORT = {
 export const WAIT_TIMEOUT = 10000;
 
 export const FILTER_LABELS = {
-  TEAM: 'Joukkue',
-  SEASON: 'Kausivalitsin',
-  START_FROM: 'Alkaen kaudesta',
-  REPORT_TYPE_REGULAR: 'Runkosarja',
-  REPORT_TYPE_PLAYOFFS: 'Playoffs',
-  STATS_PER_GAME: 'Tilastot per ottelu',
-  MIN_GAMES: 'Otteluja pelattu vähintään',
-  POSITION_ALL: 'Kaikki',
-  POSITION_FORWARDS: 'H',
-  POSITION_DEFENSE: 'P',
+  TEAM: fi('team.selector'),
+  SEASON: fi('season.selector'),
+  START_FROM: fi('startFromSeason.selector'),
+  REPORT_TYPE_REGULAR: fi('reportType.regular'),
+  REPORT_TYPE_PLAYOFFS: fi('reportType.playoffs'),
+  STATS_PER_GAME: fi('statsModeToggle'),
+  MIN_GAMES: fi('minGamesSlider.label'),
+  POSITION_ALL: fi('positionFilter.all'),
+  POSITION_FORWARDS: fi('positionFilter.forwards'),
+  POSITION_DEFENSE: fi('positionFilter.defensemen'),
 };
 
 export const TAB_LABELS = {
-  PLAYERS: 'Kenttäpelaajat',
-  GOALIES: 'Maalivahdit',
-  CAREER_PLAYERS: 'Kenttäpelaajat',
-  CAREER_GOALIES: 'Maalivahdit',
-  CAREER_HIGHLIGHTS: 'Nostot',
-  PLAYER_CARD_STATS: 'Tilastot',
-  PLAYER_CARD_BY_SEASON: 'Kausittain',
-  PLAYER_CARD_GRAPHS: 'Graafit',
-  LEADERBOARD_REGULAR: 'Runkosarja',
-  LEADERBOARD_PLAYOFFS: 'Playoffs',
-  LEADERBOARD_TRANSACTIONS: 'Siirrot',
+  PLAYERS: fi('link.playerStats'),
+  GOALIES: fi('link.goalieStats'),
+  CAREER_PLAYERS: fi('career.tabs.players'),
+  CAREER_GOALIES: fi('career.tabs.goalies'),
+  CAREER_HIGHLIGHTS: fi('career.tabs.highlights'),
+  PLAYER_CARD_STATS: fi('playerCard.all'),
+  PLAYER_CARD_BY_SEASON: fi('playerCard.bySeason'),
+  PLAYER_CARD_GRAPHS: fi('playerCard.graphs'),
+  LEADERBOARD_REGULAR: fi('leaderboards.tabs.regular'),
+  LEADERBOARD_PLAYOFFS: fi('leaderboards.tabs.playoffs'),
+  LEADERBOARD_TRANSACTIONS: fi('leaderboards.tabs.transactions'),
 };
 
 export const CAREER_HIGHLIGHT_SECTION_LABELS = {
-  GENERAL: 'Sekalaiset',
-  TRANSACTIONS: 'Siirrot',
+  GENERAL: fi('career.highlights.sections.general'),
+  TRANSACTIONS: fi('career.highlights.sections.transactions'),
 };
 
 export const CAREER_HIGHLIGHT_CARD_LABELS = {
-  MOST_TRADES: 'Eniten kaupatut',
-  MOST_CLAIMS: 'Eniten nostetut',
-  MOST_DROPS: 'Eniten pudotetut',
-  REUNION_KING: 'Eniten paluita samaan seuraan',
+  MOST_TRADES: fi('career.highlights.cards.mostTrades.title'),
+  MOST_CLAIMS: fi('career.highlights.cards.mostClaims.title'),
+  MOST_DROPS: fi('career.highlights.cards.mostDrops.title'),
+  REUNION_KING: fi('career.highlights.cards.reunionKing.title'),
 };
 
 export const NAV_LABELS = {
-  PLAYER_CAREERS: 'Pelaajaurat',
+  PLAYER_CAREERS: fi('nav.playerCareers'),
 };
 
 export const LEADERBOARD_LABELS = {
-  REGULAR: 'Runkosarja',
-  PLAYOFFS: 'Playoffs',
-  TRANSACTIONS: 'Siirrot',
+  REGULAR: fi('leaderboards.tabs.regular'),
+  PLAYOFFS: fi('leaderboards.tabs.playoffs'),
+  TRANSACTIONS: fi('leaderboards.tabs.transactions'),
 };

--- a/e2e/fixtures/data/career--highlights--most-claims--skip=0--take=10.json
+++ b/e2e/fixtures/data/career--highlights--most-claims--skip=0--take=10.json
@@ -1,5 +1,6 @@
 {
   "type": "most-claims",
+  "minAllowed": 3,
   "skip": 0,
   "take": 10,
   "total": 3,

--- a/e2e/fixtures/data/career--highlights--most-drops--skip=0--take=10.json
+++ b/e2e/fixtures/data/career--highlights--most-drops--skip=0--take=10.json
@@ -1,5 +1,6 @@
 {
   "type": "most-drops",
+  "minAllowed": 3,
   "skip": 0,
   "take": 10,
   "total": 3,

--- a/e2e/fixtures/data/career--highlights--most-stanley-cups--skip=0--take=10.json
+++ b/e2e/fixtures/data/career--highlights--most-stanley-cups--skip=0--take=10.json
@@ -1,5 +1,6 @@
 {
   "type": "most-stanley-cups",
+  "minAllowed": 2,
   "skip": 0,
   "take": 10,
   "total": 2,

--- a/e2e/fixtures/data/career--highlights--most-teams-owned--skip=0--take=10.json
+++ b/e2e/fixtures/data/career--highlights--most-teams-owned--skip=0--take=10.json
@@ -1,5 +1,6 @@
 {
   "type": "most-teams-owned",
+  "minAllowed": 5,
   "skip": 0,
   "take": 10,
   "total": 12,

--- a/e2e/fixtures/data/career--highlights--most-teams-owned--skip=10--take=10.json
+++ b/e2e/fixtures/data/career--highlights--most-teams-owned--skip=10--take=10.json
@@ -1,5 +1,6 @@
 {
   "type": "most-teams-owned",
+  "minAllowed": 5,
   "skip": 10,
   "take": 10,
   "total": 12,

--- a/e2e/fixtures/data/career--highlights--most-teams-played--skip=0--take=10.json
+++ b/e2e/fixtures/data/career--highlights--most-teams-played--skip=0--take=10.json
@@ -1,5 +1,6 @@
 {
   "type": "most-teams-played",
+  "minAllowed": 4,
   "skip": 0,
   "take": 10,
   "total": 12,

--- a/e2e/fixtures/data/career--highlights--most-teams-played--skip=10--take=10.json
+++ b/e2e/fixtures/data/career--highlights--most-teams-played--skip=10--take=10.json
@@ -1,5 +1,6 @@
 {
   "type": "most-teams-played",
+  "minAllowed": 4,
   "skip": 10,
   "take": 10,
   "total": 12,

--- a/e2e/fixtures/data/career--highlights--most-trades--skip=0--take=10.json
+++ b/e2e/fixtures/data/career--highlights--most-trades--skip=0--take=10.json
@@ -1,5 +1,6 @@
 {
   "type": "most-trades",
+  "minAllowed": 4,
   "skip": 0,
   "take": 10,
   "total": 3,

--- a/e2e/fixtures/data/career--highlights--regular-grinder-without-playoffs--skip=0--take=10.json
+++ b/e2e/fixtures/data/career--highlights--regular-grinder-without-playoffs--skip=0--take=10.json
@@ -1,5 +1,6 @@
 {
   "type": "regular-grinder-without-playoffs",
+  "minAllowed": 60,
   "skip": 0,
   "take": 10,
   "total": 2,

--- a/e2e/fixtures/data/career--highlights--reunion-king--skip=0--take=10.json
+++ b/e2e/fixtures/data/career--highlights--reunion-king--skip=0--take=10.json
@@ -1,0 +1,49 @@
+{
+  "type": "reunion-king",
+  "minAllowed": 2,
+  "skip": 0,
+  "take": 10,
+  "total": 2,
+  "items": [
+    {
+      "id": "reunion-1",
+      "name": "Mikael Granlund",
+      "position": "F",
+      "reunionCount": 2,
+      "team": {
+        "id": "1",
+        "name": "Colorado Avalanche"
+      },
+      "reunions": [
+        {
+          "date": "2013-12-18T14:12:00.000Z",
+          "type": "trade"
+        },
+        {
+          "date": "2016-08-10T09:30:00.000Z",
+          "type": "claim"
+        }
+      ]
+    },
+    {
+      "id": "reunion-2",
+      "name": "Dmitry Orlov",
+      "position": "D",
+      "reunionCount": 2,
+      "team": {
+        "id": "2",
+        "name": "Dallas Stars"
+      },
+      "reunions": [
+        {
+          "date": "2015-07-01T12:00:00.000Z",
+          "type": "claim"
+        },
+        {
+          "date": "2018-11-03T18:45:00.000Z",
+          "type": "trade"
+        }
+      ]
+    }
+  ]
+}

--- a/e2e/fixtures/data/career--highlights--same-team-seasons-owned--skip=0--take=10.json
+++ b/e2e/fixtures/data/career--highlights--same-team-seasons-owned--skip=0--take=10.json
@@ -1,5 +1,6 @@
 {
   "type": "same-team-seasons-owned",
+  "minAllowed": 10,
   "skip": 0,
   "take": 10,
   "total": 11,

--- a/e2e/fixtures/data/career--highlights--same-team-seasons-owned--skip=10--take=10.json
+++ b/e2e/fixtures/data/career--highlights--same-team-seasons-owned--skip=10--take=10.json
@@ -1,5 +1,6 @@
 {
   "type": "same-team-seasons-owned",
+  "minAllowed": 10,
   "skip": 10,
   "take": 10,
   "total": 11,

--- a/e2e/fixtures/data/career--highlights--same-team-seasons-played--skip=0--take=10.json
+++ b/e2e/fixtures/data/career--highlights--same-team-seasons-played--skip=0--take=10.json
@@ -1,5 +1,6 @@
 {
   "type": "same-team-seasons-played",
+  "minAllowed": 8,
   "skip": 0,
   "take": 10,
   "total": 11,

--- a/e2e/fixtures/data/career--highlights--same-team-seasons-played--skip=10--take=10.json
+++ b/e2e/fixtures/data/career--highlights--same-team-seasons-played--skip=10--take=10.json
@@ -1,5 +1,6 @@
 {
   "type": "same-team-seasons-played",
+  "minAllowed": 8,
   "skip": 10,
   "take": 10,
   "total": 11,

--- a/e2e/fixtures/data/career--highlights--stash-king--skip=0--take=10.json
+++ b/e2e/fixtures/data/career--highlights--stash-king--skip=0--take=10.json
@@ -1,5 +1,6 @@
 {
   "type": "stash-king",
+  "minAllowed": 10,
   "skip": 0,
   "take": 10,
   "total": 2,

--- a/e2e/specs/career.spec.ts
+++ b/e2e/specs/career.spec.ts
@@ -95,7 +95,7 @@ test.describe('Career listings', () => {
     await expect(transactionsSection).toHaveAttribute('aria-checked', 'true');
 
     const highlightCards = page.locator('app-table-card');
-    await expect(highlightCards).toHaveCount(3);
+    await expect(highlightCards).toHaveCount(4);
     await expect(
       page.getByRole('heading', { name: CAREER_HIGHLIGHT_CARD_LABELS.MOST_TRADES })
     ).toBeVisible();
@@ -105,11 +105,16 @@ test.describe('Career listings', () => {
     await expect(
       page.getByRole('heading', { name: CAREER_HIGHLIGHT_CARD_LABELS.MOST_DROPS })
     ).toBeVisible();
+    await expect(
+      page.getByRole('heading', { name: CAREER_HIGHLIGHT_CARD_LABELS.REUNION_KING })
+    ).toBeVisible();
 
     await expect(highlightCards.first().getByRole('table')).toBeVisible();
     await highlightCards.nth(1).scrollIntoViewIfNeeded();
     await expect(highlightCards.nth(1).getByRole('table')).toBeVisible();
     await highlightCards.nth(2).scrollIntoViewIfNeeded();
     await expect(highlightCards.nth(2).getByRole('table')).toBeVisible();
+    await highlightCards.nth(3).scrollIntoViewIfNeeded();
+    await expect(highlightCards.nth(3).getByRole('table')).toBeVisible();
   });
 });

--- a/public/i18n/fi.json
+++ b/public/i18n/fi.json
@@ -36,23 +36,23 @@
       "cards": {
         "mostTeamsPlayed": {
           "title": "Eniten seuroja - pelanneet",
-          "description": "Väh. 4 eri seurassa pelanneet."
+          "description": "Väh. {{minAllowed}} eri seurassa pelanneet."
         },
         "mostTeamsOwned": {
           "title": "Eniten edustusseuroja",
-          "description": "Väh. 5 eri seurassa käyneet."
+          "description": "Väh. {{minAllowed}} eri seurassa käyneet."
         },
         "sameTeamSeasonsPlayed": {
           "title": "Eniten pelikausia - sama seura",
-          "description": "Väh. 8 kautta samassa seurassa pelanneet."
+          "description": "Väh. {{minAllowed}} kautta samassa seurassa pelanneet."
         },
         "sameTeamSeasonsOwned": {
           "title": "Eniten edustuskausia - sama seura",
-          "description": "Väh. 10 kautta samassa seurassa käyneet."
+          "description": "Väh. {{minAllowed}} kautta samassa seurassa käyneet."
         },
         "mostStanleyCups": {
           "title": "Eniten Stanley Cup -sormuksia",
-          "description": "Väh. 2 mestaruutta FFHL-uran aikana."
+          "description": "Väh. {{minAllowed}} mestaruutta FFHL-uran aikana."
         },
         "regularGrinderWithoutPlayoffs": {
           "title": "Runkosarjajyrät",
@@ -60,20 +60,28 @@
         },
         "stashKing": {
           "title": "Eniten farmikausia - sama seura",
-          "description": "Väh. 10 kautta joukkueessa pelaamatta."
+          "description": "Väh. {{minAllowed}} kautta joukkueessa pelaamatta."
+        },
+        "reunionKing": {
+          "title": "Kovimmat paluumuuttajat",
+          "description": "Väh. {{minAllowed}} comebackia samaan seuraan."
         },
         "mostTrades": {
           "title": "Eniten kaupatut",
-          "description": "Väh. 4 kaupassa mukana."
+          "description": "Väh. {{minAllowed}} kaupassa mukana."
         },
         "mostClaims": {
           "title": "Eniten nostetut",
-          "description": "Väh. 3 nostoa."
+          "description": "Väh. {{minAllowed}} nostoa."
         },
         "mostDrops": {
           "title": "Eniten pudotetut",
-          "description": "Väh. 3 pudotusta."
+          "description": "Väh. {{minAllowed}} pudotusta."
         }
+      },
+      "reunionTypes": {
+        "trade": "kaupalla",
+        "claim": "vapaista"
       }
     }
   },

--- a/src/app/app.component.mobile.spec.ts
+++ b/src/app/app.component.mobile.spec.ts
@@ -314,6 +314,9 @@ describe('AppComponent — mobile frontpage', { timeout: 60_000 }, () => {
       screen.getByRole('heading', { name: 'career.highlights.cards.mostDrops.title' })
     ).toBeInTheDocument();
     expect(
+      screen.getByRole('heading', { name: 'career.highlights.cards.reunionKing.title' })
+    ).toBeInTheDocument();
+    expect(
       screen.queryByRole('heading', { name: 'career.highlights.cards.mostTeamsPlayed.title' })
     ).not.toBeInTheDocument();
 

--- a/src/app/career/highlights/career-highlights.component.html
+++ b/src/app/career/highlights/career-highlights.component.html
@@ -33,6 +33,8 @@
         (appActivateOnViewportVisible)="activateCard(card.type)"
         [titleKey]="card.state.titleKey"
         [descriptionKey]="card.state.descriptionKey"
+        [descriptionRequiresParams]="card.state.descriptionRequiresParams"
+        [descriptionParams]="card.state.descriptionParams"
         primaryColumnLabelKey="career.highlights.columns.player"
         [valueColumnLabelKey]="card.state.valueColumnLabelKey"
         [deferred]="!card.state.activated"

--- a/src/app/career/highlights/career-highlights.component.spec.ts
+++ b/src/app/career/highlights/career-highlights.component.spec.ts
@@ -14,6 +14,7 @@ import {
   mostTeamsPlayedHighlightsPage1Fixture,
   provideDisabledMaterialAnimations,
   regularGrinderWithoutPlayoffsHighlightsPage0Fixture,
+  reunionKingHighlightsPage0Fixture,
   stashKingHighlightsPage0Fixture,
   sameTeamSeasonsOwnedHighlightsPage0Fixture,
   sameTeamSeasonsHighlightsPage0Fixture,
@@ -109,7 +110,7 @@ describe('CareerHighlightsComponent', () => {
           case 'most-drops':
             return of(mostDropsHighlightsPage0Fixture);
           case 'reunion-king':
-            throw new Error('reunion-king should not be requested by the UI');
+            return of(reunionKingHighlightsPage0Fixture);
         }
       }
     );
@@ -210,7 +211,7 @@ describe('CareerHighlightsComponent', () => {
     expect(getCareerHighlights).toHaveBeenCalledWith('most-teams-played', 10, 10);
   });
 
-  it('switches to transactions and preserves per-team tooltip lines in API order', async () => {
+  it('switches to transactions, keeps reunion-king last, and preserves tooltip content order', async () => {
     const getCareerHighlights = vi.fn((type: CareerHighlightType) => {
       switch (type) {
         case 'most-teams-played':
@@ -234,7 +235,7 @@ describe('CareerHighlightsComponent', () => {
         case 'most-drops':
           return of(mostDropsHighlightsPage0Fixture);
         case 'reunion-king':
-          throw new Error('reunion-king should not be requested by the UI');
+          return of(reunionKingHighlightsPage0Fixture);
       }
     });
 
@@ -282,10 +283,25 @@ describe('CareerHighlightsComponent', () => {
         name: 'career.highlights.cards.mostDrops.title',
       }),
     ).toBeInTheDocument();
-    expect(screen.getAllByText('tableCard.loadWhenVisible')).toHaveLength(3);
+    expect(
+      screen.getByRole('heading', {
+        name: 'career.highlights.cards.reunionKing.title',
+      }),
+    ).toBeInTheDocument();
+    expect(screen.getAllByText('tableCard.loadWhenVisible')).toHaveLength(4);
+    expect(
+      screen.getAllByRole('heading', { level: 3 }).map((heading) => heading.textContent?.trim()),
+    ).toEqual([
+      'career.highlights.sectionTitle',
+      'career.highlights.cards.mostTrades.title',
+      'career.highlights.cards.mostClaims.title',
+      'career.highlights.cards.mostDrops.title',
+      'career.highlights.cards.reunionKing.title',
+    ]);
 
-    const transactionObservers = FakeIntersectionObserver.instances.slice(-3);
+    const transactionObservers = FakeIntersectionObserver.instances.slice(-4);
     transactionObservers[0]?.trigger();
+    transactionObservers[3]?.trigger();
 
     const tradesCardTitle = screen.getByRole('heading', {
       name: 'career.highlights.cards.mostTrades.title',
@@ -306,6 +322,23 @@ describe('CareerHighlightsComponent', () => {
       'Dallas Stars 2',
       'Carolina Hurricanes 1',
     ]);
+
+    const reunionState = view.fixture.componentInstance
+      .cards()
+      .find((card) => card.type === 'reunion-king')?.state;
+
+    expect(getCareerHighlights).toHaveBeenCalledWith('reunion-king', 0, 10);
+    expect(reunionState?.descriptionParams).toEqual({ minAllowed: 2 });
+    expect(reunionState?.rows[0]).toMatchObject({
+      primaryText: 'F Mikael Granlund',
+      value: 2,
+      detailHeader: 'Colorado Avalanche',
+      detailLines: [
+        '1. 18.12.2013 career.highlights.reunionTypes.trade',
+        '2. 10.8.2016 career.highlights.reunionTypes.claim',
+      ],
+      detailTooltipClass: 'table-card-tooltip--with-header',
+    });
   });
 
   it('shows an error state for an activated failing card without forcing untouched cards to load', async () => {
@@ -331,10 +364,12 @@ describe('CareerHighlightsComponent', () => {
                           ? stashKingHighlightsPage0Fixture
                           : type === 'most-trades'
                             ? mostTradesHighlightsPage0Fixture
-                            : type === 'most-claims'
+                          : type === 'most-claims'
                               ? mostClaimsHighlightsPage0Fixture
                               : type === 'most-drops'
                                 ? mostDropsHighlightsPage0Fixture
+                                : type === 'reunion-king'
+                                  ? reunionKingHighlightsPage0Fixture
                     : type === 'same-team-seasons-played'
                       ? sameTeamSeasonsHighlightsPage0Fixture
                       : mostTeamsPlayedHighlightsPage0Fixture

--- a/src/app/career/highlights/career-highlights.component.ts
+++ b/src/app/career/highlights/career-highlights.component.ts
@@ -13,12 +13,13 @@ import {
   MatButtonToggleChange,
   MatButtonToggleModule,
 } from '@angular/material/button-toggle';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateModule, TranslateService } from '@ngx-translate/core';
 
 import {
   ApiService,
   CareerHighlightPage,
   CareerRegularGrinderHighlightPage,
+  CareerReunionHighlightPage,
   CareerSameTeamHighlightPage,
   CareerStashHighlightPage,
   CareerStanleyCupHighlightPage,
@@ -31,18 +32,23 @@ import { TableCardRow } from '@shared/table-card/table-card.types';
 import { formatPlayoffYear } from '@shared/utils/season.utils';
 
 import { ActivateOnViewportDirective } from './activate-on-viewport.directive';
+import { formatReunionDetailLines } from './career-highlights.utils';
 import {
   CareerHighlightCardState,
   CareerHighlightCardView,
   CareerHighlightSection,
   CareerHighlightsUiType,
+  HighlightDescriptionParams,
 } from './career-highlights.types';
 
 const PAGE_SIZE = 10;
 
 type HighlightCardConfig = Pick<
   CareerHighlightCardState,
-  'titleKey' | 'descriptionKey' | 'valueColumnLabelKey'
+  | 'titleKey'
+  | 'descriptionKey'
+  | 'descriptionRequiresParams'
+  | 'valueColumnLabelKey'
 > & {
   readonly section: CareerHighlightSection;
   readonly type: CareerHighlightsUiType;
@@ -53,6 +59,7 @@ const MOST_TEAMS_PLAYED_CONFIG: HighlightCardConfig = {
   type: 'most-teams-played',
   titleKey: 'career.highlights.cards.mostTeamsPlayed.title',
   descriptionKey: 'career.highlights.cards.mostTeamsPlayed.description',
+  descriptionRequiresParams: true,
   valueColumnLabelKey: 'career.highlights.columns.teamCount',
 };
 
@@ -61,6 +68,7 @@ const SAME_TEAM_SEASONS_PLAYED_CONFIG: HighlightCardConfig = {
   type: 'same-team-seasons-played',
   titleKey: 'career.highlights.cards.sameTeamSeasonsPlayed.title',
   descriptionKey: 'career.highlights.cards.sameTeamSeasonsPlayed.description',
+  descriptionRequiresParams: true,
   valueColumnLabelKey: 'career.highlights.columns.seasonCount',
 };
 
@@ -69,6 +77,7 @@ const MOST_TEAMS_OWNED_CONFIG: HighlightCardConfig = {
   type: 'most-teams-owned',
   titleKey: 'career.highlights.cards.mostTeamsOwned.title',
   descriptionKey: 'career.highlights.cards.mostTeamsOwned.description',
+  descriptionRequiresParams: true,
   valueColumnLabelKey: 'career.highlights.columns.teamCount',
 };
 
@@ -77,6 +86,7 @@ const MOST_STANLEY_CUPS_CONFIG: HighlightCardConfig = {
   type: 'most-stanley-cups',
   titleKey: 'career.highlights.cards.mostStanleyCups.title',
   descriptionKey: 'career.highlights.cards.mostStanleyCups.description',
+  descriptionRequiresParams: true,
   valueColumnLabelKey: '💍',
 };
 
@@ -86,6 +96,7 @@ const REGULAR_GRINDER_WITHOUT_PLAYOFFS_CONFIG: HighlightCardConfig = {
   titleKey: 'career.highlights.cards.regularGrinderWithoutPlayoffs.title',
   descriptionKey:
     'career.highlights.cards.regularGrinderWithoutPlayoffs.description',
+  descriptionRequiresParams: false,
   valueColumnLabelKey: 'career.highlights.columns.games',
 };
 
@@ -94,7 +105,17 @@ const SAME_TEAM_SEASONS_OWNED_CONFIG: HighlightCardConfig = {
   type: 'same-team-seasons-owned',
   titleKey: 'career.highlights.cards.sameTeamSeasonsOwned.title',
   descriptionKey: 'career.highlights.cards.sameTeamSeasonsOwned.description',
+  descriptionRequiresParams: true,
   valueColumnLabelKey: 'career.highlights.columns.seasonCount',
+};
+
+const REUNION_KING_CONFIG: HighlightCardConfig = {
+  section: 'transactions',
+  type: 'reunion-king',
+  titleKey: 'career.highlights.cards.reunionKing.title',
+  descriptionKey: 'career.highlights.cards.reunionKing.description',
+  descriptionRequiresParams: true,
+  valueColumnLabelKey: '♻️',
 };
 
 const STASH_KING_CONFIG: HighlightCardConfig = {
@@ -102,6 +123,7 @@ const STASH_KING_CONFIG: HighlightCardConfig = {
   type: 'stash-king',
   titleKey: 'career.highlights.cards.stashKing.title',
   descriptionKey: 'career.highlights.cards.stashKing.description',
+  descriptionRequiresParams: true,
   valueColumnLabelKey: 'career.highlights.columns.seasonCount',
 };
 
@@ -110,6 +132,7 @@ const MOST_TRADES_CONFIG: HighlightCardConfig = {
   type: 'most-trades',
   titleKey: 'career.highlights.cards.mostTrades.title',
   descriptionKey: 'career.highlights.cards.mostTrades.description',
+  descriptionRequiresParams: true,
   valueColumnLabelKey: '🤝',
 };
 
@@ -118,6 +141,7 @@ const MOST_CLAIMS_CONFIG: HighlightCardConfig = {
   type: 'most-claims',
   titleKey: 'career.highlights.cards.mostClaims.title',
   descriptionKey: 'career.highlights.cards.mostClaims.description',
+  descriptionRequiresParams: true,
   valueColumnLabelKey: '✅',
 };
 
@@ -126,6 +150,7 @@ const MOST_DROPS_CONFIG: HighlightCardConfig = {
   type: 'most-drops',
   titleKey: 'career.highlights.cards.mostDrops.title',
   descriptionKey: 'career.highlights.cards.mostDrops.description',
+  descriptionRequiresParams: true,
   valueColumnLabelKey: '❌',
 };
 
@@ -140,6 +165,7 @@ const HIGHLIGHT_CARD_CONFIGS: readonly HighlightCardConfig[] = [
   MOST_TRADES_CONFIG,
   MOST_CLAIMS_CONFIG,
   MOST_DROPS_CONFIG,
+  REUNION_KING_CONFIG,
 ];
 
 function createInitialCardState(
@@ -148,6 +174,7 @@ function createInitialCardState(
   return {
     titleKey: config.titleKey,
     descriptionKey: config.descriptionKey,
+    descriptionRequiresParams: config.descriptionRequiresParams,
     valueColumnLabelKey: config.valueColumnLabelKey,
     activated: false,
     rows: [],
@@ -175,6 +202,7 @@ export class CareerHighlightsComponent implements OnInit {
   private readonly apiService = inject(ApiService);
   private readonly destroyRef = inject(DestroyRef);
   private readonly footerVisibilityService = inject(FooterVisibilityService);
+  private readonly translate = inject(TranslateService);
 
   readonly selectedSection = signal<CareerHighlightSection>('general');
 
@@ -198,6 +226,7 @@ export class CareerHighlightsComponent implements OnInit {
       'same-team-seasons-owned': signal(
         createInitialCardState(SAME_TEAM_SEASONS_OWNED_CONFIG),
       ),
+      'reunion-king': signal(createInitialCardState(REUNION_KING_CONFIG)),
       'stash-king': signal(createInitialCardState(STASH_KING_CONFIG)),
       'most-trades': signal(createInitialCardState(MOST_TRADES_CONFIG)),
       'most-claims': signal(createInitialCardState(MOST_CLAIMS_CONFIG)),
@@ -287,6 +316,7 @@ export class CareerHighlightsComponent implements OnInit {
           cardSignal.update((current) => ({
             ...current,
             rows: this.normalizeRows(page),
+            descriptionParams: this.descriptionParamsFor(page),
             loading: false,
             apiError: false,
             skip: page.skip,
@@ -339,6 +369,25 @@ export class CareerHighlightsComponent implements OnInit {
       }));
     }
 
+    if (this.isReunionPage(page)) {
+      return page.items.map((item) => ({
+        key: `${item.id}:${item.team.id}`,
+        primaryText: `${item.position} ${item.name}`,
+        value: item.reunionCount,
+        detailHeader: item.team.name,
+        detailLines: formatReunionDetailLines(
+          item.reunions,
+          {
+            claim: this.translate.instant('career.highlights.reunionTypes.claim'),
+            trade: this.translate.instant('career.highlights.reunionTypes.trade'),
+          },
+          this.translate.currentLang || this.translate.getFallbackLang() || 'fi',
+        ),
+        detailLabel: item.name,
+        detailTooltipClass: 'table-card-tooltip--with-header',
+      }));
+    }
+
     if (this.isRegularGrinderPage(page)) {
       return page.items.map((item) => ({
         key: item.id,
@@ -372,6 +421,14 @@ export class CareerHighlightsComponent implements OnInit {
     return [];
   }
 
+  private descriptionParamsFor(
+    page: CareerHighlightPage,
+  ): HighlightDescriptionParams | undefined {
+    return this.isRegularGrinderPage(page)
+      ? undefined
+      : { minAllowed: page.minAllowed };
+  }
+
   private isTeamCountPage(
     page: CareerHighlightPage,
   ): page is CareerTeamCountHighlightPage {
@@ -393,6 +450,12 @@ export class CareerHighlightsComponent implements OnInit {
     page: CareerHighlightPage,
   ): page is CareerStanleyCupHighlightPage {
     return page.type === 'most-stanley-cups';
+  }
+
+  private isReunionPage(
+    page: CareerHighlightPage,
+  ): page is CareerReunionHighlightPage {
+    return page.type === 'reunion-king';
   }
 
   private isRegularGrinderPage(

--- a/src/app/career/highlights/career-highlights.types.ts
+++ b/src/app/career/highlights/career-highlights.types.ts
@@ -1,12 +1,15 @@
 import { CareerHighlightType } from '@services/api.service';
 import { TableCardRow } from '@shared/table-card/table-card.types';
 
-export type CareerHighlightsUiType = Exclude<CareerHighlightType, 'reunion-king'>;
+export type CareerHighlightsUiType = CareerHighlightType;
 export type CareerHighlightSection = 'general' | 'transactions';
+export type HighlightDescriptionParams = Readonly<Record<string, number | string>>;
 
 export interface CareerHighlightCardState {
   readonly titleKey: string;
   readonly descriptionKey: string;
+  readonly descriptionRequiresParams: boolean;
+  readonly descriptionParams?: HighlightDescriptionParams;
   readonly valueColumnLabelKey: string;
   readonly activated: boolean;
   readonly rows: readonly TableCardRow[];

--- a/src/app/career/highlights/career-highlights.utils.ts
+++ b/src/app/career/highlights/career-highlights.utils.ts
@@ -1,0 +1,19 @@
+import { CareerReunionHighlightItem } from '@services/api.service';
+import { formatDateForLocale } from '@shared/utils/date.utils';
+
+type ReunionType = CareerReunionHighlightItem['reunions'][number]['type'];
+
+export type ReunionTypeLabels = Readonly<Record<ReunionType, string>>;
+
+export function formatReunionDetailLines(
+  reunions: ReadonlyArray<CareerReunionHighlightItem['reunions'][number]>,
+  reunionTypeLabels: ReunionTypeLabels,
+  locale: string,
+): string[] {
+  return reunions.map(
+    (reunion, index) => {
+      const formattedDate = formatDateForLocale(reunion.date, locale) ?? reunion.date;
+      return `${index + 1}. ${formattedDate} ${reunionTypeLabels[reunion.type]}`;
+    },
+  );
+}

--- a/src/app/services/api.service.ts
+++ b/src/app/services/api.service.ts
@@ -24,6 +24,7 @@ export type CareerHighlightTeam     = components['schemas']['CareerHighlightTeam
 export type CareerTeamCountHighlightItem = components['schemas']['CareerTeamCountHighlightItem'];
 export type CareerSameTeamHighlightItem = components['schemas']['CareerSameTeamHighlightItem'];
 export type CareerStanleyCupHighlightItem = components['schemas']['CareerStanleyCupHighlightItem'];
+export type CareerReunionHighlightItem = components['schemas']['CareerReunionHighlightItem'];
 export type CareerStashHighlightItem = components['schemas']['CareerStashHighlightItem'];
 export type CareerRegularGrinderHighlightItem =
   components['schemas']['CareerRegularGrinderHighlightItem'];
@@ -32,6 +33,7 @@ export type CareerTransactionHighlightItem =
 export type CareerTeamCountHighlightPage = components['schemas']['CareerTeamCountHighlightPage'];
 export type CareerSameTeamHighlightPage = components['schemas']['CareerSameTeamHighlightPage'];
 export type CareerStanleyCupHighlightPage = components['schemas']['CareerStanleyCupHighlightPage'];
+export type CareerReunionHighlightPage = components['schemas']['CareerReunionHighlightPage'];
 export type CareerStashHighlightPage = components['schemas']['CareerStashHighlightPage'];
 export type CareerRegularGrinderHighlightPage =
   components['schemas']['CareerRegularGrinderHighlightPage'];
@@ -41,6 +43,7 @@ export type CareerHighlightPage =
   | CareerTeamCountHighlightPage
   | CareerSameTeamHighlightPage
   | CareerStanleyCupHighlightPage
+  | CareerReunionHighlightPage
   | CareerStashHighlightPage
   | CareerRegularGrinderHighlightPage
   | CareerTransactionHighlightPage;

--- a/src/app/services/api.types.generated.ts
+++ b/src/app/services/api.types.generated.ts
@@ -1011,11 +1011,13 @@ export interface paths {
         /**
          * Career highlights leaderboard
          * @description Returns a paged mixed skater + goalie career highlights leaderboard.
+         *     Each page includes `minAllowed`, the active backend threshold for that highlight type.
          *     `most-teams-played` and `most-teams-owned` return team-count rows.
          *     `same-team-seasons-played` and `same-team-seasons-owned` return one row per top team, so the same person can appear multiple times on tied same-team results.
          *     `most-stanley-cups` returns one row per player/goalie with cup seasons and fantasy teams.
          *     `reunion-king` returns one row per top reunion team, so the same person can appear multiple
-         *     times on tied reunion results, and includes stint ranges for each return.
+         *     times on tied reunion results, and includes reunion transactions with ISO dates plus whether
+         *     the player returned by claim or trade.
          *     `stash-king` returns the top same-team zero-game season counts, similar to
          *     `same-team-seasons-owned` but counting only team seasons where both regular and playoff
          *     games stayed at zero.
@@ -1026,7 +1028,7 @@ export interface paths {
          *     traded the player away.
          *     Minimum cutoffs are 4 teams for `most-teams-played`, 5 teams for `most-teams-owned`,
          *     8 same-team seasons for `same-team-seasons-played`, 10 same-team seasons for
-         *     `same-team-seasons-owned`, 2 cups for `most-stanley-cups`, 2 reunion stints for
+         *     `same-team-seasons-owned`, 2 cups for `most-stanley-cups`, 2 reunions for
          *     `reunion-king`, 10 stash counts for `stash-king`, 60 games for
          *     `regular-grinder-without-playoffs`, 4 trades for `most-trades`, and 3 claims/drops for
          *     `most-claims` / `most-drops`.
@@ -1407,11 +1409,12 @@ export interface components {
             position: string;
             reunionCount: number;
             team: components["schemas"]["CareerHighlightTeam"];
-            stints: components["schemas"]["CareerReunionHighlightStint"][];
+            reunions: components["schemas"]["CareerReunionHighlightReunion"][];
         };
-        CareerReunionHighlightStint: {
-            fromSeason: number;
-            toSeason: number;
+        CareerReunionHighlightReunion: {
+            date: string;
+            /** @enum {string} */
+            type: "claim" | "trade";
         };
         CareerStashHighlightItem: {
             id: string;
@@ -1442,6 +1445,7 @@ export interface components {
         CareerTeamCountHighlightPage: {
             /** @enum {string} */
             type: "most-teams-played" | "most-teams-owned";
+            minAllowed: number;
             skip: number;
             take: number;
             total: number;
@@ -1450,6 +1454,7 @@ export interface components {
         CareerSameTeamHighlightPage: {
             /** @enum {string} */
             type: "same-team-seasons-played" | "same-team-seasons-owned";
+            minAllowed: number;
             skip: number;
             take: number;
             total: number;
@@ -1458,6 +1463,7 @@ export interface components {
         CareerStanleyCupHighlightPage: {
             /** @enum {string} */
             type: "most-stanley-cups";
+            minAllowed: number;
             skip: number;
             take: number;
             total: number;
@@ -1466,6 +1472,7 @@ export interface components {
         CareerReunionHighlightPage: {
             /** @enum {string} */
             type: "reunion-king";
+            minAllowed: number;
             skip: number;
             take: number;
             total: number;
@@ -1474,6 +1481,7 @@ export interface components {
         CareerStashHighlightPage: {
             /** @enum {string} */
             type: "stash-king";
+            minAllowed: number;
             skip: number;
             take: number;
             total: number;
@@ -1482,6 +1490,7 @@ export interface components {
         CareerRegularGrinderHighlightPage: {
             /** @enum {string} */
             type: "regular-grinder-without-playoffs";
+            minAllowed: number;
             skip: number;
             take: number;
             total: number;
@@ -1490,6 +1499,7 @@ export interface components {
         CareerTransactionHighlightPage: {
             /** @enum {string} */
             type: "most-trades" | "most-claims" | "most-drops";
+            minAllowed: number;
             skip: number;
             take: number;
             total: number;

--- a/src/app/shared/table-card/table-card.component.html
+++ b/src/app/shared/table-card/table-card.component.html
@@ -3,9 +3,11 @@
     <h3 mat-card-title>
       {{ titleKey() | translate }}
     </h3>
+    @if (!descriptionRequiresParams() || descriptionParams()) {
     <p mat-card-subtitle>
-      {{ descriptionKey() | translate }}
+      {{ descriptionKey() | translate : descriptionParams() }}
     </p>
+    }
   </mat-card-header>
 
   @if (loading() && !hasRows() && !deferred()) {
@@ -66,7 +68,7 @@
             </td>
             <td class="info-column">
               <button mat-icon-button type="button" [matTooltip]="getDetailsTooltip(row)"
-                matTooltipClass="table-card-tooltip"
+                [matTooltipClass]="getDetailsTooltipClass(row)"
                 [attr.aria-label]="'tableCard.showDetails' | translate : { label: row.detailLabel }">
                 <mat-icon>info_outline</mat-icon>
               </button>

--- a/src/app/shared/table-card/table-card.component.spec.ts
+++ b/src/app/shared/table-card/table-card.component.spec.ts
@@ -15,6 +15,8 @@ import { TableCardRow } from './table-card.types';
     <app-table-card
       [titleKey]="titleKey"
       [descriptionKey]="descriptionKey"
+      [descriptionRequiresParams]="descriptionRequiresParams"
+      [descriptionParams]="descriptionParams"
       [primaryColumnLabelKey]="primaryColumnLabelKey"
       [valueColumnLabelKey]="valueColumnLabelKey"
       [deferred]="deferred"
@@ -30,6 +32,8 @@ import { TableCardRow } from './table-card.types';
 class TableCardHostComponent {
   titleKey = 'career.highlights.cards.mostTeamsPlayed.title';
   descriptionKey = 'career.highlights.cards.mostTeamsPlayed.description';
+  descriptionRequiresParams = false;
+  descriptionParams: Readonly<Record<string, number | string>> | undefined = undefined;
   primaryColumnLabelKey = 'career.highlights.columns.player';
   valueColumnLabelKey = 'career.highlights.columns.teamCount';
   deferred = false;
@@ -100,5 +104,22 @@ describe('TableCardComponent', () => {
     });
 
     expect(await screen.findByText('💍')).toBeInTheDocument();
+  });
+
+  it('hides a dynamic description until translation params are available', async () => {
+    const view = await setup({
+      descriptionRequiresParams: true,
+    });
+
+    expect(
+      screen.queryByText('career.highlights.cards.mostTeamsPlayed.description'),
+    ).not.toBeInTheDocument();
+
+    view.fixture.componentInstance.descriptionParams = { minAllowed: 4 };
+    view.fixture.detectChanges();
+
+    expect(
+      screen.getByText('career.highlights.cards.mostTeamsPlayed.description'),
+    ).toBeInTheDocument();
   });
 });

--- a/src/app/shared/table-card/table-card.component.ts
+++ b/src/app/shared/table-card/table-card.component.ts
@@ -25,6 +25,8 @@ import { TableCardRow } from './table-card.types';
 export class TableCardComponent {
   readonly titleKey = input.required<string>();
   readonly descriptionKey = input.required<string>();
+  readonly descriptionRequiresParams = input(false);
+  readonly descriptionParams = input<Readonly<Record<string, number | string>> | undefined>();
   readonly primaryColumnLabelKey = input.required<string>();
   readonly valueColumnLabelKey = input.required<string>();
   readonly deferred = input(false);
@@ -45,6 +47,16 @@ export class TableCardComponent {
   readonly pageEnd = computed(() => (this.hasRows() ? this.skip() + this.rows().length : 0));
 
   getDetailsTooltip(row: TableCardRow): string {
-    return row.detailLines.join('\n');
+    if (!row.detailHeader) {
+      return row.detailLines.join('\n');
+    }
+
+    return [row.detailHeader, ...row.detailLines].join('\n');
+  }
+
+  getDetailsTooltipClass(row: TableCardRow): string[] {
+    return ['table-card-tooltip', row.detailTooltipClass].filter(
+      (className): className is string => Boolean(className),
+    );
   }
 }

--- a/src/app/shared/table-card/table-card.types.ts
+++ b/src/app/shared/table-card/table-card.types.ts
@@ -2,6 +2,8 @@ export interface TableCardRow {
   readonly key: string;
   readonly primaryText: string;
   readonly value: number | string;
+  readonly detailHeader?: string;
   readonly detailLines: readonly string[];
   readonly detailLabel: string;
+  readonly detailTooltipClass?: string;
 }

--- a/src/app/shared/utils/date.utils.ts
+++ b/src/app/shared/utils/date.utils.ts
@@ -1,0 +1,28 @@
+const dateFormatterCache = new Map<string, Intl.DateTimeFormat>();
+
+export function formatDateForLocale(
+  value: string | number | Date,
+  locale: string,
+  options: Intl.DateTimeFormatOptions = {
+    day: 'numeric',
+    month: 'numeric',
+    year: 'numeric',
+    timeZone: 'UTC',
+  },
+): string | null {
+  const date = value instanceof Date ? value : new Date(value);
+
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+
+  const formatterKey = `${locale}:${JSON.stringify(options)}`;
+  let formatter = dateFormatterCache.get(formatterKey);
+
+  if (!formatter) {
+    formatter = new Intl.DateTimeFormat(locale, options);
+    dateFormatterCache.set(formatterKey, formatter);
+  }
+
+  return formatter.format(date);
+}

--- a/src/app/testing/behavior-test-utils.ts
+++ b/src/app/testing/behavior-test-utils.ts
@@ -44,6 +44,7 @@ import sameTeamSeasonsOwnedHighlightsPage1FixtureData from '../../../e2e/fixture
 import mostTradesHighlightsPage0FixtureData from '../../../e2e/fixtures/data/career--highlights--most-trades--skip=0--take=10.json';
 import mostClaimsHighlightsPage0FixtureData from '../../../e2e/fixtures/data/career--highlights--most-claims--skip=0--take=10.json';
 import mostDropsHighlightsPage0FixtureData from '../../../e2e/fixtures/data/career--highlights--most-drops--skip=0--take=10.json';
+import reunionKingHighlightsPage0FixtureData from '../../../e2e/fixtures/data/career--highlights--reunion-king--skip=0--take=10.json';
 import leaderboardTransactionsFixtureData from '../../../e2e/fixtures/data/leaderboard--transactions.json';
 
 export const PLAYER_SLICE_COUNT = 12;
@@ -76,10 +77,13 @@ export const mostClaimsHighlightsPage0Fixture =
   mostClaimsHighlightsPage0FixtureData as CareerHighlightPage;
 export const mostDropsHighlightsPage0Fixture =
   mostDropsHighlightsPage0FixtureData as CareerHighlightPage;
+export const reunionKingHighlightsPage0Fixture =
+  reunionKingHighlightsPage0FixtureData as CareerHighlightPage;
 export const leaderboardTransactionsFixture =
   leaderboardTransactionsFixtureData as TransactionLeaderboardEntry[];
 export const mostStanleyCupsHighlightsPage0Fixture = {
   type: 'most-stanley-cups',
+  minAllowed: 2,
   skip: 0,
   take: 10,
   total: 2,
@@ -124,6 +128,7 @@ export const mostStanleyCupsHighlightsPage0Fixture = {
 } as CareerHighlightPage;
 export const regularGrinderWithoutPlayoffsHighlightsPage0Fixture = {
   type: 'regular-grinder-without-playoffs',
+  minAllowed: 60,
   skip: 0,
   take: 10,
   total: 2,
@@ -149,6 +154,7 @@ export const regularGrinderWithoutPlayoffsHighlightsPage0Fixture = {
 } as CareerHighlightPage;
 export const stashKingHighlightsPage0Fixture = {
   type: 'stash-king',
+  minAllowed: 10,
   skip: 0,
   take: 10,
   total: 2,
@@ -203,6 +209,7 @@ export type BehaviorApiMockOptions = {
   careerHighlightsMostTrades?: CareerHighlightPage;
   careerHighlightsMostClaims?: CareerHighlightPage;
   careerHighlightsMostDrops?: CareerHighlightPage;
+  careerHighlightsReunionKing?: CareerHighlightPage;
   leaderboardRegular?: RegularLeaderboardEntry[];
   leaderboardPlayoffs?: PlayoffLeaderboardEntry[];
   leaderboardTransactions?: TransactionLeaderboardEntry[];
@@ -269,7 +276,7 @@ function getDefaultCareerHighlightsFixture(
     case 'most-drops':
       return options.careerHighlightsMostDrops ?? mostDropsHighlightsPage0Fixture;
     case 'reunion-king':
-      throw new Error('Behavior test mock for reunion-king is not configured.');
+      return options.careerHighlightsReunionKing ?? reunionKingHighlightsPage0Fixture;
   }
 }
 

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -560,6 +560,16 @@ mat-checkbox .mdc-label {
   white-space: pre-line;
 }
 
+.table-card-tooltip--with-header .mdc-tooltip__surface {
+  line-height: 1.45;
+  text-align: left;
+}
+
+.table-card-tooltip--with-header .mdc-tooltip__surface::first-line {
+  font-weight: 700;
+  color: var(--mat-sys-on-surface);
+}
+
 // Shared stats-table and virtual-table shell styles. Keeping the DOM-targeting rules
 // here avoids repeating the same Material overrides in multiple component stylesheets.
 app-stats-table,


### PR DESCRIPTION
## Summary

- added `reunion-king` to career highlights transactions cards and placed it last in the section
- switched highlight card minimum-threshold descriptions to use backend `minAllowed` values, with `regularGrinderWithoutPlayoffs` kept as the exception
- updated reunion tooltips to show the team on the first line and numbered reunion entries below it
- moved date formatting to a shared `Intl.DateTimeFormat`-based helper and documented the project’s datetime handling expectations
- clarified repo workflow/testing guidance so behavior coverage stays the default and helper/unit specs remain exceptions
- added an explicit docs-only workflow exception so heavy `npm run verify` runs can be skipped when only docs/workflow text changes

## Testing

- `npm run verify` passed for the feature implementation batch
- final docs-only workflow clarification commit intentionally skipped `npm run verify`