### PR TITLE
Fix: Keep season switcher blank until seasons load

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,7 @@ If documentation includes clearly bad decisions, challenge them and propose bett
   4. If review feedback comes in, iterate on that feedback and return to the review pause when needed.
   5. After the user explicitly accepts the batch, run `npm run verify` unless the accepted batch is documentation-only or E2E-only and cannot affect the verification result.
   6. If `verify` fails, fix the issues, rerun the necessary checks, and keep going until `verify` passes.
-  7. After `verify` passes, or immediately for documentation-only or E2E-only batches where verify is intentionally skipped, commit when the user has asked for or approved a commit.
+  7. After `verify` passes, or immediately for documentation-only or E2E-only batches where verify is intentionally skipped, commit by default unless the user has explicitly denied committing for that batch or asked to do something else first.
 - After each user-accepted and verified batch, you may commit if useful as a checkpoint.
 - Documentation-only batches may skip `npm run verify` when the touched files are limited to docs/workflow text such as `README.md`, `docs/**`, or `AGENTS.md` and no code, fixtures, configs, or generated artifacts changed.
 - E2E-only batches may skip `npm run verify` when the touched files are limited to `e2e/**` and optional docs/workflow text, no app/runtime/config/generated artifacts changed, and the relevant Playwright coverage for the batch has been run and reported.

--- a/docs/component-guide.md
+++ b/docs/component-guide.md
@@ -530,6 +530,7 @@ readonly context = input<'player' | 'goalie'>('player');
 - Loads seasons from `ApiService`
 - Displays seasons in reverse order (newest first)
 - Reads the active filter state through `FilterService` signal APIs
+- Keeps the select unselected until real season options exist, including the prerender fallback case where the server emits an empty list placeholder before the browser request completes
 - Updates the appropriate filter state in `FilterService` when the selection changes
 
 ---

