### PR TITLE
Feature: Add entry draft played-status indicators

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,9 @@ The docs in this repo intentionally focus on project-specific architecture, work
 - 📝 **Draft Pages**: Standalone `/draft/entry-drafts`, `/draft/opening-draft`, and `/draft/statistics` browse routes now live under `Varaukset`
 	- Batch 1 adds the route shell, navigation, SEO, and the shared browse scaffolding
 	- Batch 2 turns `/draft/opening-draft` into a team-by-team accordion with simple pick rows, including traded-pick owner suffixes when the original pick belonged to another team
-	- Batch 3 turns `/draft/entry-drafts` into a matching team accordion with compact summary cards, round totals, and season-by-season entry draft history
-	- `Tilastot` reuses the shared paged `TableCardComponent` to rank teams across 10 entry-draft summary slices without a separate draft-only card implementation
+	- Batch 3 turns `/draft/entry-drafts` into a matching team accordion with compact summary cards, played-status totals, highest-pick highlights, and season-by-season entry draft history
+	- Entry-draft pick rows add `🟢` / `🟡` played-status markers to show whether a drafted player reached the drafting team or played elsewhere in the league
+	- `Tilastot` reuses the shared paged `TableCardComponent` to rank teams across 11 entry-draft summary slices without a separate draft-only card implementation
 - 🚦 **Split Route Shells**: Interactive dashboard routes lazy-load their heavier shell (controls, settings drawer, comparison bar, tabs), while career and leaderboard browsing routes stay on a lighter root shell
 - 🗂️ **Global Navigation**: Bottom sheet menu for switching between views (hockey stats, player careers, leaderboards, info/help)
 - 🔗 **Direct Player Links**: Shareable URLs for player/goalie cards

--- a/docs/project-overview.md
+++ b/docs/project-overview.md
@@ -95,7 +95,8 @@ Accessibility is a core requirement: the UI is designed to remain usable via key
    - Shares the lighter root-shell treatment used by other browse routes
    - Batch 1 provides the route family, tab navigation, subtitle/SEO integration, and browse-shell wiring
    - Batch 2 renders `/draft/opening-draft` as a Material accordion grouped by drafting team, with simple per-pick rows and a traded-owner suffix when the original pick came from another team
-   - Batch 3 renders `/draft/entry-drafts` as a matching team-grouped accordion, with per-team summary cards, round totals, and season-by-season pick lists that preserve null legacy player rows
+   - Batch 3 renders `/draft/entry-drafts` as a matching team-grouped accordion, with per-team summary cards, played-status totals, highest-pick highlights, and season-by-season pick lists that preserve null legacy player rows
+   - Entry-draft pick rows add `🟢` / `🟡` played-status markers to show whether a drafted player reached the drafting team or played elsewhere in the league
    - `/draft/statistics` reuses the shared card-table UI to rank teams across entry-draft summary metrics with local 10-row paging
 
 8. **Data Management**

--- a/e2e/fixtures/data/draft--entry.json
+++ b/e2e/fixtures/data/draft--entry.json
@@ -20,7 +20,9 @@
         "total": 4,
         "ownPicks": 3,
         "tradedPicks": 1,
