### PR TITLE
Feature: Add entry draft played percentages

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,9 @@ The docs in this repo intentionally focus on project-specific architecture, work
 - 📝 **Draft Pages**: Standalone `/draft/entry-drafts`, `/draft/opening-draft`, and `/draft/statistics` browse routes now live under `Varaukset`
 	- Batch 1 adds the route shell, navigation, SEO, and the shared browse scaffolding
 	- Batch 2 turns `/draft/opening-draft` into a team-by-team accordion with simple pick rows, including traded-pick owner suffixes when the original pick belonged to another team
-	- Batch 3 turns `/draft/entry-drafts` into a matching team accordion with compact summary cards, played-status totals, highest-pick highlights, and season-by-season entry draft history
+	- Batch 3 turns `/draft/entry-drafts` into a matching team accordion with compact summary cards, played-status totals plus played percentages, highest-pick highlights, and season-by-season entry draft history
 	- Entry-draft pick rows add `🟢` / `🟡` played-status markers to show whether a drafted player reached the drafting team or played elsewhere in the league
-	- `Tilastot` reuses the shared paged `TableCardComponent` to rank teams across 11 entry-draft summary slices without a separate draft-only card implementation
+	- `Tilastot` reuses the shared paged `TableCardComponent` to rank teams across 13 entry-draft summary slices, including separate played-percentage rankings, without a separate draft-only card implementation
 - 🚦 **Split Route Shells**: Interactive dashboard routes lazy-load their heavier shell (controls, settings drawer, comparison bar, tabs), while career and leaderboard browsing routes stay on a lighter root shell
 - 🗂️ **Global Navigation**: Bottom sheet menu for switching between views (hockey stats, player careers, leaderboards, info/help)
 - 🔗 **Direct Player Links**: Shareable URLs for player/goalie cards

--- a/docs/project-overview.md
+++ b/docs/project-overview.md
@@ -95,9 +95,9 @@ Accessibility is a core requirement: the UI is designed to remain usable via key
    - Shares the lighter root-shell treatment used by other browse routes
    - Batch 1 provides the route family, tab navigation, subtitle/SEO integration, and browse-shell wiring
    - Batch 2 renders `/draft/opening-draft` as a Material accordion grouped by drafting team, with simple per-pick rows and a traded-owner suffix when the original pick came from another team
-   - Batch 3 renders `/draft/entry-drafts` as a matching team-grouped accordion, with per-team summary cards, played-status totals, highest-pick highlights, and season-by-season pick lists that preserve null legacy player rows
+   - Batch 3 renders `/draft/entry-drafts` as a matching team-grouped accordion, with per-team summary cards, played-status totals plus played percentages, highest-pick highlights, and season-by-season pick lists that preserve null legacy player rows
    - Entry-draft pick rows add `🟢` / `🟡` played-status markers to show whether a drafted player reached the drafting team or played elsewhere in the league
-   - `/draft/statistics` reuses the shared card-table UI to rank teams across entry-draft summary metrics with local 10-row paging
+   - `/draft/statistics` reuses the shared card-table UI to rank teams across entry-draft summary metrics, including separate played-percentage rankings, with local 10-row paging
 
 8. **Data Management**
    - Caching service to reduce API calls

--- a/e2e/fixtures/data/draft--entry.json
+++ b/e2e/fixtures/data/draft--entry.json
@@ -22,7 +22,9 @@
         "tradedPicks": 1,
         "playersPerDraftAverage": 2,
         "playedInLeague": 2,
