### PR TITLE
Fix: Polishments after PageSpeed analyzes

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -29,6 +29,16 @@
               {
                 "glob": "**/*",
                 "input": "public"
+              },
+              {
+                "glob": "material-icons.woff2",
+                "input": "node_modules/material-icons/iconfont",
+                "output": "fonts"
+              },
+              {
+                "glob": "material-icons.woff",
+                "input": "node_modules/material-icons/iconfont",
+                "output": "fonts"
               }
             ],
             "styles": [

--- a/ngsw-config.json
+++ b/ngsw-config.json
@@ -22,6 +22,7 @@
       "resources": {
         "files": [
           "/assets/**",
+          "/fonts/**",
           "/i18n/**",
           "/icons/**",
           "/*.(png|jpg|jpeg|svg|webp|ico)"

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -1,5 +1,5 @@
 import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
-import { provideRouter } from '@angular/router';
+import { PreloadAllModules, provideRouter, withPreloading } from '@angular/router';
 import {
   provideHttpClient,
   withFetch,
@@ -16,7 +16,7 @@ import { environment } from '../environments/environment';
 export const appConfig: ApplicationConfig = {
   providers: [
     provideZoneChangeDetection({ eventCoalescing: true }),
-    provideRouter(routes),
+    provideRouter(routes, withPreloading(PreloadAllModules)),
     provideHttpClient(withFetch(), withInterceptorsFromDi()),
     provideServiceWorker('ngsw-worker.js', {
       enabled: environment.production,

--- a/src/app/shared/player-card/player-card-navigation.service.ts
+++ b/src/app/shared/player-card/player-card-navigation.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, ElementRef, ChangeDetectorRef, NgZone, inject, OnDestroy } from '@angular/core';
+import { Injectable, ChangeDetectorRef, NgZone, inject, OnDestroy } from '@angular/core';
 import { Player, Goalie } from '@services/api.service';
 import { PlayerCardDialogData } from './player-card.component';
 
@@ -14,7 +14,6 @@ export class PlayerCardNavigationService implements OnDestroy {
   liveRegionMessage = '';
 
   private context: NavigationContext | undefined;
-  private host!: ElementRef<HTMLElement>;
   private cdr!: ChangeDetectorRef;
   private onNavigateCallback?: (player: Player | Goalie, index: number) => void;
 
@@ -27,19 +26,18 @@ export class PlayerCardNavigationService implements OnDestroy {
   private wheelResetTimer: ReturnType<typeof setTimeout> | null = null;
   private wheelCooldownTimer: ReturnType<typeof setTimeout> | null = null;
   private animationTimer: ReturnType<typeof setTimeout> | null = null;
+  private rafId: number | null = null;
   private readonly animationDuration = 125;
   private readonly wheelHandler = (e: WheelEvent) => this.onWheel(e);
 
   init(
     context: NavigationContext | undefined,
-    host: ElementRef<HTMLElement>,
     cdr: ChangeDetectorRef,
     onNavigate: (player: Player | Goalie, index: number) => void,
   ): void {
     this.context = context;
     this.currentIndex = context?.currentIndex ?? 0;
     this.allPlayers = context?.allPlayers ?? [];
-    this.host = host;
     this.cdr = cdr;
     this.onNavigateCallback = onNavigate;
 
@@ -50,6 +48,7 @@ export class PlayerCardNavigationService implements OnDestroy {
 
   ngOnDestroy(): void {
     document.removeEventListener('wheel', this.wheelHandler);
+    if (this.rafId !== null) cancelAnimationFrame(this.rafId);
     if (this.wheelResetTimer) clearTimeout(this.wheelResetTimer);
     if (this.wheelCooldownTimer) clearTimeout(this.wheelCooldownTimer);
     if (this.animationTimer) clearTimeout(this.animationTimer);
@@ -92,6 +91,7 @@ export class PlayerCardNavigationService implements OnDestroy {
 
   navigateToIndex(newIndex: number, direction: 'left' | 'right'): void {
     if (this.animationTimer) { clearTimeout(this.animationTimer); this.animationTimer = null; }
+    if (this.rafId !== null) { cancelAnimationFrame(this.rafId); this.rafId = null; }
 
     const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
     if (prefersReducedMotion) { this.applyNavigation(newIndex); return; }
@@ -100,14 +100,22 @@ export class PlayerCardNavigationService implements OnDestroy {
     this.cdr.detectChanges();
 
     this.animationTimer = setTimeout(() => {
+      this.animationTimer = null;
       this.applyNavigation(newIndex);
       const enterFrom = direction === 'left' ? 'left' : 'right';
       this.slideClass = `card-content-wrapper slide-in-${enterFrom}`;
       this.cdr.detectChanges();
-      this.host.nativeElement.querySelector('.card-content-wrapper')?.getBoundingClientRect();
-      this.slideClass = 'card-content-wrapper';
-      this.cdr.detectChanges();
-      this.animationTimer = setTimeout(() => { this.animationTimer = null; }, this.animationDuration);
+      // Double rAF: first frame commits the snap; second frame starts the transition back to centre
+      this.rafId = requestAnimationFrame(() => {
+        this.rafId = requestAnimationFrame(() => {
+          this.zone.run(() => {
+            this.rafId = null;
+            this.slideClass = 'card-content-wrapper';
+            this.cdr.detectChanges();
+            this.animationTimer = setTimeout(() => { this.animationTimer = null; }, this.animationDuration);
+          });
+        });
+      });
     }, this.animationDuration);
   }
 

--- a/src/app/shared/player-card/player-card.component.spec.ts
+++ b/src/app/shared/player-card/player-card.component.spec.ts
@@ -1,3 +1,5 @@
+import { ChangeDetectorRef } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
 import { fireEvent, render, screen, within } from '@testing-library/angular';
 
 import { AppComponent } from '../../app.component';
@@ -10,6 +12,7 @@ import {
     waitForBehaviorAssertion,
 } from '../../testing/behavior-test-utils';
 import { toSlug } from '@shared/utils/slug.utils';
+import { PlayerCardNavigationService } from './player-card-navigation.service';
 
 describe('PlayerCardComponent — desktop user flow', { timeout: 90_000 }, () => {
     const writeTextMock = vi.fn<(_: string) => Promise<void>>();
@@ -189,6 +192,40 @@ describe('PlayerCardComponent — desktop user flow', { timeout: 90_000 }, () =>
                 within(dialog).getByRole('button', { name: 'graphs.switchToRadar' })
             ).toBeInTheDocument();
         });
+    });
+
+    it('should not call getBoundingClientRect during card navigation (no forced reflow)', async () => {
+        vi.useFakeTimers();
+        polyfillMatchMedia();
+
+        const wrapper = document.createElement('div');
+        wrapper.className = 'card-content-wrapper';
+        document.body.appendChild(wrapper);
+
+        const spy = vi.spyOn(wrapper, 'getBoundingClientRect');
+
+        const service = TestBed.runInInjectionContext(() => new PlayerCardNavigationService());
+        const cdrStub = { detectChanges: vi.fn() } as unknown as ChangeDetectorRef;
+
+        const mockPlayers = [
+            { name: 'Player A' },
+            { name: 'Player B' },
+        ] as never[];
+
+        service.init(
+            { allPlayers: mockPlayers, currentIndex: 0 },
+            cdrStub,
+            vi.fn(),
+        );
+
+        service.navigateToNext();
+        vi.runAllTimers();
+
+        expect(spy).not.toHaveBeenCalled();
+
+        service.ngOnDestroy();
+        document.body.removeChild(wrapper);
+        vi.useRealTimers();
     });
 
     it('supports touch and wheel navigation while announcing the active player', async () => {

--- a/src/app/shared/player-card/player-card.component.spec.ts
+++ b/src/app/shared/player-card/player-card.component.spec.ts
@@ -196,36 +196,39 @@ describe('PlayerCardComponent — desktop user flow', { timeout: 90_000 }, () =>
 
     it('should not call getBoundingClientRect during card navigation (no forced reflow)', async () => {
         vi.useFakeTimers();
-        polyfillMatchMedia();
+        try {
+            polyfillMatchMedia();
 
-        const wrapper = document.createElement('div');
-        wrapper.className = 'card-content-wrapper';
-        document.body.appendChild(wrapper);
+            const wrapper = document.createElement('div');
+            wrapper.className = 'card-content-wrapper';
+            document.body.appendChild(wrapper);
 
-        const spy = vi.spyOn(wrapper, 'getBoundingClientRect');
+            const spy = vi.spyOn(wrapper, 'getBoundingClientRect');
 
-        const service = TestBed.runInInjectionContext(() => new PlayerCardNavigationService());
-        const cdrStub = { detectChanges: vi.fn() } as unknown as ChangeDetectorRef;
+            const service = TestBed.runInInjectionContext(() => new PlayerCardNavigationService());
+            const cdrStub = { detectChanges: vi.fn() } as unknown as ChangeDetectorRef;
 
-        const mockPlayers = [
-            { name: 'Player A' },
-            { name: 'Player B' },
-        ] as never[];
+            const mockPlayers = [
+                { name: 'Player A' },
+                { name: 'Player B' },
+            ] as never[];
 
-        service.init(
-            { allPlayers: mockPlayers, currentIndex: 0 },
-            cdrStub,
-            vi.fn(),
-        );
+            service.init(
+                { allPlayers: mockPlayers, currentIndex: 0 },
+                cdrStub,
+                vi.fn(),
+            );
 
-        service.navigateToNext();
-        vi.runAllTimers();
+            service.navigateToNext();
+            vi.runAllTimers();
 
-        expect(spy).not.toHaveBeenCalled();
+            expect(spy).not.toHaveBeenCalled();
 
-        service.ngOnDestroy();
-        document.body.removeChild(wrapper);
-        vi.useRealTimers();
+            service.ngOnDestroy();
+            document.body.removeChild(wrapper);
+        } finally {
+            vi.useRealTimers();
+        }
     });
 
     it('supports touch and wheel navigation while announcing the active player', async () => {

--- a/src/app/shared/player-card/player-card.component.ts
+++ b/src/app/shared/player-card/player-card.component.ts
@@ -207,7 +207,6 @@ export class PlayerCardComponent implements AfterViewInit {
 
     this.navigationService.init(
       this.navigationContext,
-      this.host,
       this.cdr,
       (player) => {
         this.dataState.set(player);

--- a/src/app/shared/stats-table/virtual-table.component.spec.ts
+++ b/src/app/shared/stats-table/virtual-table.component.spec.ts
@@ -151,6 +151,22 @@ describe('VirtualTableComponent — user behavior', () => {
     expect(await screen.findByText('table.loading')).toBeInTheDocument();
   });
 
+  it('should defer syncViewportMetrics to rAF on window resize (avoid forced reflow)', async () => {
+    const view = await setup();
+    const table = view.fixture.debugElement.children[0].componentInstance as VirtualTableComponent;
+
+    await screen.findByText('Beta Blueliner');
+
+    const spy = vi.spyOn(table as any, 'syncViewportMetrics');
+    table.onWindowResize();
+    // Must NOT be called synchronously
+    expect(spy).not.toHaveBeenCalled();
+    // Should be called after rAF, exactly once
+    await vi.waitFor(() => {
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
+  });
+
   it('covers the remaining keyboard and resize paths used by the career table', async () => {
     const view = await setup();
     const table = view.fixture.debugElement.children[0].componentInstance as VirtualTableComponent;
@@ -203,8 +219,10 @@ describe('VirtualTableComponent — user behavior', () => {
     };
     table.onWindowResize();
 
-    expect(table.headerScrollbarOffset).toBe(20);
-    expect(detectChangesSpy).toHaveBeenCalled();
+    await vi.waitFor(() => {
+      expect(table.headerScrollbarOffset).toBe(20);
+      expect(detectChangesSpy).toHaveBeenCalled();
+    });
   });
 
   it('supports name sorting while keeping the running-number column visible', async () => {

--- a/src/app/shared/stats-table/virtual-table.component.ts
+++ b/src/app/shared/stats-table/virtual-table.component.ts
@@ -93,6 +93,7 @@ export class VirtualTableComponent implements AfterViewInit {
   private previousData?: TableRow[];
   private previousColumns?: Column[];
   private previousDefaultSortColumn?: string;
+  private resizeRafId: ReturnType<typeof requestAnimationFrame> | null = null;
 
   constructor() {
     effect(() => {
@@ -133,6 +134,10 @@ export class VirtualTableComponent implements AfterViewInit {
       this.previousColumns = columns;
       this.previousDefaultSortColumn = defaultSortColumn;
     });
+
+    this.destroyRef.onDestroy(() => {
+      if (this.resizeRafId !== null) cancelAnimationFrame(this.resizeRafId);
+    });
   }
 
   ngAfterViewInit(): void {
@@ -151,7 +156,11 @@ export class VirtualTableComponent implements AfterViewInit {
   }
 
   onWindowResize(): void {
-    this.syncViewportMetrics();
+    if (this.resizeRafId !== null) cancelAnimationFrame(this.resizeRafId);
+    this.resizeRafId = requestAnimationFrame(() => {
+      this.resizeRafId = null;
+      this.syncViewportMetrics();
+    });
   }
 
   getHeaderIconType(column: Column): ColumnIcon['type'] | null {

--- a/src/index.html
+++ b/src/index.html
@@ -3,6 +3,8 @@
 
 <head>
   <meta charset="utf-8">
+  <link rel="preload" href="fonts/material-icons.woff2"
+        as="font" type="font/woff2" crossorigin>
   <title>FFHL tilastopalvelu</title>
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/src/index.html
+++ b/src/index.html
@@ -3,7 +3,7 @@
 
 <head>
   <meta charset="utf-8">
-  <link rel="preload" href="fonts/material-icons.woff2"
+  <link rel="preload" href="/fonts/material-icons.woff2"
         as="font" type="font/woff2" crossorigin>
   <title>FFHL tilastopalvelu</title>
   <base href="/">

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -6,8 +6,8 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: url("material-icons/iconfont/material-icons.woff2") format("woff2"),
-       url("material-icons/iconfont/material-icons.woff") format("woff");
+  src: url("/fonts/material-icons.woff2") format("woff2"),
+       url("/fonts/material-icons.woff") format("woff");
 }
 
 .material-icons {


### PR DESCRIPTION
## Summary

- Fix forced layout reflows (PageSpeed issue 1): defer `syncViewportMetrics()` to `requestAnimationFrame` in `virtual-table` on window resize, and replace the `getBoundingClientRect()` animation restart hack in `player-card-navigation` with a double-rAF pattern — no synchronous layout queries remain in either path
- Fix critical request chain (PageSpeed issue 2): serve Material Icons font from a fixed `/fonts/` path (no content hash) so a `<link rel="preload">` in `<head>` can start the fetch before CSS is parsed; add `/fonts/**` to the service worker cache; add `PreloadAllModules` to prefetch lazy route chunks during idle time
- Remove `ElementRef`/`host` from `PlayerCardNavigationService` — the field only existed to support the now-removed reflow hack