### PR TITLE
Docs: Switch browser automation guidance to agent-browser

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,14 +38,16 @@ For an approved multi-batch plan, treat all batches as part of the same task unt
 
 If a proposed change would alter user-visible application behavior or semantics, stop and confirm with the user before implementing it. Do not make behavior-changing production edits based only on inference from a plan or coverage goal.
 
+## Browser Automation Rules
+- For manual browser automation and visual inspection that previously used Playwright MCP, prefer the device-wide `agent-browser` CLI.
+- Typical workflow: `agent-browser open <url>`, `agent-browser wait --load networkidle`, `agent-browser snapshot -i`, interact via refs such as `@e2`, then `agent-browser close` when finished.
+- When checking theme-sensitive UI, use explicit browser media settings such as `agent-browser --color-scheme dark open <url>` or `agent-browser set media dark`.
+- Use agent-browser only when the task includes real theming or styling risk that benefits from browser inspection.
+- Do not use agent-browser for routine non-visual changes that do not meaningfully affect rendering, such as pure data wiring, copy-only tweaks, or simple column-order updates.
+- If using agent-browser during a task, close the browser after you are done with it and no longer need it. Do not leave sessions open across unrelated steps or future sessions.
+
 ## Playwright Rules
 - For local `npm run e2e` or other local Playwright test runs, prefer running outside the sandbox. In this repo the sandboxed path is not reliable for the Playwright web server / browser flow, while the non-sandbox path works consistently better.
-- For Playwright MCP browser checks, also prefer the non-sandbox path.
-- Use Playwright MCP only when the task includes real theming or styling risk that benefits from browser inspection. Treat the following as theming/styling work:
-  - direct light/dark theme changes
-  - introducing new Angular Material components that need visual verification
-  - custom layout or styling work significant enough that browser rendering should be checked
-- Do not use Playwright MCP for routine non-visual changes that do not meaningfully affect theming/styling, such as pure data wiring, copy-only tweaks, or simple column-order updates.
-- If using Playwright MCP during a task, close the browser after you are done with it and no longer need it. Do not leave Playwright browser sessions open across unrelated steps or future sessions.
+- Keep Playwright focused on automated E2E and perf-audit coverage; do not route ad hoc manual browser inspection through Playwright MCP anymore.
 
 For local Playwright E2E runs, the user controls the backend on `localhost:3000`. If it is not running, ask the user to start it instead of switching to CI-mode mocking as a workaround.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,8 +12,12 @@ If documentation includes clearly bad decisions, challenge them and propose bett
 - If currently on `main`, ask user to create a branch before implementing task changes.
 - If considering `git worktree`, always ask explicitly first and explain why worktree would help.
 - In every task, include a user review phase before final verify. After implementation, pause and hand the work to the user for review before running the final `npm run verify` or creating a commit.
-- Do not run the final verification gate and do not commit until the user has explicitly accepted the review phase for that batch. After review is accepted and verify passes, you can commit. After each user-accepted and verified batch, you may commit if useful as a checkpoint. Offer PR notes as a copy-pasteable code block only when the branch is fully implemented and ready for PR; user will handle the rest.
-- Before any commit, `npm run verify` must pass. Targeted tests are not a substitute for the full verification gate.
+- Do not run the final verification gate and do not commit until the user has explicitly accepted the review phase for that batch.
+- After review is accepted and `verify` passes, commit by default unless the user has explicitly denied committing for that batch or asked to do something else first.
+- Documentation-only batches may skip `npm run verify` when the touched files are limited to workflow/docs text such as `@README`, `@docs/**`, `AGENTS.md`, or `CLAUDE.md` and no code, fixtures, configs, or generated artifacts changed.
+- E2E-only batches may skip `npm run verify` when the touched files are limited to `e2e/**` and optional workflow/docs text, no app/runtime/config/generated artifacts changed, and the relevant Playwright coverage for the batch has been run and reported.
+- Before any commit for a non-docs-only batch, `npm run verify` must pass. Targeted tests are not a substitute for the full verification gate.
+- After a verified commit, offer PR notes as a copy-pasteable code block when the branch is fully implemented and ready for PR, unless the user explicitly says they do not want them.
 - Commit message prefixes should use capitalized conventional labels.
 - New features must use the prefix `Feature: `.
 - Non-feature commits should use a capitalized prefix such as `Fix:`, `Docs:`, `Chore:`, etc.
@@ -25,4 +29,8 @@ For an approved multi-batch plan, treat all batches as part of the same task unt
 
 If a proposed change would alter user-visible application behavior or semantics, stop and confirm with the user before implementing it. Do not make behavior-changing production edits based only on inference from a plan or coverage goal.
 
-If using Playwright MCP during a task, close the browser after you are done with it and no longer need it. Do not leave Playwright browser sessions open across unrelated steps or future sessions.
+## Browser Automation Rules
+- For manual browser automation and visual inspection that previously used Playwright MCP, prefer the device-wide `agent-browser` CLI.
+- Typical workflow: `agent-browser open <url>`, `agent-browser wait --load networkidle`, `agent-browser snapshot -i`, interact via refs such as `@e2`, then `agent-browser close` when finished.
+- When checking theme-sensitive UI, use explicit browser media settings such as `agent-browser --color-scheme dark open <url>` or `agent-browser set media dark`.
+- Keep Playwright focused on automated E2E coverage; use agent-browser for ad hoc browser inspection instead.

--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -219,6 +219,7 @@ npm run test:watch
 ```bash
 npx playwright test
 ```
+
 - Runs Playwright E2E tests
 - Headless by default
 - Results in `test-results/`
@@ -239,6 +240,26 @@ npx playwright test e2e/specs/leaderboards.spec.ts
 # Headed browser run
 npx playwright test --headed
 ```
+
+### Manual Browser Automation For Agent Work
+
+Use the device-wide `agent-browser` CLI for ad hoc browser inspection tasks that are not Playwright E2E tests.
+
+Recommended flow:
+
+```bash
+agent-browser open http://localhost:4200
+agent-browser wait --load networkidle
+agent-browser snapshot -i
+agent-browser click @e2
+agent-browser close
+```
+
+Notes:
+
+- Prefer `agent-browser` for manual UI/theme inspection that older workflow text may still call "Playwright MCP".
+- Keep Playwright for automated E2E coverage (`npm run e2e`, `npx playwright test`, `npm run perf:audit`).
+- For dark-mode checks, use explicit browser media settings such as `agent-browser --color-scheme dark open http://localhost:4200`.
 
 ### Angular CLI Commands
 ```bash


### PR DESCRIPTION
## Summary:
- replace Playwright MCP guidance with device-wide `agent-browser` guidance for manual browser automation
- document the recommended `agent-browser` workflow in AGENTS, CLAUDE, and the development guide
- clarify that Playwright remains the tool for automated E2E and perf-audit coverage
- align workflow docs so future browser-inspection tasks use the same tooling expectations