-        "playedForDraftingTeam": 1
+        "playedInLeaguePercent": 0.5,
+        "playedForDraftingTeam": 1,
+        "playedForDraftingTeamPercent": 0.25
       },
       "rounds": {
         "first": 2,
@@ -112,7 +114,9 @@
         "tradedPicks": 1,
         "playersPerDraftAverage": 1.5,
         "playedInLeague": 2,
-        "playedForDraftingTeam": 1
+        "playedInLeaguePercent": 0.667,
+        "playedForDraftingTeam": 1,
+        "playedForDraftingTeamPercent": 0.333
       },
       "rounds": {
         "first": 1,

--- a/public/i18n/fi.json
+++ b/public/i18n/fi.json
@@ -101,7 +101,8 @@
         "pickCount": "Varaukset",
         "average": "Keskiarvo",
         "turn": "Vuoro",
-        "players": "Pelaajat"
+        "players": "Pelaajat",
+        "share": "Osuus"
       },
       "cards": {
         "totalPicks": {
@@ -127,6 +128,14 @@
         "playedInLeague": {
           "title": "Eniten pelanneita varauksia",
           "description": "Varatut pelaajat, joilla on otteluita ylhäällä."
+        },
+        "playedInLeaguePercent": {
+          "title": "Varausprosentti - kaikki joukkueet",
+          "description": "Varattu pelaaja pelannut jossain joukkueessa."
+        },
+        "playedForDraftingTeamPercent": {
+          "title": "Varausprosentti - oma joukkue",
+          "description": "Varattu pelaaja pelannut omassa joukkueessa."
         },
         "roundOne": {
           "title": "Eniten 1. kierroksen varauksia",
@@ -159,10 +168,10 @@
       "ownPicksLabel": "Omilla vuoroilla",
       "tradedPicksLabel": "Treidatuilla vuoroilla",
       "playersPerDraftAverageLabel": "Varausta / draft",
-      "playedInLeagueLabel": "Liigassa",
-      "playedForDraftingTeamLabel": "Varaajajoukkueessa",
+      "playedInLeagueLabel": "Missä tahansa",
+      "playedForDraftingTeamLabel": "Omassa joukkueessa",
       "playedInLeagueTooltip": "Pelannut muualla",
-      "playedForDraftingTeamTooltip": "Pelannut varaajajoukkueessa",
+      "playedForDraftingTeamTooltip": "Pelannut omassa joukkueessa",
       "highestPickHeading": "Korkeimmalla varattu",
       "noHighestPick": "Ei varaustietoa",
       "roundsHeading": "Varaukset kierroksittain",
@@ -183,10 +192,6 @@
       "roundLabel": "Kierros",
       "turnLabel": "Vuoro",
       "originalOwnerLabel": "Alkuperäinen vuoro:"
-    },
-    "placeholders": {
-      "entryDrafts": "Varaukset-osion perusrunko on nyt paikallaan. Entry draftit -sisältö rakennetaan seuraavassa työerässä.",
-      "openingDraft": "Varaukset-osion perusrunko on nyt paikallaan. Avausdrafti-sisältö rakennetaan seuraavassa työerässä."
     },
     "loading": "Ladataan varausdataa...",
     "apiUnavailable": "Varausdata ei ole saatavilla juuri nyt. Yritä hetken päästä uudelleen.",

--- a/src/app/draft/entry-drafts/entry-drafts.component.html
+++ b/src/app/draft/entry-drafts/entry-drafts.component.html
@@ -120,6 +120,9 @@
                   </span>
                   <strong class="entry-played-value">
                     {{ group.summary.amounts.playedInLeague }}
+                    <span class="entry-played-percent">
+                      ({{ group.summary.amounts.playedInLeaguePercent | percent: '1.0-1' : 'fi' }})
+                    </span>
                   </strong>
                 </div>
 
@@ -129,6 +132,9 @@
                   </span>
                   <strong class="entry-played-value">
                     {{ group.summary.amounts.playedForDraftingTeam }}
+                    <span class="entry-played-percent">
+                      ({{ group.summary.amounts.playedForDraftingTeamPercent | percent: '1.0-1' : 'fi' }})
+                    </span>
                   </strong>
                 </div>
               </div>

--- a/src/app/draft/entry-drafts/entry-drafts.component.scss
+++ b/src/app/draft/entry-drafts/entry-drafts.component.scss
@@ -75,6 +75,11 @@
   line-height: 1.2;
 }
 
+.entry-played-percent {
+  font-size: 0.9rem;
+  font-weight: 600;
+}
+
 .entry-played-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(132px, 1fr));