-        "playersPerDraftAverage": 2
+        "playersPerDraftAverage": 2,
+        "playedInLeague": 2,
+        "playedForDraftingTeam": 1
       },
       "rounds": {
         "first": 2,
@@ -38,6 +40,8 @@
             "round": 1,
             "pickNumber": 4,
             "draftedPlayer": "Matthew Schaefer",
+            "playedInLeague": false,
+            "playedForDraftingTeam": false,
             "originalOwner": {
               "id": "1",
               "name": "Colorado Avalanche"
@@ -47,6 +51,8 @@
             "round": 2,
             "pickNumber": 28,
             "draftedPlayer": null,
+            "playedInLeague": false,
+            "playedForDraftingTeam": false,
             "originalOwner": {
               "id": "29",
               "name": "Dallas Stars"
@@ -61,6 +67,8 @@
             "round": 1,
             "pickNumber": 11,
             "draftedPlayer": "Tij Iginla",
+            "playedInLeague": true,
+            "playedForDraftingTeam": false,
             "originalOwner": {
               "id": "1",
               "name": "Colorado Avalanche"
@@ -70,6 +78,8 @@
             "round": 3,
             "pickNumber": 27,
             "draftedPlayer": "Jesse Pulkkinen",
+            "playedInLeague": true,
+            "playedForDraftingTeam": true,
             "originalOwner": {
               "id": "1",
               "name": "Colorado Avalanche"
@@ -100,7 +110,9 @@
         "total": 3,
         "ownPicks": 2,
         "tradedPicks": 1,
-        "playersPerDraftAverage": 1.5
+        "playersPerDraftAverage": 1.5,
+        "playedInLeague": 2,
+        "playedForDraftingTeam": 1
       },
       "rounds": {
         "first": 1,
@@ -118,6 +130,8 @@
             "round": 1,
             "pickNumber": 2,
             "draftedPlayer": "Michael Misa",
+            "playedInLeague": false,
+            "playedForDraftingTeam": false,
             "originalOwner": {
               "id": "29",
               "name": "Dallas Stars"
@@ -127,6 +141,8 @@
             "round": 2,
             "pickNumber": 14,
             "draftedPlayer": "Kashawn Aitcheson",
+            "playedInLeague": true,
+            "playedForDraftingTeam": false,
             "originalOwner": {
               "id": "16",
               "name": "Tampa Bay Lightning"
@@ -141,6 +157,8 @@
             "round": 3,
             "pickNumber": 21,
             "draftedPlayer": "Aron Kiviharju",
+            "playedInLeague": true,
+            "playedForDraftingTeam": true,
             "originalOwner": {
               "id": "29",
               "name": "Dallas Stars"

--- a/e2e/specs/career.spec.ts
+++ b/e2e/specs/career.spec.ts
@@ -6,6 +6,10 @@ import {
   CAREER_HIGHLIGHT_SECTION_LABELS,
   TAB_LABELS,
 } from '../config/test-data';
+import {
+  GENERAL_CAREER_HIGHLIGHT_CARD_TYPES,
+  TRANSACTION_CAREER_HIGHLIGHT_CARD_TYPES,
+} from '../../src/app/career/highlights/career-highlights.constants';
 
 test.describe('Career listings', () => {
   test('redirects /career to players, renders the table, switches to highlights, and then to goalie careers', async ({ page }) => {
@@ -30,20 +34,12 @@ test.describe('Career listings', () => {
     await expect(page).toHaveURL(/\/career\/highlights$/);
     await expect(highlightsTab).toHaveAttribute('aria-selected', 'true');
     const highlightCards = page.locator('app-table-card');
-    await expect(highlightCards).toHaveCount(7);
-    await expect(highlightCards.first().getByRole('table')).toBeVisible();
-    await highlightCards.nth(1).scrollIntoViewIfNeeded();
-    await expect(highlightCards.nth(1).getByRole('table')).toBeVisible();
-    await highlightCards.nth(2).scrollIntoViewIfNeeded();
-    await expect(highlightCards.nth(2).getByRole('table')).toBeVisible();
-    await highlightCards.nth(3).scrollIntoViewIfNeeded();
-    await expect(highlightCards.nth(3).getByRole('table')).toBeVisible();
-    await highlightCards.nth(4).scrollIntoViewIfNeeded();
-    await expect(highlightCards.nth(4).getByRole('table')).toBeVisible();
-    await highlightCards.nth(5).scrollIntoViewIfNeeded();
-    await expect(highlightCards.nth(5).getByRole('table')).toBeVisible();
-    await highlightCards.nth(6).scrollIntoViewIfNeeded();
-    await expect(highlightCards.nth(6).getByRole('table')).toBeVisible();
+    await expect(highlightCards).toHaveCount(GENERAL_CAREER_HIGHLIGHT_CARD_TYPES.length);
+    for (let index = 0; index < GENERAL_CAREER_HIGHLIGHT_CARD_TYPES.length; index += 1) {
+      const card = highlightCards.nth(index);
+      await card.scrollIntoViewIfNeeded();
+      await expect(card.getByRole('table')).toBeVisible();
+    }
 
     const nextPageButtons = page.getByRole('button', { name: 'Näytä seuraavat rivit' });
     let pagedCard: Locator | null = null;
@@ -95,7 +91,7 @@ test.describe('Career listings', () => {
     await expect(transactionsSection).toHaveAttribute('aria-checked', 'true');
 
     const highlightCards = page.locator('app-table-card');
-    await expect(highlightCards).toHaveCount(4);
+    await expect(highlightCards).toHaveCount(TRANSACTION_CAREER_HIGHLIGHT_CARD_TYPES.length);
     await expect(
       page.getByRole('heading', { name: CAREER_HIGHLIGHT_CARD_LABELS.MOST_TRADES })
     ).toBeVisible();
@@ -109,12 +105,10 @@ test.describe('Career listings', () => {
       page.getByRole('heading', { name: CAREER_HIGHLIGHT_CARD_LABELS.REUNION_KING })
     ).toBeVisible();
 
-    await expect(highlightCards.first().getByRole('table')).toBeVisible();
-    await highlightCards.nth(1).scrollIntoViewIfNeeded();
-    await expect(highlightCards.nth(1).getByRole('table')).toBeVisible();
-    await highlightCards.nth(2).scrollIntoViewIfNeeded();
-    await expect(highlightCards.nth(2).getByRole('table')).toBeVisible();
-    await highlightCards.nth(3).scrollIntoViewIfNeeded();
-    await expect(highlightCards.nth(3).getByRole('table')).toBeVisible();
+    for (let index = 0; index < TRANSACTION_CAREER_HIGHLIGHT_CARD_TYPES.length; index += 1) {
+      const card = highlightCards.nth(index);
+      await card.scrollIntoViewIfNeeded();
+      await expect(card.getByRole('table')).toBeVisible();
+    }
   });
 });

--- a/e2e/specs/draft.spec.ts
+++ b/e2e/specs/draft.spec.ts
@@ -3,6 +3,7 @@ import type { Page } from '@playwright/test';
 import { test, expect } from '../fixtures/test-fixture';
 import { NAV_LABELS, TAB_LABELS } from '../config/test-data';
 import { fi } from '../config/i18n';
+import { DRAFT_STATISTICS_CARD_IDS } from '../../src/app/draft/statistics/draft-statistics.constants';
 
 function waitForOpeningDraftResponse(page: Page) {
   return page.waitForResponse(
@@ -26,7 +27,7 @@ async function expectStatisticsContent(page: Page) {
   });
   const pageSummary = firstCard.locator('.page-summary');
 
-  await expect(cards).toHaveCount(10);
+  await expect(cards).toHaveCount(DRAFT_STATISTICS_CARD_IDS.length);
   await expect(
     firstCard.getByRole('heading', {
       name: fi('draft.statistics.cards.totalPicks.title'),

--- a/public/i18n/fi.json
+++ b/public/i18n/fi.json
@@ -100,7 +100,8 @@
         "team": "Joukkue",
         "pickCount": "Varaukset",
         "average": "Keskiarvo",
-        "turn": "Vuoro"
+        "turn": "Vuoro",
+        "players": "Pelaajat"
       },
       "cards": {
         "totalPicks": {
@@ -122,6 +123,10 @@
         "averagePosition": {
           "title": "Paras vuorojen keskiarvo",
           "description": "Paras varattujen vuorojen keskiarvo."
+        },
+        "playedInLeague": {
+          "title": "Eniten pelanneita varauksia",
+          "description": "Varatut pelaajat, joilla on otteluita ylhäällä."
         },
         "roundOne": {
           "title": "Eniten 1. kierroksen varauksia",
@@ -147,12 +152,17 @@
     },
     "entryDrafts": {
       "summaryHeading": "Yhteenveto",
+      "playedHeading": "Pelanneet varaukset",
       "averageDraftPositionLabel": "Keskimääräinen vuoro",
       "noAverageDraftPosition": "Ei tiedossa",
       "totalPicksLabel": "Varattu pelaajia",
       "ownPicksLabel": "Omilla vuoroilla",
       "tradedPicksLabel": "Treidatuilla vuoroilla",
       "playersPerDraftAverageLabel": "Varausta / draft",
+      "playedInLeagueLabel": "Liigassa",
+      "playedForDraftingTeamLabel": "Varaajajoukkueessa",
+      "playedInLeagueTooltip": "Pelannut muualla",
+      "playedForDraftingTeamTooltip": "Pelannut varaajajoukkueessa",
       "highestPickHeading": "Korkeimmalla varattu",
       "noHighestPick": "Ei varaustietoa",
       "roundsHeading": "Varaukset kierroksittain",

--- a/src/app/career/highlights/career-highlights.component.spec.ts
+++ b/src/app/career/highlights/career-highlights.component.spec.ts
@@ -19,6 +19,9 @@ import {
   sameTeamSeasonsOwnedHighlightsPage0Fixture,
   sameTeamSeasonsHighlightsPage0Fixture,
 } from '../../testing/behavior-test-utils';
+import {
+  GENERAL_CAREER_HIGHLIGHT_CARD_TYPES,
+} from './career-highlights.constants';
 import { CareerHighlightsComponent } from './career-highlights.component';
 
 class FakeIntersectionObserver {
@@ -164,11 +167,11 @@ describe('CareerHighlightsComponent', () => {
     ).toBeInTheDocument();
 
     await vi.waitFor(() => {
-      expect(FakeIntersectionObserver.instances).toHaveLength(7);
+      expect(FakeIntersectionObserver.instances).toHaveLength(GENERAL_CAREER_HIGHLIGHT_CARD_TYPES.length);
     });
 
     expect(getCareerHighlights).not.toHaveBeenCalled();
-    expect(screen.getAllByText('tableCard.loadWhenVisible')).toHaveLength(7);
+    expect(screen.getAllByText('tableCard.loadWhenVisible')).toHaveLength(GENERAL_CAREER_HIGHLIGHT_CARD_TYPES.length);
 
     FakeIntersectionObserver.instances[0]?.trigger();
     FakeIntersectionObserver.instances[2]?.trigger();
@@ -254,7 +257,7 @@ describe('CareerHighlightsComponent', () => {
     });
 
     await vi.waitFor(() => {
-      expect(FakeIntersectionObserver.instances).toHaveLength(7);
+      expect(FakeIntersectionObserver.instances).toHaveLength(GENERAL_CAREER_HIGHLIGHT_CARD_TYPES.length);
     });
 
     fireEvent.click(

--- a/src/app/career/highlights/career-highlights.component.ts
+++ b/src/app/career/highlights/career-highlights.component.ts
@@ -32,12 +32,15 @@ import { TableCardRow } from '@shared/table-card/table-card.types';
 import { formatPlayoffYear } from '@shared/utils/season.utils';
 
 import { ActivateOnViewportDirective } from './activate-on-viewport.directive';
+import {
+  CAREER_HIGHLIGHT_CARD_TYPES_BY_SECTION,
+  CareerHighlightSection,
+  CareerHighlightsUiType,
+} from './career-highlights.constants';
 import { formatReunionDetailLines } from './career-highlights.utils';
 import {
   CareerHighlightCardState,
   CareerHighlightCardView,
-  CareerHighlightSection,
-  CareerHighlightsUiType,
   HighlightDescriptionParams,
 } from './career-highlights.types';
 
@@ -154,18 +157,23 @@ const MOST_DROPS_CONFIG: HighlightCardConfig = {
   valueColumnLabelKey: '❌',
 };
 
+const highlightCardConfigsByType: Record<CareerHighlightsUiType, HighlightCardConfig> = {
+  'most-stanley-cups': MOST_STANLEY_CUPS_CONFIG,
+  'regular-grinder-without-playoffs': REGULAR_GRINDER_WITHOUT_PLAYOFFS_CONFIG,
+  'most-teams-played': MOST_TEAMS_PLAYED_CONFIG,
+  'most-teams-owned': MOST_TEAMS_OWNED_CONFIG,
+  'same-team-seasons-played': SAME_TEAM_SEASONS_PLAYED_CONFIG,
+  'same-team-seasons-owned': SAME_TEAM_SEASONS_OWNED_CONFIG,
+  'stash-king': STASH_KING_CONFIG,
+  'most-trades': MOST_TRADES_CONFIG,
+  'most-claims': MOST_CLAIMS_CONFIG,
+  'most-drops': MOST_DROPS_CONFIG,
+  'reunion-king': REUNION_KING_CONFIG,
+};
+
 const HIGHLIGHT_CARD_CONFIGS: readonly HighlightCardConfig[] = [
-  MOST_STANLEY_CUPS_CONFIG,
-  REGULAR_GRINDER_WITHOUT_PLAYOFFS_CONFIG,
-  MOST_TEAMS_PLAYED_CONFIG,
-  MOST_TEAMS_OWNED_CONFIG,
-  SAME_TEAM_SEASONS_PLAYED_CONFIG,
-  SAME_TEAM_SEASONS_OWNED_CONFIG,
-  STASH_KING_CONFIG,
-  MOST_TRADES_CONFIG,
-  MOST_CLAIMS_CONFIG,
-  MOST_DROPS_CONFIG,
-  REUNION_KING_CONFIG,
+  ...CAREER_HIGHLIGHT_CARD_TYPES_BY_SECTION.general.map((type) => highlightCardConfigsByType[type]),
+  ...CAREER_HIGHLIGHT_CARD_TYPES_BY_SECTION.transactions.map((type) => highlightCardConfigsByType[type]),
 ];
 
 function createInitialCardState(

--- a/src/app/career/highlights/career-highlights.constants.ts
+++ b/src/app/career/highlights/career-highlights.constants.ts
@@ -1,0 +1,29 @@
+export const GENERAL_CAREER_HIGHLIGHT_CARD_TYPES = [
+  'most-stanley-cups',
+  'regular-grinder-without-playoffs',
+  'most-teams-played',
+  'most-teams-owned',
+  'same-team-seasons-played',
+  'same-team-seasons-owned',
+  'stash-king',
+] as const;
+
+export const TRANSACTION_CAREER_HIGHLIGHT_CARD_TYPES = [
+  'most-trades',
+  'most-claims',
+  'most-drops',
+  'reunion-king',
+] as const;
+
+export const CAREER_HIGHLIGHT_CARD_TYPES_BY_SECTION = {
+  general: GENERAL_CAREER_HIGHLIGHT_CARD_TYPES,
+  transactions: TRANSACTION_CAREER_HIGHLIGHT_CARD_TYPES,
+} as const;
+
+export const CAREER_HIGHLIGHT_CARD_TYPES = [
+  ...GENERAL_CAREER_HIGHLIGHT_CARD_TYPES,
+  ...TRANSACTION_CAREER_HIGHLIGHT_CARD_TYPES,
+] as const;
+
+export type CareerHighlightSection = keyof typeof CAREER_HIGHLIGHT_CARD_TYPES_BY_SECTION;
+export type CareerHighlightsUiType = (typeof CAREER_HIGHLIGHT_CARD_TYPES)[number];

--- a/src/app/career/highlights/career-highlights.types.ts
+++ b/src/app/career/highlights/career-highlights.types.ts
@@ -1,8 +1,10 @@
-import { CareerHighlightType } from '@services/api.service';
 import { TableCardRow } from '@shared/table-card/table-card.types';
+import type { CareerHighlightsUiType } from './career-highlights.constants';
 
-export type CareerHighlightsUiType = CareerHighlightType;
-export type CareerHighlightSection = 'general' | 'transactions';
+export type {
+  CareerHighlightSection,
+  CareerHighlightsUiType,
+} from './career-highlights.constants';
 export type HighlightDescriptionParams = Readonly<Record<string, number | string>>;
 
 export interface CareerHighlightCardState {

--- a/src/app/draft/entry-drafts/entry-drafts.component.html
+++ b/src/app/draft/entry-drafts/entry-drafts.component.html
@@ -4,185 +4,215 @@
   </h3>
 
   @if (loading) {
-    <p class="draft-status" role="status" aria-live="polite" tabindex="-1" data-skip-focus="true">
-      {{ 'draft.loading' | translate }}
-    </p>
+  <p class="draft-status" role="status" aria-live="polite" tabindex="-1" data-skip-focus="true">
+    {{ 'draft.loading' | translate }}
+  </p>
   } @else if (apiError) {
-    <p class="draft-status draft-status--error" role="alert" tabindex="-1" data-skip-focus="true">
-      {{ 'draft.apiUnavailable' | translate }}
-    </p>
+  <p class="draft-status draft-status--error" role="alert" tabindex="-1" data-skip-focus="true">
+    {{ 'draft.apiUnavailable' | translate }}
+  </p>
   } @else if (groups.length === 0) {
-    <p class="draft-status" tabindex="-1" data-skip-focus="true">
-      {{ 'draft.noResults' | translate }}
-    </p>
+  <p class="draft-status" tabindex="-1" data-skip-focus="true">
+    {{ 'draft.noResults' | translate }}
+  </p>
   } @else {
-    <mat-accordion class="draft-accordion" displayMode="flat">
-      @for (group of groups; track group.team.id) {
-        <mat-expansion-panel class="draft-panel">
-          <mat-expansion-panel-header class="draft-panel-header">
-            <mat-panel-title class="draft-panel-title">
-              {{ group.team.name }}
-            </mat-panel-title>
-          </mat-expansion-panel-header>
+  <mat-accordion class="draft-accordion" displayMode="flat">
+    @for (group of groups; track group.team.id) {
+    <mat-expansion-panel class="draft-panel">
+      <mat-expansion-panel-header class="draft-panel-header">
+        <mat-panel-title class="draft-panel-title">
+          {{ group.team.name }}
+        </mat-panel-title>
+      </mat-expansion-panel-header>
 
-          <div class="entry-draft-panel-content">
-            <section class="entry-summary" aria-labelledby="entry-summary-heading-{{ group.team.id }}">
-              <h4 class="entry-section-title" id="entry-summary-heading-{{ group.team.id }}">
-                {{ 'draft.entryDrafts.summaryHeading' | translate }}
-              </h4>
+      <div class="entry-draft-panel-content">
+        <section class="entry-summary" aria-labelledby="entry-summary-heading-{{ group.team.id }}">
+          <h4 class="entry-section-title" id="entry-summary-heading-{{ group.team.id }}">
+            {{ 'draft.entryDrafts.summaryHeading' | translate }}
+          </h4>
 
-              <div class="entry-summary-grid">
-                <article class="entry-summary-card entry-summary-card--wide">
-                  <div class="entry-summary-stats">
-                    <div class="entry-summary-stat">
-                      <span class="entry-summary-label">
-                        {{ 'draft.entryDrafts.totalPicksLabel' | translate }}
-                      </span>
-                      <strong class="entry-summary-value">{{ group.summary.amounts.total }}</strong>
-                    </div>
-
-                    <div class="entry-summary-stat">
-                      <span class="entry-summary-label">
-                        {{ 'draft.entryDrafts.ownPicksLabel' | translate }}
-                      </span>
-                      <strong class="entry-summary-value">{{ group.summary.amounts.ownPicks }}</strong>
-                    </div>
-
-                    <div class="entry-summary-stat">
-                      <span class="entry-summary-label">
-                        {{ 'draft.entryDrafts.tradedPicksLabel' | translate }}
-                      </span>
-                      <strong class="entry-summary-value">{{ group.summary.amounts.tradedPicks }}</strong>
-                    </div>
-
-                    <div class="entry-summary-stat">
-                      <span class="entry-summary-label">
-                        {{ 'draft.entryDrafts.playersPerDraftAverageLabel' | translate }}
-                      </span>
-                      <strong class="entry-summary-value">
-                        {{ group.summary.amounts.playersPerDraftAverage | number: '1.0-2' : 'fi' }}
-                      </strong>
-                    </div>
-
-                    <div class="entry-summary-stat">
-                      <span class="entry-summary-label">
-                        {{ 'draft.entryDrafts.averageDraftPositionLabel' | translate }}
-                      </span>
-                      <strong class="entry-summary-value">
-                        @if (group.summary.averageDraftPosition !== null) {
-                          {{ group.summary.averageDraftPosition | number: '1.0-2' : 'fi' }}
-                        } @else {
-                          {{ 'draft.entryDrafts.noAverageDraftPosition' | translate }}
-                        }
-                      </strong>
-                    </div>
-                  </div>
-                </article>
-
-                <article class="entry-summary-card">
-                  <h5 class="entry-summary-card-title">
-                    {{ 'draft.entryDrafts.roundsHeading' | translate }}
-                  </h5>
-
-                  <div class="entry-rounds-grid">
-                    <div class="entry-round-item">
-                      <span class="entry-round-label">{{ 'draft.entryDrafts.roundOneLabel' | translate }}</span>
-                      <strong class="entry-round-value">{{ group.summary.rounds.first }}</strong>
-                    </div>
-                    <div class="entry-round-item">
-                      <span class="entry-round-label">{{ 'draft.entryDrafts.roundTwoLabel' | translate }}</span>
-                      <strong class="entry-round-value">{{ group.summary.rounds.second }}</strong>
-                    </div>
-                    <div class="entry-round-item">
-                      <span class="entry-round-label">{{ 'draft.entryDrafts.roundThreeLabel' | translate }}</span>
-                      <strong class="entry-round-value">{{ group.summary.rounds.third }}</strong>
-                    </div>
-                    <div class="entry-round-item">
-                      <span class="entry-round-label">{{ 'draft.entryDrafts.roundFourLabel' | translate }}</span>
-                      <strong class="entry-round-value">{{ group.summary.rounds.fourth }}</strong>
-                    </div>
-                    <div class="entry-round-item">
-                      <span class="entry-round-label">{{ 'draft.entryDrafts.roundFiveLabel' | translate }}</span>
-                      <strong class="entry-round-value">{{ group.summary.rounds.fifth }}</strong>
-                    </div>
-                  </div>
-                </article>
-
-                <article class="entry-summary-card">
-                  <h5 class="entry-summary-card-title">
-                    {{ 'draft.entryDrafts.highestPickHeading' | translate }}
-                  </h5>
-
-                  @if (group.summary.highestPick; as highestPick) {
-                    <p class="entry-highlight-value">
-                      {{ 'draft.entryDrafts.turnLabel' | translate }} {{ highestPick.pickNumber }}
-                    </p>
-                    <p class="entry-highlight-summary">
-                      @for (item of highestPick.items; track item.season + '-' + item.draftedPlayer; let isLast = $last) {
-                        <span>{{ item.season }} {{ item.draftedPlayer }}</span>@if (!isLast) {<span>, </span>}
-                      }
-                    </p>
-                  } @else {
-                    <p class="entry-summary-empty">
-                      {{ 'draft.entryDrafts.noHighestPick' | translate }}
-                    </p>
-                  }
-                </article>
-              </div>
-            </section>
-
-            <section class="entry-seasons" aria-labelledby="entry-seasons-heading-{{ group.team.id }}">
-              <h4 class="entry-section-title" id="entry-seasons-heading-{{ group.team.id }}">
-                {{ 'draft.entryDrafts.seasonsHeading' | translate }}
-              </h4>
-
-              @if (group.seasons.length === 0) {
-                <p class="entry-season-empty">{{ 'draft.noResults' | translate }}</p>
-              } @else {
-                <div class="entry-season-list">
-                  @for (season of group.seasons; track season.season) {
-                    <section class="entry-season" aria-labelledby="entry-season-title-{{ group.team.id }}-{{ season.season }}">
-                      <h5 class="entry-season-title" id="entry-season-title-{{ group.team.id }}-{{ season.season }}">
-                        {{ season.season }}
-                      </h5>
-
-                      <mat-list class="draft-pick-list" role="list">
-                        @for (pick of season.picks; track pick.pickNumber; let pickIndex = $index) {
-                          <div class="draft-pick-item" role="listitem">
-                            <div class="draft-pick-row">
-                              <span class="draft-pick-tag">
-                                {{ 'draft.entryDrafts.selectionLabel' | translate }} {{ pickIndex + 1 }}
-                              </span>
-                              <span class="draft-pick-tag">
-                                {{ 'draft.entryDrafts.roundLabel' | translate }} {{ pick.round }}
-                              </span>
-                              <span class="draft-pick-tag">
-                                {{ 'draft.entryDrafts.turnLabel' | translate }} {{ pick.pickNumber }}
-                              </span>
-                              <span
-                                class="draft-pick-player"
-                                [class.draft-pick-player--missing]="pick.draftedPlayer === null"
-                              >
-                                {{ pick.draftedPlayer ?? ('draft.entryDrafts.unknownPlayerLabel' | translate) }}
-                              </span>
-                              @if (isTradedPick(group.team, pick)) {
-                                <span class="draft-pick-origin">
-                                  {{ 'draft.entryDrafts.originalOwnerLabel' | translate }}
-                                  <span class="draft-pick-origin-team">{{ pick.originalOwner.name }}</span>
-                                </span>
-                              }
-                            </div>
-                          </div>
-                        }
-                      </mat-list>
-                    </section>
-                  }
+          <div class="entry-summary-grid">
+            <article class="entry-summary-card entry-summary-card--wide">
+              <div class="entry-summary-stats">
+                <div class="entry-summary-stat">
+                  <span class="entry-summary-label">
+                    {{ 'draft.entryDrafts.totalPicksLabel' | translate }}
+                  </span>
+                  <strong class="entry-summary-value">{{ group.summary.amounts.total }}</strong>
                 </div>
-              }
-            </section>
+
+                <div class="entry-summary-stat">
+                  <span class="entry-summary-label">
+                    {{ 'draft.entryDrafts.ownPicksLabel' | translate }}
+                  </span>
+                  <strong class="entry-summary-value">{{ group.summary.amounts.ownPicks }}</strong>
+                </div>
+
+                <div class="entry-summary-stat">
+                  <span class="entry-summary-label">
+                    {{ 'draft.entryDrafts.tradedPicksLabel' | translate }}
+                  </span>
+                  <strong class="entry-summary-value">{{ group.summary.amounts.tradedPicks }}</strong>
+                </div>
+
+                <div class="entry-summary-stat">
+                  <span class="entry-summary-label">
+                    {{ 'draft.entryDrafts.playersPerDraftAverageLabel' | translate }}
+                  </span>
+                  <strong class="entry-summary-value">
+                    {{ group.summary.amounts.playersPerDraftAverage | number: '1.0-2' : 'fi' }}
+                  </strong>
+                </div>
+
+                <div class="entry-summary-stat">
+                  <span class="entry-summary-label">
+                    {{ 'draft.entryDrafts.averageDraftPositionLabel' | translate }}
+                  </span>
+                  <strong class="entry-summary-value">
+                    @if (group.summary.averageDraftPosition !== null) {
+                    {{ group.summary.averageDraftPosition | number: '1.0-2' : 'fi' }}
+                    } @else {
+                    {{ 'draft.entryDrafts.noAverageDraftPosition' | translate }}
+                    }
+                  </strong>
+                </div>
+              </div>
+            </article>
+
+            <article class="entry-summary-card">
+              <h5 class="entry-summary-card-title">
+                {{ 'draft.entryDrafts.roundsHeading' | translate }}
+              </h5>
+
+              <div class="entry-rounds-grid">
+                <div class="entry-round-item">
+                  <span class="entry-round-label">{{ 'draft.entryDrafts.roundOneLabel' | translate }}</span>
+                  <strong class="entry-round-value">{{ group.summary.rounds.first }}</strong>
+                </div>
+                <div class="entry-round-item">
+                  <span class="entry-round-label">{{ 'draft.entryDrafts.roundTwoLabel' | translate }}</span>
+                  <strong class="entry-round-value">{{ group.summary.rounds.second }}</strong>
+                </div>
+                <div class="entry-round-item">
+                  <span class="entry-round-label">{{ 'draft.entryDrafts.roundThreeLabel' | translate }}</span>
+                  <strong class="entry-round-value">{{ group.summary.rounds.third }}</strong>
+                </div>
+                <div class="entry-round-item">
+                  <span class="entry-round-label">{{ 'draft.entryDrafts.roundFourLabel' | translate }}</span>
+                  <strong class="entry-round-value">{{ group.summary.rounds.fourth }}</strong>
+                </div>
+                <div class="entry-round-item">
+                  <span class="entry-round-label">{{ 'draft.entryDrafts.roundFiveLabel' | translate }}</span>
+                  <strong class="entry-round-value">{{ group.summary.rounds.fifth }}</strong>
+                </div>
+              </div>
+            </article>
+
+            <article class="entry-summary-card">
+              <h5 class="entry-summary-card-title">
+                {{ 'draft.entryDrafts.playedHeading' | translate }}
+              </h5>
+
+              <div class="entry-played-grid">
+                <div class="entry-played-item">
+                  <span class="entry-played-label">
+                    {{ 'draft.entryDrafts.playedInLeagueLabel' | translate }}
+                  </span>
+                  <strong class="entry-played-value">
+                    {{ group.summary.amounts.playedInLeague }}
+                  </strong>
+                </div>
+
+                <div class="entry-played-item">
+                  <span class="entry-played-label">
+                    {{ 'draft.entryDrafts.playedForDraftingTeamLabel' | translate }}
+                  </span>
+                  <strong class="entry-played-value">
+                    {{ group.summary.amounts.playedForDraftingTeam }}
+                  </strong>
+                </div>
+              </div>
+            </article>
           </div>
-        </mat-expansion-panel>
-      }
-    </mat-accordion>
+
+          <section class="entry-highlight-strip" aria-labelledby="entry-highlight-heading-{{ group.team.id }}">
+            <h5 class="entry-highlight-label" id="entry-highlight-heading-{{ group.team.id }}">
+              {{ 'draft.entryDrafts.highestPickHeading' | translate }}
+            </h5>
+
+            @if (group.summary.highestPick; as highestPick) {
+            <p class="entry-highlight-text">
+              <span class="entry-highlight-turn">
+                {{ 'draft.entryDrafts.turnLabel' | translate }} {{ highestPick.pickNumber }}:
+              </span>
+              @for (item of highestPick.items; track item.season + '-' + item.draftedPlayer; let isLast = $last) {
+              <span>{{ item.season }} {{ item.draftedPlayer }}</span>@if (!isLast) {<span>, </span>}
+              }
+            </p>
+            } @else {
+            <p class="entry-summary-empty">
+              {{ 'draft.entryDrafts.noHighestPick' | translate }}
+            </p>
+            }
+          </section>
+        </section>
+
+        <section class="entry-seasons" aria-labelledby="entry-seasons-heading-{{ group.team.id }}">
+          <h4 class="entry-section-title" id="entry-seasons-heading-{{ group.team.id }}">
+            {{ 'draft.entryDrafts.seasonsHeading' | translate }}
+          </h4>
+
+          @if (group.seasons.length === 0) {
+          <p class="entry-season-empty">{{ 'draft.noResults' | translate }}</p>
+          } @else {
+          <div class="entry-season-list">
+            @for (season of group.seasons; track season.season) {
+            <section class="entry-season" aria-labelledby="entry-season-title-{{ group.team.id }}-{{ season.season }}">
+              <h5 class="entry-season-title" id="entry-season-title-{{ group.team.id }}-{{ season.season }}">
+                {{ season.season }}
+              </h5>
+
+              <mat-list class="draft-pick-list" role="list">
+                @for (pick of season.picks; track pick.pickNumber; let pickIndex = $index) {
+                <div class="draft-pick-item" role="listitem">
+                  <div class="draft-pick-row">
+                    <span class="draft-pick-tag">
+                      {{ 'draft.entryDrafts.selectionLabel' | translate }} {{ pickIndex + 1 }}
+                    </span>
+                    <span class="draft-pick-tag">
+                      {{ 'draft.entryDrafts.roundLabel' | translate }} {{ pick.round }}
+                    </span>
+                    <span class="draft-pick-tag">
+                      {{ 'draft.entryDrafts.turnLabel' | translate }} {{ pick.pickNumber }}
+                    </span>
+                    <span class="draft-pick-player" [class.draft-pick-player--missing]="pick.draftedPlayer === null">
+                      <span>{{ pick.draftedPlayer ?? ('draft.entryDrafts.unknownPlayerLabel' | translate) }}</span>
+                      @if (getPickStatus(pick); as pickStatus) {
+                      <span class="draft-pick-status-badge" [matTooltip]="pickStatus.tooltipKey | translate"
+                        aria-hidden="true">
+                        {{ pickStatus.emoji }}
+                      </span>
+                      <span class="sr-only">{{ pickStatus.tooltipKey | translate }}</span>
+                      }
+                    </span>
+                    @if (isTradedPick(group.team, pick)) {
+                    <span class="draft-pick-origin">
+                      {{ 'draft.entryDrafts.originalOwnerLabel' | translate }}
+                      <span class="draft-pick-origin-team">{{ pick.originalOwner.name }}</span>
+                    </span>
+                    }
+                  </div>
+                </div>
+                }
+              </mat-list>
+            </section>
+            }
+          </div>
+          }
+        </section>
+      </div>
+    </mat-expansion-panel>
+    }
+  </mat-accordion>
   }
 </section>

--- a/src/app/draft/entry-drafts/entry-drafts.component.scss
+++ b/src/app/draft/entry-drafts/entry-drafts.component.scss
@@ -48,7 +48,8 @@
 }
 
 .entry-summary-stat,
-.entry-round-item {
+.entry-round-item,
+.entry-played-item {
   display: grid;
   gap: 0.2rem;
   padding: 0.6rem 0.7rem;
@@ -57,7 +58,8 @@
 }
 
 .entry-summary-label,
-.entry-round-label {
+.entry-round-label,
+.entry-played-label {
   color: var(--mat-sys-on-surface-variant);
   font-size: 0.74rem;
   font-weight: 600;
@@ -65,27 +67,18 @@
 }
 
 .entry-summary-value,
-.entry-round-value {
+.entry-round-value,
+.entry-played-value {
   color: var(--mat-sys-on-surface);
   font-size: 1rem;
   font-weight: 700;
   line-height: 1.2;
 }
 
-.entry-highlight-value {
-  margin: 0 0 0.45rem;
-  color: var(--mat-sys-on-surface);
-  font-size: 1.05rem;
-  font-weight: 700;
-}
-
-.entry-highlight-summary {
-  margin: 0;
-  color: var(--mat-sys-on-surface);
-  font-size: 0.8rem;
-  font-weight: 500;
-  line-height: 1.45;
-  overflow-wrap: anywhere;
+.entry-played-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(132px, 1fr));
+  gap: 0.4rem;
 }
 
 .entry-summary-empty,
@@ -101,6 +94,40 @@
   gap: 0.4rem;
 }
 
+.entry-highlight-strip {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 0.3rem 0.6rem;
+  margin-top: 0.75rem;
+  padding: 0.7rem 1rem;
+  border: 1px solid var(--mat-sys-outline-variant);
+  border-radius: 0.95rem;
+  background: var(--mat-sys-surface-container-lowest);
+}
+
+.entry-highlight-label {
+  margin: 0;
+  color: var(--mat-sys-on-surface-variant);
+  font-size: 0.76rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.entry-highlight-text {
+  margin: 0;
+  color: var(--mat-sys-on-surface);
+  font-size: 0.88rem;
+  line-height: 1.45;
+  overflow-wrap: anywhere;
+}
+
+.entry-highlight-turn {
+  font-weight: 600;
+  white-space: nowrap;
+}
+
 .entry-season-list {
   display: grid;
   gap: 0.75rem;
@@ -111,11 +138,9 @@
   border-radius: 1rem;
   padding: 0.8rem 1rem 0.2rem;
   background:
-    linear-gradient(
-      180deg,
+    linear-gradient(180deg,
       color-mix(in srgb, var(--mat-sys-surface-container) 70%, transparent) 0%,
-      var(--mat-sys-surface-container-lowest) 100%
-    );
+      var(--mat-sys-surface-container-lowest) 100%);
 }
 
 .entry-season-title {
@@ -128,6 +153,15 @@
 .draft-pick-player--missing {
   color: var(--mat-sys-on-surface-variant);
   font-weight: 500;
+}
+
+.draft-pick-status-badge {
+  display: inline-flex;
+  align-items: center;
+  margin-inline-start: 0.35rem;
+  font-size: 0.95rem;
+  line-height: 1;
+  vertical-align: middle;
 }
 
 @media (max-width: 720px) {
@@ -146,7 +180,8 @@
   }
 
   .entry-summary-card,
-  .entry-season {
+  .entry-season,
+  .entry-highlight-strip {
     padding-inline: 0.9rem;
   }
 }

--- a/src/app/draft/entry-drafts/entry-drafts.component.spec.ts
+++ b/src/app/draft/entry-drafts/entry-drafts.component.spec.ts
@@ -36,6 +36,8 @@ const entryDraftGroupsFixture: EntryDraftTeamGroup[] = [
         ownPicks: 52,
         tradedPicks: 12,
         playersPerDraftAverage: 4.92,
+        playedInLeague: 2,
+        playedForDraftingTeam: 1,
       },
       rounds: {
         first: 13,
@@ -53,12 +55,16 @@ const entryDraftGroupsFixture: EntryDraftTeamGroup[] = [
             round: 4,
             pickNumber: 116,
             draftedPlayer: 'Brett Pesce',
+            playedInLeague: true,
+            playedForDraftingTeam: true,
             originalOwner: { id: '6', name: 'Detroit Red Wings' },
           },
           {
             round: 5,
             pickNumber: 129,
             draftedPlayer: null,
+            playedInLeague: false,
+            playedForDraftingTeam: false,
             originalOwner: { id: '4', name: 'Vancouver Canucks' },
           },
         ],
@@ -70,12 +76,16 @@ const entryDraftGroupsFixture: EntryDraftTeamGroup[] = [
             round: 1,
             pickNumber: 22,
             draftedPlayer: 'Cameron Reid',
+            playedInLeague: false,
+            playedForDraftingTeam: false,
             originalOwner: { id: '12', name: 'Anaheim Ducks' },
           },
           {
             round: 1,
             pickNumber: 29,
             draftedPlayer: 'Blake Fiddler',
+            playedInLeague: true,
+            playedForDraftingTeam: false,
             originalOwner: { id: '1', name: 'Colorado Avalanche' },
           },
         ],
@@ -92,6 +102,8 @@ const entryDraftGroupsFixture: EntryDraftTeamGroup[] = [
         ownPicks: 0,
         tradedPicks: 0,
         playersPerDraftAverage: 0,
+        playedInLeague: 0,
+        playedForDraftingTeam: 0,
       },
       rounds: {
         first: 0,
@@ -160,17 +172,21 @@ describe('EntryDraftsComponent', () => {
     const firstPanelQueries = within(firstPanelElement);
 
     expect(firstPanelQueries.getByText('draft.entryDrafts.summaryHeading')).toBeInTheDocument();
+    expect(firstPanelQueries.getByText('draft.entryDrafts.playedHeading')).toBeInTheDocument();
     expect(firstPanelQueries.getByText('draft.entryDrafts.highestPickHeading')).toBeInTheDocument();
     expect(firstPanelQueries.getByText('draft.entryDrafts.roundsHeading')).toBeInTheDocument();
-    expect(firstPanelQueries.getByText('draft.entryDrafts.turnLabel 8')).toBeInTheDocument();
-    expect(firstPanelQueries.getByText('Blake Fiddler')).toBeInTheDocument();
+    expect(firstPanelQueries.getByText(/draft\.entryDrafts\.turnLabel 8:?/)).toBeInTheDocument();
+    expect(firstPanelQueries.getByText(/Blake Fiddler/)).toBeInTheDocument();
     expect(firstPanelQueries.getByText('draft.entryDrafts.unknownPlayerLabel')).toBeInTheDocument();
     expect(firstPanelQueries.getAllByText(/draft\.entryDrafts\.originalOwnerLabel/)).toHaveLength(3);
     expect(firstPanelQueries.getByText('Colorado Avalanche')).toBeInTheDocument();
     expect(firstPanelQueries.getByText('Detroit Red Wings')).toBeInTheDocument();
     expect(firstPanelQueries.getByText('Vancouver Canucks')).toBeInTheDocument();
 
-    const highestPickSummary = firstPanelElement.querySelector('.entry-highlight-summary')?.textContent?.trim();
+    expect(firstPanelQueries.getByText('draft.entryDrafts.playedInLeagueLabel')).toBeInTheDocument();
+    expect(firstPanelQueries.getByText('draft.entryDrafts.playedForDraftingTeamLabel')).toBeInTheDocument();
+
+    const highestPickSummary = firstPanelElement.querySelector('.entry-highlight-text')?.textContent?.trim();
     expect(highestPickSummary).toContain('2015 Ivan Provorov');
     expect(highestPickSummary).toContain('2013 Max Domi');
     expect(highestPickSummary).not.toContain('draft.entryDrafts.roundLabel');
@@ -179,6 +195,11 @@ describe('EntryDraftsComponent', () => {
       .map((element) => element.textContent?.trim())
       .filter((value): value is string => Boolean(value));
     expect(summaryValues).toEqual(expect.arrayContaining(['82,89', '64', '52', '12', '4,92']));
+
+    const playedValues = Array.from(firstPanelElement.querySelectorAll('.entry-played-value'))
+      .map((element) => element.textContent?.trim())
+      .filter((value): value is string => Boolean(value));
+    expect(playedValues).toEqual(['2', '1']);
 
     const roundValues = Array.from(firstPanelElement.querySelectorAll('.entry-round-value'))
       .map((element) => element.textContent?.trim())
@@ -189,6 +210,28 @@ describe('EntryDraftsComponent', () => {
       .map((element) => element.textContent?.trim())
       .filter((value): value is string => Boolean(value));
     expect(seasonTitles).toEqual(['2025', '2013']);
+
+    const statusBadges = Array.from(firstPanelElement.querySelectorAll('.draft-pick-status-badge'))
+      .map((element) => element.textContent?.trim());
+    expect(statusBadges).toEqual(['🟡', '🟢']);
+
+    const pickPlayerTexts = Array.from(firstPanelElement.querySelectorAll('.draft-pick-player'))
+      .map((element) => element.textContent?.replace(/\s+/g, ' ').trim());
+    expect(
+      pickPlayerTexts.some((text) =>
+        text?.includes('Blake Fiddler')
+        && text.includes('🟡')
+        && text.includes('draft.entryDrafts.playedInLeagueTooltip'),
+      ),
+    ).toBe(true);
+    expect(
+      pickPlayerTexts.some((text) =>
+        text?.includes('Brett Pesce')
+        && text.includes('🟢')
+        && text.includes('draft.entryDrafts.playedForDraftingTeamTooltip'),
+      ),
+    ).toBe(true);
+    expect(pickPlayerTexts).toContain('draft.entryDrafts.unknownPlayerLabel');
 
     expect(fixture.componentInstance.loading).toBe(false);
     expect(fixture.componentInstance.apiError).toBe(false);

--- a/src/app/draft/entry-drafts/entry-drafts.component.ts
+++ b/src/app/draft/entry-drafts/entry-drafts.component.ts
@@ -11,15 +11,23 @@ import {
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { MatExpansionModule } from '@angular/material/expansion';
 import { MatListModule } from '@angular/material/list';
+import { MatTooltipModule } from '@angular/material/tooltip';
 import { TranslateModule } from '@ngx-translate/core';
 
 import { ApiService, DraftPick, DraftTeamRef, EntryDraftTeamGroup } from '@services/api.service';
 import { FooterVisibilityService } from '@services/footer-visibility.service';
 
+type DraftPickStatus = {
+  readonly emoji: '🟢' | '🟡';
+  readonly tooltipKey:
+    | 'draft.entryDrafts.playedForDraftingTeamTooltip'
+    | 'draft.entryDrafts.playedInLeagueTooltip';
+};
+
 @Component({
   selector: 'app-entry-drafts',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [DecimalPipe, MatExpansionModule, MatListModule, TranslateModule],
+  imports: [DecimalPipe, MatExpansionModule, MatListModule, MatTooltipModule, TranslateModule],
   templateUrl: './entry-drafts.component.html',
   styleUrl: './entry-drafts.component.scss',
 })
@@ -66,6 +74,28 @@ export class EntryDraftsComponent implements OnInit {
 
   isTradedPick(team: DraftTeamRef, pick: DraftPick): boolean {
     return pick.originalOwner.id !== team.id;
+  }
+
+  getPickStatus(pick: DraftPick): DraftPickStatus | null {
+    if (pick.draftedPlayer === null) {
+      return null;
+    }
+
+    if (pick.playedForDraftingTeam) {
+      return {
+        emoji: '🟢',
+        tooltipKey: 'draft.entryDrafts.playedForDraftingTeamTooltip',
+      };
+    }
+
+    if (pick.playedInLeague) {
+      return {
+        emoji: '🟡',
+        tooltipKey: 'draft.entryDrafts.playedInLeagueTooltip',
+      };
+    }
+
+    return null;
   }
 
   private normalizeGroups(groups: EntryDraftTeamGroup[]): EntryDraftTeamGroup[] {

--- a/src/app/draft/statistics/draft-statistics.component.spec.ts
+++ b/src/app/draft/statistics/draft-statistics.component.spec.ts
@@ -9,6 +9,7 @@ import {
   provideDisabledMaterialAnimations,
   waitForBehaviorAssertion,
 } from '../../testing/behavior-test-utils';
+import { DRAFT_STATISTICS_CARD_IDS } from './draft-statistics.constants';
 import { DraftStatisticsComponent } from './draft-statistics.component';
 
 function createEntryDraftGroup(index: number): EntryDraftTeamGroup {
@@ -88,19 +89,9 @@ describe('DraftStatisticsComponent', () => {
     ).toBeInTheDocument();
     expect(screen.getByRole('heading', { name: 'draft.statistics.cards.playedInLeague.title' })).toBeInTheDocument();
     expect(fixture.componentInstance.cards.map((card) => card.id)).toEqual([
-      'total-picks',
-      'own-picks',
-      'traded-picks',
-      'players-per-draft',
-      'average-position',
-      'played-in-league',
-      'round-1',
-      'round-2',
-      'round-3',
-      'round-4',
-      'round-5',
+      ...DRAFT_STATISTICS_CARD_IDS,
     ]);
-    expect(screen.getAllByRole('table')).toHaveLength(11);
+    expect(screen.getAllByRole('table')).toHaveLength(DRAFT_STATISTICS_CARD_IDS.length);
     expect(
       screen.queryByRole('button', { name: /tableCard\.showDetails/ }),
     ).not.toBeInTheDocument();
@@ -138,7 +129,7 @@ describe('DraftStatisticsComponent', () => {
       footerVisibilityService,
     });
 
-    expect(screen.getAllByRole('progressbar')).toHaveLength(11);
+    expect(screen.getAllByRole('progressbar')).toHaveLength(DRAFT_STATISTICS_CARD_IDS.length);
     expect(footerVisibilityService.markReady).not.toHaveBeenCalled();
 
     response$.next(statisticsGroupsFixture);
@@ -146,7 +137,7 @@ describe('DraftStatisticsComponent', () => {
 
     await waitForBehaviorAssertion(fixture, () => {
       expect(fixture.componentInstance.loading).toBe(false);
-      expect(screen.getAllByRole('table')).toHaveLength(11);
+      expect(screen.getAllByRole('table')).toHaveLength(DRAFT_STATISTICS_CARD_IDS.length);
     });
     expect(footerVisibilityService.markReady).toHaveBeenCalledWith(9);
   });
@@ -161,7 +152,7 @@ describe('DraftStatisticsComponent', () => {
       footerVisibilityService,
     });
 
-    expect(await screen.findAllByText('tableCard.apiUnavailable')).toHaveLength(11);
+    expect(await screen.findAllByText('tableCard.apiUnavailable')).toHaveLength(DRAFT_STATISTICS_CARD_IDS.length);
     expect(footerVisibilityService.markReady).toHaveBeenCalledWith(9);
   });
 
@@ -177,7 +168,7 @@ describe('DraftStatisticsComponent', () => {
       platformId: 'server',
     });
 
-    expect(screen.getAllByRole('progressbar')).toHaveLength(11);
+    expect(screen.getAllByRole('progressbar')).toHaveLength(DRAFT_STATISTICS_CARD_IDS.length);
     expect(fixture.componentInstance.loading).toBe(true);
     expect(fixture.componentInstance.apiError).toBe(false);
     expect(getEntryDrafts).not.toHaveBeenCalled();

--- a/src/app/draft/statistics/draft-statistics.component.spec.ts
+++ b/src/app/draft/statistics/draft-statistics.component.spec.ts
@@ -25,6 +25,8 @@ function createEntryDraftGroup(index: number): EntryDraftTeamGroup {
         ownPicks: 15 - index,
         tradedPicks: 5,
         playersPerDraftAverage: 6 - index * 0.1,
+        playedInLeague: 12 - index,
+        playedForDraftingTeam: 6 - Math.floor(index / 2),
       },
       rounds: {
         first: 12 - index,
@@ -84,7 +86,21 @@ describe('DraftStatisticsComponent', () => {
     expect(
       await screen.findByRole('heading', { name: 'draft.statistics.cards.totalPicks.title' }),
     ).toBeInTheDocument();
-    expect(screen.getAllByRole('table')).toHaveLength(10);
+    expect(screen.getByRole('heading', { name: 'draft.statistics.cards.playedInLeague.title' })).toBeInTheDocument();
+    expect(fixture.componentInstance.cards.map((card) => card.id)).toEqual([
+      'total-picks',
+      'own-picks',
+      'traded-picks',
+      'players-per-draft',
+      'average-position',
+      'played-in-league',
+      'round-1',
+      'round-2',
+      'round-3',
+      'round-4',
+      'round-5',
+    ]);
+    expect(screen.getAllByRole('table')).toHaveLength(11);
     expect(
       screen.queryByRole('button', { name: /tableCard\.showDetails/ }),
     ).not.toBeInTheDocument();
@@ -122,7 +138,7 @@ describe('DraftStatisticsComponent', () => {
       footerVisibilityService,
     });
 
-    expect(screen.getAllByRole('progressbar')).toHaveLength(10);
+    expect(screen.getAllByRole('progressbar')).toHaveLength(11);
     expect(footerVisibilityService.markReady).not.toHaveBeenCalled();
 
     response$.next(statisticsGroupsFixture);
@@ -130,7 +146,7 @@ describe('DraftStatisticsComponent', () => {
 
     await waitForBehaviorAssertion(fixture, () => {
       expect(fixture.componentInstance.loading).toBe(false);
-      expect(screen.getAllByRole('table')).toHaveLength(10);
+      expect(screen.getAllByRole('table')).toHaveLength(11);
     });
     expect(footerVisibilityService.markReady).toHaveBeenCalledWith(9);
   });
@@ -145,7 +161,7 @@ describe('DraftStatisticsComponent', () => {
       footerVisibilityService,
     });
 
-    expect(await screen.findAllByText('tableCard.apiUnavailable')).toHaveLength(10);
+    expect(await screen.findAllByText('tableCard.apiUnavailable')).toHaveLength(11);
     expect(footerVisibilityService.markReady).toHaveBeenCalledWith(9);
   });
 
@@ -161,7 +177,7 @@ describe('DraftStatisticsComponent', () => {
       platformId: 'server',
     });
 
-    expect(screen.getAllByRole('progressbar')).toHaveLength(10);
+    expect(screen.getAllByRole('progressbar')).toHaveLength(11);
     expect(fixture.componentInstance.loading).toBe(true);
     expect(fixture.componentInstance.apiError).toBe(false);
     expect(getEntryDrafts).not.toHaveBeenCalled();

--- a/src/app/draft/statistics/draft-statistics.component.ts
+++ b/src/app/draft/statistics/draft-statistics.component.ts
@@ -28,6 +28,7 @@ type DraftStatisticsCardId =
   | 'traded-picks'
   | 'players-per-draft'
   | 'average-position'
+  | 'played-in-league'
   | 'round-1'
   | 'round-2'
   | 'round-3'
@@ -103,6 +104,14 @@ const draftStatisticDefinitions: readonly DraftStatisticDefinition[] = [
     direction: 'asc',
     valueFor: (group) => group.summary.averageDraftPosition,
     formatValue: (value) => draftStatisticNumberFormatter.format(value),
+  },
+  {
+    id: 'played-in-league',
+    titleKey: 'draft.statistics.cards.playedInLeague.title',
+    descriptionKey: 'draft.statistics.cards.playedInLeague.description',
+    valueColumnLabelKey: 'draft.statistics.columns.players',
+    direction: 'desc',
+    valueFor: (group) => group.summary.amounts.playedInLeague,
   },
   {
     id: 'round-1',

--- a/src/app/draft/statistics/draft-statistics.component.ts
+++ b/src/app/draft/statistics/draft-statistics.component.ts
@@ -16,24 +16,16 @@ import { FooterVisibilityService } from '@services/footer-visibility.service';
 import { TableCardComponent } from '@shared/table-card/table-card.component';
 import { TableCardRow } from '@shared/table-card/table-card.types';
 
+import {
+  DRAFT_STATISTICS_CARD_IDS,
+  DraftStatisticsCardId,
+} from './draft-statistics.constants';
+
 const PAGE_SIZE = 10;
 const draftStatisticNumberFormatter = new Intl.NumberFormat('fi-FI', {
   minimumFractionDigits: 0,
   maximumFractionDigits: 2,
 });
-
-type DraftStatisticsCardId =
-  | 'total-picks'
-  | 'own-picks'
-  | 'traded-picks'
-  | 'players-per-draft'
-  | 'average-position'
-  | 'played-in-league'
-  | 'round-1'
-  | 'round-2'
-  | 'round-3'
-  | 'round-4'
-  | 'round-5';
 
 type SortDirection = 'asc' | 'desc';
 
@@ -62,33 +54,32 @@ type DraftStatisticsCard = {
   readonly total: number;
 };
 
-const draftStatisticDefinitions: readonly DraftStatisticDefinition[] = [
-  {
-    id: 'total-picks',
+const draftStatisticDefinitionsById: Record<
+  DraftStatisticsCardId,
+  Omit<DraftStatisticDefinition, 'id'>
+> = {
+  'total-picks': {
     titleKey: 'draft.statistics.cards.totalPicks.title',
     descriptionKey: 'draft.statistics.cards.totalPicks.description',
     valueColumnLabelKey: 'draft.statistics.columns.pickCount',
     direction: 'desc',
     valueFor: (group) => group.summary.amounts.total,
   },
-  {
-    id: 'own-picks',
+  'own-picks': {
     titleKey: 'draft.statistics.cards.ownPicks.title',
     descriptionKey: 'draft.statistics.cards.ownPicks.description',
     valueColumnLabelKey: 'draft.statistics.columns.pickCount',
     direction: 'desc',
     valueFor: (group) => group.summary.amounts.ownPicks,
   },
-  {
-    id: 'traded-picks',
+  'traded-picks': {
     titleKey: 'draft.statistics.cards.tradedPicks.title',
     descriptionKey: 'draft.statistics.cards.tradedPicks.description',
     valueColumnLabelKey: 'draft.statistics.columns.pickCount',
     direction: 'desc',
     valueFor: (group) => group.summary.amounts.tradedPicks,
   },
-  {
-    id: 'players-per-draft',
+  'players-per-draft': {
     titleKey: 'draft.statistics.cards.playersPerDraft.title',
     descriptionKey: 'draft.statistics.cards.playersPerDraft.description',
     valueColumnLabelKey: 'draft.statistics.columns.average',
@@ -96,8 +87,7 @@ const draftStatisticDefinitions: readonly DraftStatisticDefinition[] = [
     valueFor: (group) => group.summary.amounts.playersPerDraftAverage,
     formatValue: (value) => draftStatisticNumberFormatter.format(value),
   },
-  {
-    id: 'average-position',
+  'average-position': {
     titleKey: 'draft.statistics.cards.averagePosition.title',
     descriptionKey: 'draft.statistics.cards.averagePosition.description',
     valueColumnLabelKey: 'draft.statistics.columns.turn',
@@ -105,55 +95,54 @@ const draftStatisticDefinitions: readonly DraftStatisticDefinition[] = [
     valueFor: (group) => group.summary.averageDraftPosition,
     formatValue: (value) => draftStatisticNumberFormatter.format(value),
   },
-  {
-    id: 'played-in-league',
+  'played-in-league': {
     titleKey: 'draft.statistics.cards.playedInLeague.title',
     descriptionKey: 'draft.statistics.cards.playedInLeague.description',
     valueColumnLabelKey: 'draft.statistics.columns.players',
     direction: 'desc',
     valueFor: (group) => group.summary.amounts.playedInLeague,
   },
-  {
-    id: 'round-1',
+  'round-1': {
     titleKey: 'draft.statistics.cards.roundOne.title',
     descriptionKey: 'draft.statistics.cards.roundOne.description',
     valueColumnLabelKey: 'draft.statistics.columns.pickCount',
     direction: 'desc',
     valueFor: (group) => group.summary.rounds.first,
   },
-  {
-    id: 'round-2',
+  'round-2': {
     titleKey: 'draft.statistics.cards.roundTwo.title',
     descriptionKey: 'draft.statistics.cards.roundTwo.description',
     valueColumnLabelKey: 'draft.statistics.columns.pickCount',
     direction: 'desc',
     valueFor: (group) => group.summary.rounds.second,
   },
-  {
-    id: 'round-3',
+  'round-3': {
     titleKey: 'draft.statistics.cards.roundThree.title',
     descriptionKey: 'draft.statistics.cards.roundThree.description',
     valueColumnLabelKey: 'draft.statistics.columns.pickCount',
     direction: 'desc',
     valueFor: (group) => group.summary.rounds.third,
   },
-  {
-    id: 'round-4',
+  'round-4': {
     titleKey: 'draft.statistics.cards.roundFour.title',
     descriptionKey: 'draft.statistics.cards.roundFour.description',
     valueColumnLabelKey: 'draft.statistics.columns.pickCount',
     direction: 'desc',
     valueFor: (group) => group.summary.rounds.fourth,
   },
-  {
-    id: 'round-5',
+  'round-5': {
     titleKey: 'draft.statistics.cards.roundFive.title',
     descriptionKey: 'draft.statistics.cards.roundFive.description',
     valueColumnLabelKey: 'draft.statistics.columns.pickCount',
     direction: 'desc',
     valueFor: (group) => group.summary.rounds.fifth,
   },
-] as const;
+};
+
+const draftStatisticDefinitions: readonly DraftStatisticDefinition[] = DRAFT_STATISTICS_CARD_IDS.map((id) => ({
+  id,
+  ...draftStatisticDefinitionsById[id],
+}));
 
 @Component({
   selector: 'app-draft-statistics',

--- a/src/app/draft/statistics/draft-statistics.constants.ts
+++ b/src/app/draft/statistics/draft-statistics.constants.ts
@@ -1,0 +1,15 @@
+export const DRAFT_STATISTICS_CARD_IDS = [
+  'total-picks',
+  'own-picks',
+  'traded-picks',
+  'players-per-draft',
+  'average-position',
+  'played-in-league',
+  'round-1',
+  'round-2',
+  'round-3',
+  'round-4',
+  'round-5',
+] as const;
+
+export type DraftStatisticsCardId = (typeof DRAFT_STATISTICS_CARD_IDS)[number];

--- a/src/app/services/api.service.spec.ts
+++ b/src/app/services/api.service.spec.ts
@@ -288,6 +288,8 @@ describe('ApiService', () => {
             ownPicks: 0,
             tradedPicks: 0,
             playersPerDraftAverage: 0,
+            playedInLeague: 0,
+            playedForDraftingTeam: 0,
           },
           rounds: {
             first: 0,
@@ -312,6 +314,8 @@ describe('ApiService', () => {
             ownPicks: 0,
             tradedPicks: 0,
             playersPerDraftAverage: 0,
+            playedInLeague: 0,
+            playedForDraftingTeam: 0,
           },
           rounds: {
             first: 0,
@@ -336,6 +340,8 @@ describe('ApiService', () => {
             ownPicks: 0,
             tradedPicks: 0,
             playersPerDraftAverage: 0,
+            playedInLeague: 0,
+            playedForDraftingTeam: 0,
           },
           rounds: {
             first: 0,

--- a/src/app/services/api.types.generated.ts
+++ b/src/app/services/api.types.generated.ts
@@ -308,7 +308,11 @@ export interface paths {
          *     Each team's `seasons` array is sorted newest-first, and picks within one season
          *     are sorted by draft order.
          *     Team roots also include a `summary` object with highest-pick, average-position,
-         *     pick-count aggregates, and a fixed round breakdown calculated from the grouped data.
+         *     pick-count aggregates, played counts, and a fixed round breakdown calculated from
+         *     the grouped data.
+         *     Each pick also includes `playedInLeague` and `playedForDraftingTeam` flags based
+         *     on whether the linked Fantrax entity has games-played rows in `players` or
+         *     `goalies`.
          *     Picks with `draftedPlayer: null` stay in the season pick lists but are excluded from
          *     all summary calculations.
          */
@@ -1359,6 +1363,16 @@ export interface components {
             pickNumber: number;
             /** @example Connor McDavid */
             draftedPlayer: string | null;
+            /**
+             * @description True when the linked Fantrax entity has at least one games-played row in `players` or `goalies` for any fantasy team.
+             * @example true
+             */
+            playedInLeague: boolean;
+            /**
+             * @description True when the linked Fantrax entity has at least one games-played row for the same fantasy team that drafted them.
+             * @example false
+             */
+            playedForDraftingTeam: boolean;
             originalOwner: components["schemas"]["DraftTeamRef"];
         };
         OpeningDraftPick: {
@@ -1404,6 +1418,16 @@ export interface components {
              * @example 5.71
              */
             playersPerDraftAverage: number;
+            /**
+             * @description Drafted players with at least one games-played row in `players` or `goalies` for any fantasy team.
+             * @example 28
+             */
+            playedInLeague: number;
+            /**
+             * @description Drafted players with at least one games-played row for the same fantasy team that drafted them.
+             * @example 14
+             */
+            playedForDraftingTeam: number;
         };
         EntryDraftRoundsSummary: {
             /** @example 12 */


### PR DESCRIPTION
## Summary
- add regenerated OpenAPI entry-draft played-status fields to frontend types
- replace the old highest-pick side card with compact played-status summary tags
- move highest-pick content into a thinner full-width strip above season breakdowns
- show green/yellow played-status indicators next to drafted players with tooltip/accessibility support
- add a new "Eniten liigassa pelanneita pelaajia" card to draft statistics
- update fixtures, tests, and docs for the new entry-draft presentation

## Verification
- npm run verify
