### PR TITLE
Refactoring: Cleaner and more widely compatible Angular 21 lifecycle/state patterns

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -40,14 +40,6 @@ The repo is already mostly signals-first, but a few app-owned UI state services 
 - Prefer writable/computed signals for owned state, with observable APIs kept only where async composition or backwards compatibility still needs them
 - Keep this as a behavior-preserving refactor; do not mix it with product changes
 
-#### Remove Remaining Manual Subscription Teardown (~3-5h)
-
-Most new code already uses `takeUntilDestroyed()` or signal-driven flows, but a few older components still keep `Subject<void>` plus `takeUntil()` teardown patterns.
-
-- Prioritize `StatsBaseComponent`, direct card route components, and the career list route containers
-- Simplify teardown where Angular 21 injection-context patterns make the lifecycle wiring smaller and easier to read
-- Treat this as cleanup for maintainability, not as an excuse to churn stable code without a clear benefit
-
 ## E2E Testing
 
 ### Test data management

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -28,18 +28,6 @@ Override the current auto-only system-preference-based theme. Persist choice in 
 
 Persist the user's last sort column and direction per table (players/goalies) in localStorage across sessions.
 
-## Architecture and maintenance
-
-### Low priority
-
-#### Finish Signal-Native UI State Cleanup (~4-8h)
-
-The repo is already mostly signals-first, but a few app-owned UI state services still use `BehaviorSubject` plus `toSignal()` as a compatibility bridge.
-
-- Prioritize `FilterService`, `SettingsService`, `ComparisonService`, and `DrawerContextService`
-- Prefer writable/computed signals for owned state, with observable APIs kept only where async composition or backwards compatibility still needs them
-- Keep this as a behavior-preserving refactor; do not mix it with product changes
-
 ## E2E Testing
 
 ### Test data management

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -6,15 +6,6 @@ Planned improvements and future development ideas, roughly ordered by priority.
 
 ### High priority
 
-#### Startup Performance and Rendering Strategy (conditional follow-up only)
-
-Improve startup performance without defaulting to SSR where it is not worth the complexity.
-
-- The dashboard-shell split, the first startup deferrals, and the main-thread cleanup batch are already in place; keep the roadmap focused on whether any data-path cleanup is still necessary rather than repeating completed implementation detail here.
-- Recent build verification reduced the initial estimated transfer budget again and split the footer into its own lazy chunk; preserve those startup wins while validating real-user impact.
-- Treat data-path cleanup as optional follow-up only if later perf checks still show meaningful startup headroom on the homepage.
-- Track implementation detail in the active local `docs/plans/` plan; keep the roadmap high level and remove finished execution detail from here.
-
 #### Favorites / Watchlist (~4-6h)
 
 Star/bookmark players, persisted in localStorage. Add a "Suosikit" filter toggle to quickly view only watched players. No API changes needed.
@@ -36,6 +27,26 @@ Override the current auto-only system-preference-based theme. Persist choice in 
 #### Remember Sort Column (~1-2h)
 
 Persist the user's last sort column and direction per table (players/goalies) in localStorage across sessions.
+
+## Architecture and maintenance
+
+### Low priority
+
+#### Finish Signal-Native UI State Cleanup (~4-8h)
+
+The repo is already mostly signals-first, but a few app-owned UI state services still use `BehaviorSubject` plus `toSignal()` as a compatibility bridge.
+
+- Prioritize `FilterService`, `SettingsService`, `ComparisonService`, and `DrawerContextService`
+- Prefer writable/computed signals for owned state, with observable APIs kept only where async composition or backwards compatibility still needs them
+- Keep this as a behavior-preserving refactor; do not mix it with product changes
+
+#### Remove Remaining Manual Subscription Teardown (~3-5h)
+
+Most new code already uses `takeUntilDestroyed()` or signal-driven flows, but a few older components still keep `Subject<void>` plus `takeUntil()` teardown patterns.
+
+- Prioritize `StatsBaseComponent`, direct card route components, and the career list route containers
+- Simplify teardown where Angular 21 injection-context patterns make the lifecycle wiring smaller and easier to read
+- Treat this as cleanup for maintainability, not as an excuse to churn stable code without a clear benefit
 
 ## E2E Testing
 