--- a/src/app/draft/entry-drafts/entry-drafts.component.spec.ts
+++ b/src/app/draft/entry-drafts/entry-drafts.component.spec.ts
@@ -37,7 +37,9 @@ const entryDraftGroupsFixture: EntryDraftTeamGroup[] = [
         tradedPicks: 12,
         playersPerDraftAverage: 4.92,
         playedInLeague: 2,
+        playedInLeaguePercent: 0.031,
         playedForDraftingTeam: 1,
+        playedForDraftingTeamPercent: 0.016,
       },
       rounds: {
         first: 13,
@@ -103,7 +105,9 @@ const entryDraftGroupsFixture: EntryDraftTeamGroup[] = [
         tradedPicks: 0,
         playersPerDraftAverage: 0,
         playedInLeague: 0,
+        playedInLeaguePercent: 0,
         playedForDraftingTeam: 0,
+        playedForDraftingTeamPercent: 0,
       },
       rounds: {
         first: 0,
@@ -197,9 +201,9 @@ describe('EntryDraftsComponent', () => {
     expect(summaryValues).toEqual(expect.arrayContaining(['82,89', '64', '52', '12', '4,92']));
 
     const playedValues = Array.from(firstPanelElement.querySelectorAll('.entry-played-value'))
-      .map((element) => element.textContent?.trim())
+      .map((element) => element.textContent?.replace(/\s+/g, ' ').trim())
       .filter((value): value is string => Boolean(value));
-    expect(playedValues).toEqual(['2', '1']);
+    expect(playedValues).toEqual(['2 (3,1 %)', '1 (1,6 %)']);
 
     const roundValues = Array.from(firstPanelElement.querySelectorAll('.entry-round-value'))
       .map((element) => element.textContent?.trim())

--- a/src/app/draft/entry-drafts/entry-drafts.component.ts
+++ b/src/app/draft/entry-drafts/entry-drafts.component.ts
@@ -1,4 +1,4 @@
-import { DecimalPipe, isPlatformBrowser } from '@angular/common';
+import { DecimalPipe, PercentPipe, isPlatformBrowser } from '@angular/common';
 import {
   ChangeDetectionStrategy,
   ChangeDetectorRef,
@@ -27,7 +27,7 @@ type DraftPickStatus = {
 @Component({
   selector: 'app-entry-drafts',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [DecimalPipe, MatExpansionModule, MatListModule, MatTooltipModule, TranslateModule],
+  imports: [DecimalPipe, PercentPipe, MatExpansionModule, MatListModule, MatTooltipModule, TranslateModule],
   templateUrl: './entry-drafts.component.html',
   styleUrl: './entry-drafts.component.scss',
 })

--- a/src/app/draft/statistics/draft-statistics.component.spec.ts
+++ b/src/app/draft/statistics/draft-statistics.component.spec.ts
@@ -27,7 +27,11 @@ function createEntryDraftGroup(index: number): EntryDraftTeamGroup {
         tradedPicks: 5,
         playersPerDraftAverage: 6 - index * 0.1,
         playedInLeague: 12 - index,
+        playedInLeaguePercent: Number(((12 - index) / (20 - index)).toFixed(3)),
         playedForDraftingTeam: 6 - Math.floor(index / 2),
+        playedForDraftingTeamPercent: Number(
+          ((6 - Math.floor(index / 2)) / (20 - index)).toFixed(3),
+        ),
       },
       rounds: {
         first: 12 - index,
@@ -88,6 +92,12 @@ describe('DraftStatisticsComponent', () => {
       await screen.findByRole('heading', { name: 'draft.statistics.cards.totalPicks.title' }),
     ).toBeInTheDocument();
     expect(screen.getByRole('heading', { name: 'draft.statistics.cards.playedInLeague.title' })).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: 'draft.statistics.cards.playedInLeaguePercent.title' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: 'draft.statistics.cards.playedForDraftingTeamPercent.title' }),
+    ).toBeInTheDocument();
     expect(fixture.componentInstance.cards.map((card) => card.id)).toEqual([
       ...DRAFT_STATISTICS_CARD_IDS,
     ]);
@@ -106,6 +116,18 @@ describe('DraftStatisticsComponent', () => {
     const totalPicksQueries = within(totalPicksCard as HTMLElement);
     expect(totalPicksQueries.getByText(totalPicksState!.rows[0].primaryText)).toBeInTheDocument();
     expect(totalPicksQueries.queryByText(totalPicksState!.allRows[10].primaryText)).not.toBeInTheDocument();
+
+    const playedInLeaguePercentCard = screen
+      .getByRole('heading', { name: 'draft.statistics.cards.playedInLeaguePercent.title' })
+      .closest('app-table-card');
+    expect(playedInLeaguePercentCard).not.toBeNull();
+    expect(within(playedInLeaguePercentCard as HTMLElement).getByText('60 %')).toBeInTheDocument();
+
+    const playedForDraftingTeamPercentCard = screen
+      .getByRole('heading', { name: 'draft.statistics.cards.playedForDraftingTeamPercent.title' })
+      .closest('app-table-card');
+    expect(playedForDraftingTeamPercentCard).not.toBeNull();
+    expect(within(playedForDraftingTeamPercentCard as HTMLElement).getByText('30 %')).toBeInTheDocument();
 
     fireEvent.click(totalPicksQueries.getByRole('button', { name: 'tableCard.nextPage' }));
 

--- a/src/app/draft/statistics/draft-statistics.component.ts
+++ b/src/app/draft/statistics/draft-statistics.component.ts
@@ -26,6 +26,11 @@ const draftStatisticNumberFormatter = new Intl.NumberFormat('fi-FI', {
   minimumFractionDigits: 0,
   maximumFractionDigits: 2,
 });
+const draftStatisticPercentFormatter = new Intl.NumberFormat('fi-FI', {
+  style: 'percent',
+  minimumFractionDigits: 0,
+  maximumFractionDigits: 1,
+});
 
 type SortDirection = 'asc' | 'desc';
 
@@ -101,6 +106,22 @@ const draftStatisticDefinitionsById: Record<
     valueColumnLabelKey: 'draft.statistics.columns.players',
     direction: 'desc',
     valueFor: (group) => group.summary.amounts.playedInLeague,
+  },
+  'played-in-league-percent': {
+    titleKey: 'draft.statistics.cards.playedInLeaguePercent.title',
+    descriptionKey: 'draft.statistics.cards.playedInLeaguePercent.description',
+    valueColumnLabelKey: 'draft.statistics.columns.share',
+    direction: 'desc',
+    valueFor: (group) => group.summary.amounts.playedInLeaguePercent,
+    formatValue: (value) => draftStatisticPercentFormatter.format(value),
+  },
+  'played-for-drafting-team-percent': {
+    titleKey: 'draft.statistics.cards.playedForDraftingTeamPercent.title',
+    descriptionKey: 'draft.statistics.cards.playedForDraftingTeamPercent.description',
+    valueColumnLabelKey: 'draft.statistics.columns.share',
+    direction: 'desc',
+    valueFor: (group) => group.summary.amounts.playedForDraftingTeamPercent,
+    formatValue: (value) => draftStatisticPercentFormatter.format(value),
   },
   'round-1': {
     titleKey: 'draft.statistics.cards.roundOne.title',

--- a/src/app/draft/statistics/draft-statistics.constants.ts
+++ b/src/app/draft/statistics/draft-statistics.constants.ts
@@ -5,6 +5,8 @@ export const DRAFT_STATISTICS_CARD_IDS = [
   'players-per-draft',
   'average-position',
   'played-in-league',
+  'played-in-league-percent',
+  'played-for-drafting-team-percent',
   'round-1',
   'round-2',
   'round-3',

--- a/src/app/services/api.service.spec.ts
+++ b/src/app/services/api.service.spec.ts
@@ -289,7 +289,9 @@ describe('ApiService', () => {
             tradedPicks: 0,
             playersPerDraftAverage: 0,
             playedInLeague: 0,
+            playedInLeaguePercent: 0,
             playedForDraftingTeam: 0,
+            playedForDraftingTeamPercent: 0,
           },
           rounds: {
             first: 0,
@@ -315,7 +317,9 @@ describe('ApiService', () => {
             tradedPicks: 0,
             playersPerDraftAverage: 0,
             playedInLeague: 0,
+            playedInLeaguePercent: 0,
             playedForDraftingTeam: 0,
+            playedForDraftingTeamPercent: 0,
           },
           rounds: {
             first: 0,
@@ -341,7 +345,9 @@ describe('ApiService', () => {
             tradedPicks: 0,
             playersPerDraftAverage: 0,
             playedInLeague: 0,
+            playedInLeaguePercent: 0,
             playedForDraftingTeam: 0,
+            playedForDraftingTeamPercent: 0,
           },
           rounds: {
             first: 0,

--- a/src/app/services/api.types.generated.ts
+++ b/src/app/services/api.types.generated.ts
@@ -308,8 +308,8 @@ export interface paths {
          *     Each team's `seasons` array is sorted newest-first, and picks within one season
          *     are sorted by draft order.
          *     Team roots also include a `summary` object with highest-pick, average-position,
-         *     pick-count aggregates, played counts, and a fixed round breakdown calculated from
-         *     the grouped data.
+         *     pick-count aggregates, played counts, played percentages, and a fixed round
+         *     breakdown calculated from the grouped data.
          *     Each pick also includes `playedInLeague` and `playedForDraftingTeam` flags based
          *     on whether the linked Fantrax entity has games-played rows in `players` or
          *     `goalies`.
@@ -1424,10 +1424,20 @@ export interface components {
              */
             playedInLeague: number;
             /**
+             * @description Fraction of drafted players who appeared in league games for any fantasy team, rounded to three decimals.
+             * @example 0.7
+             */
+            playedInLeaguePercent: number;
+            /**
              * @description Drafted players with at least one games-played row for the same fantasy team that drafted them.
              * @example 14
              */
             playedForDraftingTeam: number;
+            /**
+             * @description Fraction of drafted players who appeared in league games for the fantasy team that drafted them, rounded to three decimals.
+             * @example 0.35
+             */
+            playedForDraftingTeamPercent: number;
         };
         EntryDraftRoundsSummary: {
             /** @example 12 */


### PR DESCRIPTION
## Summary
- add played percentages to entry draft summary totals
- add two played-percentage cards to draft statistics before the round cards
- regenerate entry draft API types and update related tests/fixtures/docs

## Testing
- npm run verify

## Notes
- includes final accepted wording tweaks in fi.json