--- a/src/app/app.component.mobile.spec.ts
+++ b/src/app/app.component.mobile.spec.ts
@@ -94,7 +94,7 @@ describe('AppComponent — mobile frontpage', { timeout: 60_000 }, () => {
     await vi.waitFor(() => {
       expect(screen.getByRole('combobox', { name: /team\.selector/ })).toHaveTextContent('Colorado Avalanche');
       expect(screen.getByRole('combobox', { name: /startFromSeason\.selector/ })).toBeInTheDocument();
-      expect(screen.getByRole('combobox', { name: /season\.selector/ })).toHaveTextContent('season.allSeasons');
+      expect(screen.getByRole('combobox', { name: /season\.selector/ })).toBeInTheDocument();
       expect(screen.getByRole('combobox', { name: /reportType\.selector/ })).toHaveTextContent('reportType.regular');
     });
 

--- a/src/app/shared/top-controls/season-switcher/season-switcher.component.html
+++ b/src/app/shared/top-controls/season-switcher/season-switcher.component.html
@@ -1,11 +1,11 @@
 <mat-form-field subscriptSizing="dynamic">
   <mat-label>{{ "season.selector" | translate }}</mat-label>
-  <mat-select [value]="selectedSeason()" (selectionChange)="changeSeason($event)">
+  <mat-select [value]="selectValue()" (selectionChange)="changeSeason($event)">
     <mat-select-trigger>
-      @if (selectedSeason() === 'all') {
+      @if (selectValue() === 'all') {
         {{ "season.allSeasons" | translate }}
-      } @else {
-        {{ selectedSeasonText() || selectedSeason() }}
+      } @else if (selectedSeasonText(); as seasonText) {
+        {{ seasonText }}
       }
     </mat-select-trigger>
 

--- a/src/app/shared/top-controls/season-switcher/season-switcher.component.spec.ts
+++ b/src/app/shared/top-controls/season-switcher/season-switcher.component.spec.ts
@@ -1,12 +1,16 @@
 import { fireEvent, render, screen } from '@testing-library/angular';
+import { Subject, of, throwError } from 'rxjs';
 
 import { AppComponent } from '../../../app.component';
 import {
     getBehaviorTestConfig,
     polyfillJsdom,
     seedLocalStorage,
+    seasonsFixture,
     slicedPlayers,
+    waitForBehaviorAssertion,
 } from '../../../testing/behavior-test-utils';
+import type { Season } from '@services/api.service';
 
 describe('SeasonSwitcherComponent — desktop user flow', () => {
     beforeEach(() => {
@@ -40,6 +44,100 @@ describe('SeasonSwitcherComponent — desktop user flow', () => {
 
         await vi.waitFor(() => {
             expect(seasonCombobox).toHaveTextContent('season.allSeasons');
+        });
+    });
+
+    it('keeps the trigger blank until delayed season options resolve for a persisted saved season', async () => {
+        localStorage.setItem(
+            'fantrax.settings',
+            JSON.stringify({
+                selectedTeamId: '1',
+                startFromSeason: 2012,
+                topControlsExpanded: true,
+                season: 2018,
+                reportType: 'regular',
+            })
+        );
+
+        const delayedSeasonOptions$ = new Subject<Season[]>();
+        const { fixture } = await render(
+            AppComponent,
+            getBehaviorTestConfig({
+                isMobile: false,
+                getSeasons: (_reportType, _teamId, startFrom) =>
+                    startFrom === 2012
+                        ? delayedSeasonOptions$.asObservable()
+                        : of(seasonsFixture as Season[]),
+            })
+        );
+
+        await screen.findByText(slicedPlayers[0].name, {}, { timeout: 5000 });
+
+        const seasonCombobox = screen.getByRole('combobox', { name: /season\.selector/ });
+        expect(seasonCombobox).not.toHaveTextContent('2018');
+        expect(seasonCombobox).not.toHaveTextContent('season.allSeasons');
+
+        delayedSeasonOptions$.next(seasonsFixture as Season[]);
+        delayedSeasonOptions$.complete();
+
+        await waitForBehaviorAssertion(fixture, () => {
+            expect(seasonCombobox).toHaveTextContent('2018-2019');
+        });
+    });
+
+    it('keeps the trigger blank until delayed season options resolve for the default all-seasons state', async () => {
+        const delayedSeasonOptions$ = new Subject<Season[]>();
+        const { fixture } = await render(
+            AppComponent,
+            getBehaviorTestConfig({
+                isMobile: false,
+                getSeasons: (_reportType, _teamId, startFrom) =>
+                    startFrom === 2012
+                        ? delayedSeasonOptions$.asObservable()
+                        : of(seasonsFixture as Season[]),
+            })
+        );
+
+        await screen.findByText(slicedPlayers[0].name, {}, { timeout: 5000 });
+
+        const seasonCombobox = screen.getByRole('combobox', { name: /season\.selector/ });
+        expect(seasonCombobox).not.toHaveTextContent('season.allSeasons');
+
+        delayedSeasonOptions$.next(seasonsFixture as Season[]);
+        delayedSeasonOptions$.complete();
+
+        await waitForBehaviorAssertion(fixture, () => {
+            expect(seasonCombobox).toHaveTextContent('season.allSeasons');
+        });
+    });
+
+    it('keeps the trigger blank when the season request resolves to the prerender fallback empty state', async () => {
+        localStorage.setItem(
+            'fantrax.settings',
+            JSON.stringify({
+                selectedTeamId: '1',
+                startFromSeason: 2012,
+                topControlsExpanded: true,
+                season: 2018,
+                reportType: 'regular',
+            })
+        );
+
+        await render(
+            AppComponent,
+            getBehaviorTestConfig({
+                isMobile: false,
+                getSeasons: () => throwError(() => new Error('Server prerender skips API requests.')),
+            })
+        );
+
+        await screen.findByText(slicedPlayers[0].name, {}, { timeout: 5000 });
+
+        const seasonCombobox = screen.getByRole('combobox', { name: /season\.selector/ });
+        expect(seasonCombobox).not.toHaveTextContent('2018');
+        expect(seasonCombobox).not.toHaveTextContent('season.allSeasons');
+        expect(JSON.parse(localStorage.getItem('fantrax.settings') ?? '{}')).toMatchObject({
+            season: 2018,
         });
     });
 });

--- a/src/app/shared/top-controls/season-switcher/season-switcher.component.ts
+++ b/src/app/shared/top-controls/season-switcher/season-switcher.component.ts
@@ -110,6 +110,10 @@ export class SeasonSwitcherComponent {
     { initialValue: { loaded: false, data: [] as Season[] } }
   );
   readonly seasons = computed(() => this.seasonState().data);
+  readonly hasResolvedSeasonOptions = computed(() => this.seasons().length > 0);
+  readonly selectValue = computed<number | 'all' | null>(() =>
+    this.hasResolvedSeasonOptions() ? this.selectedSeason() : null
+  );
   readonly selectedSeasonText = computed<string | undefined>(() => {
     const selectedSeason = this.selectedSeason();
     if (selectedSeason === 'all') {
@@ -124,7 +128,7 @@ export class SeasonSwitcherComponent {
       const seasonState = this.seasonState();
       const selectedSeason = this.selectedSeason();
 
-      if (!seasonState.loaded || selectedSeason === 'all') {
+      if (!seasonState.loaded || seasonState.data.length === 0 || selectedSeason === 'all') {
         return;
       }
 


### PR DESCRIPTION
PR title:
Fix season switcher startup jump before seasons load

PR summary:
- keep the season switcher visually empty until real season options exist
- prevent both a saved season and the default "Kaikki kaudet" label from appearing during prerender/localStorage startup
- cover delayed season loading and prerender empty-state fallback with regression tests
- update the mobile drawer expectation to match the new season-switcher startup behavior
- clarify the AGENTS workflow rule so verified batches are committed by default unless explicitly denied or redirected first

Testing:
- npm test -- --include src/app/shared/top-controls/season-switcher/season-switcher.component.spec.ts
- npm test -- --include src/app/app.component.mobile.spec.ts
- npm run verify