--- a/docs/service-guide.md
+++ b/docs/service-guide.md
@@ -502,10 +502,10 @@ expect(screen.getByText('Player 1')).toBeInTheDocument();
    - FilterService: Data manipulation only
    - CacheService: Caching only
 
-2. **Observable Patterns**
-   - Use shareReplay for shared data streams
-   - Use BehaviorSubject for state management
-   - Always unsubscribe or use async pipe
+2. **Reactive Patterns**
+   - Prefer writable/computed signals for app-owned UI state, exposing readonly signal APIs where possible
+   - Keep observable APIs for async composition, transport flows, or compatibility with existing consumers
+   - Use `shareReplay` for shared fetch streams and prefer `takeUntilDestroyed()` over manual teardown when you need subscriptions in an injection context
 
 3. **Error Handling**
    - Handle errors at service level

--- a/src/app/app.component.mobile.spec.ts
+++ b/src/app/app.component.mobile.spec.ts
@@ -346,12 +346,16 @@ describe('AppComponent — mobile frontpage', { timeout: 60_000 }, () => {
 
     fireEvent.click(screen.getByRole('tab', { name: 'draft.tabs.openingDraft' }));
 
-    expect(await screen.findByRole('heading', { name: 'draft.tabs.openingDraft' })).toBeInTheDocument();
-    expect(await screen.findByText(openingDraftsFixture[0].team.name)).toBeInTheDocument();
+    expect(
+      await screen.findByRole('heading', { name: 'draft.tabs.openingDraft' }, { timeout: 5000 })
+    ).toBeInTheDocument();
+    expect(await screen.findByText(openingDraftsFixture[0].team.name, {}, { timeout: 5000 })).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('tab', { name: 'draft.tabs.statistics' }));
 
-    expect(await screen.findByRole('heading', { name: 'draft.tabs.statistics' })).toBeInTheDocument();
+    expect(
+      await screen.findByRole('heading', { name: 'draft.tabs.statistics' }, { timeout: 5000 })
+    ).toBeInTheDocument();
     expect(screen.getByText('draft.statistics.cards.totalPicks.title')).toBeInTheDocument();
   });
 });

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -201,7 +201,7 @@ describe('AppComponent — desktop frontpage', { timeout: 60_000 }, () => {
 
     await vi.waitFor(() => {
       expect(bottomSheetFactory).toHaveBeenCalledTimes(1);
-    });
+    }, { timeout: 5000 });
   });
 
   it('starts with visible defaults when browser storage is empty', async () => {

--- a/src/app/base/stats/stats-base.component.ts
+++ b/src/app/base/stats/stats-base.component.ts
@@ -1,6 +1,6 @@
-import { Directive, OnInit, OnDestroy, inject } from '@angular/core';
+import { DestroyRef, Directive, OnInit, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import {
-  Subject,
   Observable,
   auditTime,
   catchError,
@@ -10,7 +10,6 @@ import {
   map,
   of,
   switchMap,
-  takeUntil,
 } from 'rxjs';
 import { ApiParams, ApiService, Player, Goalie, ReportType } from '@services/api.service';
 import { FilterService, FilterState, PositionFilter } from '@services/filter.service';
@@ -26,14 +25,14 @@ import { toApiTeamId } from '@shared/utils/api.utils';
 import { FooterVisibilityService } from '@services/footer-visibility.service';
 
 @Directive()
-export abstract class StatsBaseComponent<T extends Player | Goalie> implements OnInit, OnDestroy {
+export abstract class StatsBaseComponent<T extends Player | Goalie> implements OnInit {
   protected apiService = inject(ApiService);
   protected filterService = inject(FilterService);
   protected statsService = inject(StatsService);
   protected teamService = inject(TeamService);
   protected settingsService = inject(SettingsService);
   protected drawerContextService = inject(DrawerContextService);
-  protected destroy$ = new Subject<void>();
+  protected destroyRef = inject(DestroyRef);
   private readonly footerVisibilityService = inject(FooterVisibilityService);
 
   readonly isMobile$ = inject(ViewportService).isMobile$;
@@ -142,7 +141,7 @@ export abstract class StatsBaseComponent<T extends Player | Goalie> implements O
             catchError(() => of({ data: [] as T[], isError: true as const }))
           );
         }),
-        takeUntil(this.destroy$)
+        takeUntilDestroyed(this.destroyRef)
       )
       .subscribe({
         next: ({ data, isError }) => {
@@ -164,11 +163,6 @@ export abstract class StatsBaseComponent<T extends Player | Goalie> implements O
         },
         // Stream should not error due to catchError above.
       });
-  }
-
-  ngOnDestroy(): void {
-    this.destroy$.next();
-    this.destroy$.complete();
   }
 
   private markFooterReady(): void {

--- a/src/app/career/goalies/career-goalies.component.ts
+++ b/src/app/career/goalies/career-goalies.component.ts
@@ -1,5 +1,5 @@
-import { Component, OnDestroy, OnInit, inject } from '@angular/core';
-import { Subject, takeUntil } from 'rxjs';
+import { Component, DestroyRef, OnInit, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 import { ApiService, CareerGoalieListItem } from '@services/api.service';
 import { TableRow } from '@shared/stats-table/stats-table.component';
@@ -14,9 +14,9 @@ import { FooterVisibilityService } from '@services/footer-visibility.service';
   imports: [VirtualTableComponent],
   templateUrl: './career-goalies.component.html',
 })
-export class CareerGoaliesComponent implements OnInit, OnDestroy {
+export class CareerGoaliesComponent implements OnInit {
   private readonly apiService = inject(ApiService);
-  private readonly destroy$ = new Subject<void>();
+  private readonly destroyRef = inject(DestroyRef);
   private readonly footerVisibilityService = inject(FooterVisibilityService);
 
   readonly columns: Column[] = CAREER_GOALIE_COLUMNS;
@@ -37,7 +37,7 @@ export class CareerGoaliesComponent implements OnInit, OnDestroy {
     this.loading = true;
     this.apiService
       .getCareerGoalies()
-      .pipe(takeUntil(this.destroy$))
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
         next: (data) => {
           this.data = data;
@@ -51,11 +51,6 @@ export class CareerGoaliesComponent implements OnInit, OnDestroy {
           this.footerVisibilityService.markReady(this.footerVisibilityCycle);
         },
       });
-  }
-
-  ngOnDestroy(): void {
-    this.destroy$.next();
-    this.destroy$.complete();
   }
 
   private formatCellValue(column: string, value: number | string | undefined): string {

--- a/src/app/career/players/career-players.component.ts
+++ b/src/app/career/players/career-players.component.ts
@@ -1,5 +1,5 @@
-import { Component, OnDestroy, OnInit, inject } from '@angular/core';
-import { Subject, takeUntil } from 'rxjs';
+import { Component, DestroyRef, OnInit, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 import { ApiService, CareerPlayerListItem } from '@services/api.service';
 import { TableRow } from '@shared/stats-table/stats-table.component';
@@ -14,9 +14,9 @@ import { FooterVisibilityService } from '@services/footer-visibility.service';
   imports: [VirtualTableComponent],
   templateUrl: './career-players.component.html',
 })
-export class CareerPlayersComponent implements OnInit, OnDestroy {
+export class CareerPlayersComponent implements OnInit {
   private readonly apiService = inject(ApiService);
-  private readonly destroy$ = new Subject<void>();
+  private readonly destroyRef = inject(DestroyRef);
   private readonly footerVisibilityService = inject(FooterVisibilityService);
 
   readonly columns: Column[] = CAREER_PLAYER_COLUMNS;
@@ -37,7 +37,7 @@ export class CareerPlayersComponent implements OnInit, OnDestroy {
     this.loading = true;
     this.apiService
       .getCareerPlayers()
-      .pipe(takeUntil(this.destroy$))
+      .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
         next: (data) => {
           this.data = data;
@@ -51,11 +51,6 @@ export class CareerPlayersComponent implements OnInit, OnDestroy {
           this.footerVisibilityService.markReady(this.footerVisibilityCycle);
         },
       });
-  }
-
-  ngOnDestroy(): void {
-    this.destroy$.next();
-    this.destroy$.complete();
   }
 
   private formatCellValue(

--- a/src/app/goalie-route/goalie-route.component.ts
+++ b/src/app/goalie-route/goalie-route.component.ts
@@ -1,7 +1,8 @@
-import { Component, OnInit, OnDestroy, inject } from '@angular/core';
+import { Component, DestroyRef, OnInit, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Router } from '@angular/router';
 import { MatDialog } from '@angular/material/dialog';
-import { Subject, combineLatest, of, switchMap, takeUntil, tap, take } from 'rxjs';
+import { combineLatest, of, switchMap, tap, take } from 'rxjs';
 import { ApiService, Goalie, Team } from '@services/api.service';
 import { TeamService } from '@services/team.service';
 import { FilterService } from '@services/filter.service';
@@ -64,14 +65,14 @@ import { matchesSlug } from '@shared/utils/slug.utils';
     }
   `],
 })
-export class GoalieRouteComponent implements OnInit, OnDestroy {
+export class GoalieRouteComponent implements OnInit {
+  private readonly destroyRef = inject(DestroyRef);
   private route = inject(ActivatedRoute);
   private router = inject(Router);
   private dialog = inject(MatDialog);
   private apiService = inject(ApiService);
   private teamService = inject(TeamService);
   private filterService = inject(FilterService);
-  private destroy$ = new Subject<void>();
 
   error: string | null = null;
   private dialogOpened = false;
@@ -131,14 +132,9 @@ export class GoalieRouteComponent implements OnInit, OnDestroy {
             })
           );
         }),
-        takeUntil(this.destroy$)
+        takeUntilDestroyed(this.destroyRef)
       )
       .subscribe();
-  }
-
-  ngOnDestroy() {
-    this.destroy$.next();
-    this.destroy$.complete();
   }
 
   private findTeam(teams: Team[], slugOrId: string): Team | undefined {

--- a/src/app/player-route/player-route.component.ts
+++ b/src/app/player-route/player-route.component.ts
@@ -1,7 +1,8 @@
-import { Component, OnInit, OnDestroy, inject } from '@angular/core';
+import { Component, DestroyRef, OnInit, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Router } from '@angular/router';
 import { MatDialog } from '@angular/material/dialog';
-import { Subject, combineLatest, of, switchMap, takeUntil, tap, take } from 'rxjs';
+import { combineLatest, of, switchMap, tap, take } from 'rxjs';
 import { ApiService, Player, Team } from '@services/api.service';
 import { TeamService } from '@services/team.service';
 import { FilterService } from '@services/filter.service';
@@ -64,14 +65,14 @@ import { matchesSlug } from '@shared/utils/slug.utils';
     }
   `],
 })
-export class PlayerRouteComponent implements OnInit, OnDestroy {
+export class PlayerRouteComponent implements OnInit {
+  private readonly destroyRef = inject(DestroyRef);
   private route = inject(ActivatedRoute);
   private router = inject(Router);
   private dialog = inject(MatDialog);
   private apiService = inject(ApiService);
   private teamService = inject(TeamService);
   private filterService = inject(FilterService);
-  private destroy$ = new Subject<void>();
 
   error: string | null = null;
   private dialogOpened = false;
@@ -131,14 +132,9 @@ export class PlayerRouteComponent implements OnInit, OnDestroy {
             })
           );
         }),
-        takeUntil(this.destroy$)
+        takeUntilDestroyed(this.destroyRef)
       )
       .subscribe();
-  }
-
-  ngOnDestroy() {
-    this.destroy$.next();
-    this.destroy$.complete();
   }
 
   private findTeam(teams: Team[], slugOrId: string): Team | undefined {

--- a/src/app/services/comparison.service.ts
+++ b/src/app/services/comparison.service.ts
@@ -1,7 +1,6 @@
-import { DestroyRef, inject, Injectable } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { BehaviorSubject, combineLatest } from 'rxjs';
-import { distinctUntilChanged, map, skip } from 'rxjs/operators';
+import { computed, DestroyRef, inject, Injectable, signal } from '@angular/core';
+import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
+import { distinctUntilChanged, map, skip } from 'rxjs';
 import { Player, Goalie } from './api.service';
 import { TeamService } from './team.service';
 import { FilterService } from './filter.service';
@@ -21,46 +20,45 @@ export class ComparisonService {
   private readonly settingsService = inject(SettingsService);
   private readonly statsService = inject(StatsService);
 
-  private selectedPlayers = new BehaviorSubject<(Player | Goalie)[]>([]);
+  private readonly selectedPlayersState = signal<(Player | Goalie)[]>([]);
+  readonly selectionSignal = this.selectedPlayersState.asReadonly();
 
-  readonly selection$ = this.selectedPlayers.asObservable();
+  readonly selection$ = toObservable(this.selectionSignal);
+  readonly canSelectMoreSignal = computed(() => this.selectionSignal().length < 2);
+  readonly canSelectMore$ = toObservable(this.canSelectMoreSignal);
 
-  readonly canSelectMore$ = this.selection$.pipe(
-    map((selection) => selection.length < 2),
-  );
+  readonly orderedSelectionSignal = computed<OrderedComparison | null>(() => {
+    const selection = this.selectionSignal();
+    const playerFilters = this.filterService.playerFiltersSignal();
+    const goalieFilters = this.filterService.goalieFiltersSignal();
 
-  readonly orderedSelection$ = combineLatest([
-    this.selection$,
-    this.filterService.playerFilters$,
-    this.filterService.goalieFilters$,
-  ]).pipe(
-    map(([selection, playerFilters, goalieFilters]): OrderedComparison | null => {
-      if (selection.length < 2) {
-        return null;
-      }
-      let [a, b] = selection;
+    if (selection.length < 2) {
+      return null;
+    }
+    let [a, b] = selection;
 
-      // Check if we should use per-game stats
-      const isGoalie = (p: Player | Goalie): p is Goalie => 'wins' in p;
-      const aIsGoalie = isGoalie(a);
-      const bIsGoalie = isGoalie(b);
-      const statsPerGame = aIsGoalie ? goalieFilters.statsPerGame : playerFilters.statsPerGame;
+    // Check if we should use per-game stats
+    const isGoalie = (p: Player | Goalie): p is Goalie => 'wins' in p;
+    const aIsGoalie = isGoalie(a);
+    const bIsGoalie = isGoalie(b);
+    const statsPerGame = aIsGoalie ? goalieFilters.statsPerGame : playerFilters.statsPerGame;
 
-      if (statsPerGame) {
-        // Transform to per-game stats
-        a = aIsGoalie
-          ? this.statsService.getGoalieStatsPerGame([a as Goalie])[0]
-          : this.statsService.getPlayerStatsPerGame([a as Player])[0];
-        b = bIsGoalie
-          ? this.statsService.getGoalieStatsPerGame([b as Goalie])[0]
-          : this.statsService.getPlayerStatsPerGame([b as Player])[0];
-      }
+    if (statsPerGame) {
+      // Transform to per-game stats
+      a = aIsGoalie
+        ? this.statsService.getGoalieStatsPerGame([a as Goalie])[0]
+        : this.statsService.getPlayerStatsPerGame([a as Player])[0];
+      b = bIsGoalie
+        ? this.statsService.getGoalieStatsPerGame([b as Goalie])[0]
+        : this.statsService.getPlayerStatsPerGame([b as Player])[0];
+    }
 
-      return a.score >= b.score
-        ? { playerA: a, playerB: b }
-        : { playerA: b, playerB: a };
-    }),
-  );
+    return a.score >= b.score
+      ? { playerA: a, playerB: b }
+      : { playerA: b, playerB: a };
+  });
+
+  readonly orderedSelection$ = toObservable(this.orderedSelectionSignal);
 
   constructor() {
     // Clear on team change
@@ -95,23 +93,23 @@ export class ComparisonService {
   }
 
   toggle(player: Player | Goalie): void {
-    const current = this.selectedPlayers.value;
+    const current = this.selectionSignal();
     const key = this.playerKey(player);
     const index = current.findIndex((p) => this.playerKey(p) === key);
     if (index >= 0) {
-      this.selectedPlayers.next(current.filter((_, i) => i !== index));
+      this.selectedPlayersState.set(current.filter((_, i) => i !== index));
     } else if (current.length < 2) {
-      this.selectedPlayers.next([...current, player]);
+      this.selectedPlayersState.set([...current, player]);
     }
   }
 
   isSelected(player: Player | Goalie): boolean {
     const key = this.playerKey(player);
-    return this.selectedPlayers.value.some((p) => this.playerKey(p) === key);
+    return this.selectionSignal().some((p) => this.playerKey(p) === key);
   }
 
   clear(): void {
-    this.selectedPlayers.next([]);
+    this.selectedPlayersState.set([]);
   }
 
   private playerKey(player: Player | Goalie): string {

--- a/src/app/services/drawer-context.service.ts
+++ b/src/app/services/drawer-context.service.ts
@@ -1,5 +1,5 @@
-import { Injectable } from '@angular/core';
-import { BehaviorSubject, map } from 'rxjs';
+import { computed, Injectable, signal } from '@angular/core';
+import { toObservable } from '@angular/core/rxjs-interop';
 import { StatsContext } from '@shared/types/context.types';
 
 export type ControlsContext = StatsContext;
@@ -11,30 +11,32 @@ type DrawerContextState = {
 
 @Injectable({ providedIn: 'root' })
 export class DrawerContextService {
-  private readonly stateSubject = new BehaviorSubject<DrawerContextState>({
+  private readonly state = signal<DrawerContextState>({
     playerMaxGames: 0,
     goalieMaxGames: 0,
   });
 
-  readonly state$ = this.stateSubject.asObservable();
-
-  readonly playerMaxGames$ = this.state$.pipe(map((s) => s.playerMaxGames));
-  readonly goalieMaxGames$ = this.state$.pipe(map((s) => s.goalieMaxGames));
+  readonly stateSignal = this.state.asReadonly();
+  readonly state$ = toObservable(this.stateSignal);
+  readonly playerMaxGamesSignal = computed(() => this.stateSignal().playerMaxGames);
+  readonly goalieMaxGamesSignal = computed(() => this.stateSignal().goalieMaxGames);
+  readonly playerMaxGames$ = toObservable(this.playerMaxGamesSignal);
+  readonly goalieMaxGames$ = toObservable(this.goalieMaxGamesSignal);
 
   setMaxGames(context: ControlsContext, maxGames: number): void {
     const normalized = Number.isFinite(maxGames)
       ? Math.max(0, Math.floor(maxGames))
       : 0;
 
-    const current = this.stateSubject.value;
+    const current = this.stateSignal();
 
     if (context === 'player') {
       if (current.playerMaxGames === normalized) return;
-      this.stateSubject.next({ ...current, playerMaxGames: normalized });
+      this.state.set({ ...current, playerMaxGames: normalized });
       return;
     }
 
     if (current.goalieMaxGames === normalized) return;
-    this.stateSubject.next({ ...current, goalieMaxGames: normalized });
+    this.state.set({ ...current, goalieMaxGames: normalized });
   }
 }

--- a/src/app/services/filter.service.ts
+++ b/src/app/services/filter.service.ts
@@ -1,6 +1,5 @@
-import { Injectable, inject } from '@angular/core';
-import { toSignal } from '@angular/core/rxjs-interop';
-import { BehaviorSubject } from 'rxjs';
+import { Injectable, inject, signal } from '@angular/core';
+import { toObservable } from '@angular/core/rxjs-interop';
 import { ReportType } from './api.service';
 import { SettingsService } from './settings.service';
 
@@ -20,37 +19,21 @@ export interface FilterState {
 export class FilterService {
   private readonly settingsService = inject(SettingsService);
 
-  private filters = {
-    players: new BehaviorSubject<FilterState>({
-      reportType: this.settingsService.reportType,
-      season: this.settingsService.season,
-      statsPerGame: false,
-      minGames: 0,
-      positionFilter: 'all',
-    }),
-    goalies: new BehaviorSubject<FilterState>({
-      reportType: this.settingsService.reportType,
-      season: this.settingsService.season,
-      statsPerGame: false,
-      minGames: 0,
-      positionFilter: 'all',
-    }),
-  };
+  private readonly playerFiltersState = signal<FilterState>(this.buildInitialFilterState());
+  private readonly goalieFiltersState = signal<FilterState>(this.buildInitialFilterState());
 
-  playerFilters$ = this.filters.players.asObservable();
-  goalieFilters$ = this.filters.goalies.asObservable();
-  readonly playerFiltersSignal = toSignal(this.playerFilters$, { requireSync: true });
-  readonly goalieFiltersSignal = toSignal(this.goalieFilters$, { requireSync: true });
+  readonly playerFiltersSignal = this.playerFiltersState.asReadonly();
+  readonly goalieFiltersSignal = this.goalieFiltersState.asReadonly();
+  readonly playerFilters$ = toObservable(this.playerFiltersSignal);
+  readonly goalieFilters$ = toObservable(this.goalieFiltersSignal);
 
   updatePlayerFilters(change: Partial<FilterState>): void {
-    const current = this.filters.players.value;
-    this.filters.players.next({ ...current, ...change });
+    this.playerFiltersState.update((current) => ({ ...current, ...change }));
     this.syncGlobalFilters('players', change);
   }
 
   updateGoalieFilters(change: Partial<FilterState>): void {
-    const current = this.filters.goalies.value;
-    this.filters.goalies.next({ ...current, ...change });
+    this.goalieFiltersState.update((current) => ({ ...current, ...change }));
     this.syncGlobalFilters('goalies', change);
   }
 
@@ -69,33 +52,40 @@ export class FilterService {
     if (hasSeason) globalChange.season = change.season;
     if (hasReportType) globalChange.reportType = change.reportType;
 
-    const target = source === 'players' ? this.filters.goalies : this.filters.players;
-    const current = target.value;
-    target.next({ ...current, ...globalChange });
+    const targetState = source === 'players' ? this.goalieFiltersState : this.playerFiltersState;
+    targetState.update((current) => ({ ...current, ...globalChange }));
   }
 
   resetPlayerFilters(): void {
-    const current = this.filters.players.value;
-    this.filters.players.next({
+    this.playerFiltersState.update((current) => ({
       ...current,
       statsPerGame: false,
       minGames: 0,
       positionFilter: 'all',
-    });
+    }));
   }
 
   resetGoalieFilters(): void {
-    const current = this.filters.goalies.value;
-    this.filters.goalies.next({
+    this.goalieFiltersState.update((current) => ({
       ...current,
       statsPerGame: false,
       minGames: 0,
-    });
+    }));
   }
 
   resetAll(): void {
     this.updatePlayerFilters({ reportType: 'regular', season: undefined });
     this.resetPlayerFilters();
     this.resetGoalieFilters();
+  }
+
+  private buildInitialFilterState(): FilterState {
+    return {
+      reportType: this.settingsService.reportType,
+      season: this.settingsService.season,
+      statsPerGame: false,
+      minGames: 0,
+      positionFilter: 'all',
+    };
   }
 }

--- a/src/app/services/settings.service.ts
+++ b/src/app/services/settings.service.ts
@@ -1,6 +1,5 @@
-import { computed, Injectable } from '@angular/core';
-import { toSignal } from '@angular/core/rxjs-interop';
-import { BehaviorSubject, distinctUntilChanged, map } from 'rxjs';
+import { computed, Injectable, signal } from '@angular/core';
+import { toObservable } from '@angular/core/rxjs-interop';
 import { ReportType } from './api.service';
 
 export type AppSettings = {
@@ -20,43 +19,32 @@ export class SettingsService {
   private readonly defaultTeamId = '1';
   private readonly defaultTopControlsExpanded = true;
 
-  private readonly settingsSubject = new BehaviorSubject<AppSettings>(
-    this.loadInitialSettings()
-  );
+  private readonly settingsState = signal<AppSettings>(this.loadInitialSettings());
+  private readonly settingsSignal = this.settingsState.asReadonly();
 
-  private readonly settings$ = this.settingsSubject.asObservable();
-  private readonly settingsSignal = toSignal(this.settings$, { requireSync: true });
-
-  readonly selectedTeamId$ = this.settings$.pipe(
-    map((s) => s.selectedTeamId),
-    distinctUntilChanged()
-  );
   readonly selectedTeamIdSignal = computed(() => this.settingsSignal().selectedTeamId);
+  readonly selectedTeamId$ = toObservable(this.selectedTeamIdSignal);
 
-  readonly startFromSeason$ = this.settings$.pipe(
-    map((s) => this.normalizeOptionalSeason(s.startFromSeason)),
-    distinctUntilChanged()
+  readonly startFromSeasonSignal = computed(() =>
+    this.normalizeOptionalSeason(this.settingsSignal().startFromSeason)
   );
+  readonly startFromSeason$ = toObservable(this.startFromSeasonSignal);
   readonly topControlsExpandedSignal = computed(() => this.settingsSignal().topControlsExpanded);
 
   get selectedTeamId(): string {
-    return this.settingsSubject.value.selectedTeamId;
+    return this.settingsSignal().selectedTeamId;
   }
 
   get startFromSeason(): number | undefined {
-    return this.settingsSubject.value.startFromSeason === null
-      ? undefined
-      : this.settingsSubject.value.startFromSeason;
+    return this.startFromSeasonSignal();
   }
 
   get season(): number | undefined {
-    return this.settingsSubject.value.season === null
-      ? undefined
-      : this.settingsSubject.value.season;
+    return this.normalizeOptionalSeason(this.settingsSignal().season);
   }
 
   get reportType(): ReportType {
-    return this.settingsSubject.value.reportType;
+    return this.settingsSignal().reportType;
   }
 
   setSelectedTeamId(teamId: string): void {
@@ -66,28 +54,28 @@ export class SettingsService {
 
   setStartFromSeason(season: number | undefined): void {
     const normalized = season === undefined ? null : season;
-    if (normalized === this.settingsSubject.value.startFromSeason) return;
+    if (normalized === this.settingsSignal().startFromSeason) return;
     this.updateSettings({ startFromSeason: normalized });
   }
 
   setTopControlsExpanded(expanded: boolean): void {
-    if (expanded === this.settingsSubject.value.topControlsExpanded) return;
+    if (expanded === this.settingsSignal().topControlsExpanded) return;
     this.updateSettings({ topControlsExpanded: expanded });
   }
 
   setSeason(season: number | null): void {
-    if (season === this.settingsSubject.value.season) return;
+    if (season === this.settingsSignal().season) return;
     this.updateSettings({ season });
   }
 
   setReportType(reportType: ReportType): void {
-    if (reportType === this.settingsSubject.value.reportType) return;
+    if (reportType === this.settingsSignal().reportType) return;
     this.updateSettings({ reportType });
   }
 
   private updateSettings(patch: Partial<AppSettings>): void {
-    const next: AppSettings = { ...this.settingsSubject.value, ...patch };
-    this.settingsSubject.next(next);
+    const next: AppSettings = { ...this.settingsSignal(), ...patch };
+    this.settingsState.set(next);
     this.persist(next);
   }
 


### PR DESCRIPTION
## Summary

This branch completes the two architecture and maintenance cleanup items from the roadmap as separate refactor commits.

## What changed

- Replaced the remaining manual `Subject<void>` + `takeUntil()` teardown patterns in:
  - `src/app/base/stats/stats-base.component.ts`
  - `src/app/player-route/player-route.component.ts`
  - `src/app/goalie-route/goalie-route.component.ts`
  - `src/app/career/players/career-players.component.ts`
  - `src/app/career/goalies/career-goalies.component.ts`
- Moved app-owned UI state in these services to signal-backed internal state:
  - `src/app/services/settings.service.ts`
  - `src/app/services/filter.service.ts`
  - `src/app/services/comparison.service.ts`
  - `src/app/services/drawer-context.service.ts`
- Kept the existing observable read APIs available for compatibility where current consumers still use them.
- Removed the now-completed architecture/maintenance follow-up items from `docs/roadmap.md`.
- Stabilized two app-shell behavior specs under coverage by giving lazy route/module waits explicit timeouts:
  - `src/app/app.component.spec.ts`
  - `src/app/app.component.mobile.spec.ts`

## Impact

- No intended user-facing behavior changes.
- Main impact is cleaner Angular 21 lifecycle/state patterns and less legacy RxJS-first service state.

## Testing

- Batch 1: `npm run verify`
- Batch 2: `npm run verify`
