### PR TITLE
Feature: Polish draft statistics browsing experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ The docs in this repo intentionally focus on project-specific architecture, work
 		- Entry-draft pick rows add `🟢` / `🟡` played-status markers to show whether a drafted player reached the drafting team or played elsewhere in the league
 		- Expanded draft panels auto-align their sticky header to the top of the viewport when opened; `ArrowDown` still explicitly moves from the team header into the panel body, `ArrowUp` / `ArrowDown` / `Home` / `End` / `PageUp` / `PageDown` browse within it, and `Escape` collapses the panel while returning focus to the header
 		- `Tilastot` reuses the shared paged `TableCardComponent` to rank teams across 13 entry-draft summary slices, including separate played-percentage rankings, without a separate draft-only card implementation
+		- Draft statistics cards are grouped under `Varausmäärät`, `Osumat`, and `Kierrokset`, with a sticky jump bar plus an optional team highlight control that jumps each card to the selected team's ranking page and emphasizes that row
 - 🚦 **Split Route Shells**: Interactive dashboard routes lazy-load their heavier shell (controls, settings drawer, comparison bar, tabs), while career and leaderboard browsing routes stay on a lighter root shell
 - 🗂️ **Global Navigation**: Bottom sheet menu for switching between views (hockey stats, player careers, leaderboards, info/help)
 	- Supports wrapped `ArrowUp` / `ArrowDown` navigation between menu items in addition to normal `Tab` browsing

--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -115,6 +115,14 @@ Notes:
 
 On mobile, top controls + settings are shown inside a left-side settings drawer (opened via the settings icon in the app header). The drawer content is rendered in a non-collapsible "content-only" mode.
 
+### Standalone card tables
+
+Browse surfaces such as career highlights and draft statistics use standalone card-contained tables.
+
+- Each table must expose an accessible name derived from the card heading
+- Include the card subtitle in the table labeling when it adds meaning
+- Repeated pager controls must include the card title in their accessible name so screen reader users can distinguish which card they belong to
+
 ### Player Card navigation
 
 The player card supports navigating between players without closing the dialog:

--- a/docs/component-guide.md
+++ b/docs/component-guide.md
@@ -90,6 +90,7 @@ Do not collapse these into a single "universal" table component unless the produ
 
 - Shared compact read-only card/table used by highlight and draft statistics views
 - Keep loading, empty, error, tooltip, and paging behavior consistent across consumers
+- Preserve its semantic table labeling and optional row emphasis hooks when extending browse-oriented ranking views
 
 ### `StartFromSeasonSwitcherComponent` And `StartFromSeasonSyncService`
 

--- a/e2e/specs/career.spec.ts
+++ b/e2e/specs/career.spec.ts
@@ -1,6 +1,7 @@
 import { Locator } from '@playwright/test';
 
 import { test, expect } from '../fixtures/test-fixture';
+import { fi } from '../config/i18n';
 import {
   CAREER_HIGHLIGHT_CARD_LABELS,
   CAREER_HIGHLIGHT_SECTION_LABELS,
@@ -41,7 +42,9 @@ test.describe('Career listings', () => {
       await expect(card.getByRole('table')).toBeVisible();
     }
 
-    const nextPageButtons = page.getByRole('button', { name: 'Näytä seuraavat rivit' });
+    const nextPageButtons = page.getByRole('button', {
+      name: new RegExp(fi('tableCard.next')),
+    });
     let pagedCard: Locator | null = null;
     let pagedCardFirstRow: Locator | null = null;
 

--- a/e2e/specs/draft.spec.ts
+++ b/e2e/specs/draft.spec.ts
@@ -23,7 +23,7 @@ async function expectStatisticsContent(page: Page) {
   const cards = page.locator('app-table-card');
   const firstCard = cards.first();
   const nextPageButton = firstCard.getByRole('button', {
-    name: fi('tableCard.nextPage'),
+    name: new RegExp(`${fi('draft.statistics.cards.totalPicks.title')}.*${fi('tableCard.next')}`),
   });
   const pageSummary = firstCard.locator('.page-summary');
 

--- a/e2e/specs/draft.spec.ts
+++ b/e2e/specs/draft.spec.ts
@@ -63,7 +63,7 @@ async function expectEntryDraftContent(page: Page) {
   const firstPanel = panels.first();
   const firstHeader = firstPanel.locator('mat-expansion-panel-header');
 
-  await expect(firstHeader).toBeVisible();
+  await expect(firstHeader).toBeVisible({ timeout: 15000 });
   await firstHeader.click();
 
   await expect(firstPanel.locator('.entry-summary-card').first()).toBeVisible();

--- a/public/i18n/fi.json
+++ b/public/i18n/fi.json
@@ -96,6 +96,12 @@
       "statistics": "Tilastot"
     },
     "statistics": {
+      "intro": "Korosta halutessasi joukkueesi. Tieto tallentuu selaimen muistiin.",
+      "jumpNavAriaLabel": "Draftitilastojen osiot",
+      "highlightTeam": {
+        "label": "Korosta joukkue",
+        "clear": "Ei korostusta"
+      },
       "columns": {
         "team": "Joukkue",
         "pickCount": "Varaukset",
@@ -103,6 +109,20 @@
         "turn": "Vuoro",
         "players": "Pelaajat",
         "share": "Osuus"
+      },
+      "sections": {
+        "pickVolume": {
+          "title": "Varausmäärät",
+          "description": "Varausten käytön tilastot."
+        },
+        "outcomes": {
+          "title": "Osumat",
+          "description": "Varausten onnistumisten tilastot."
+        },
+        "rounds": {
+          "title": "Kierrokset",
+          "description": "Varausmäärät kierroksittain."
+        }
       },
       "cards": {
         "totalPicks": {

--- a/src/app/app.component.mobile.spec.ts
+++ b/src/app/app.component.mobile.spec.ts
@@ -270,9 +270,16 @@ describe('AppComponent — mobile frontpage', { timeout: 60_000 }, () => {
     expect(screen.queryByText(/team\.selector:/)).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('tab', { name: 'career.tabs.highlights' }));
+    await vi.waitFor(() => {
+      expect(router.url).toBe('/career/highlights');
+    }, { timeout: 15_000 });
 
     expect(
-      await screen.findByRole('heading', { name: 'career.highlights.cards.mostTeamsPlayed.title' })
+      await screen.findByRole(
+        'heading',
+        { name: 'career.highlights.cards.mostTeamsPlayed.title' },
+        { timeout: 15_000 }
+      )
     ).toBeInTheDocument();
     expect(
       screen.getByRole('heading', { name: 'career.highlights.cards.mostTeamsOwned.title' })
@@ -307,7 +314,11 @@ describe('AppComponent — mobile frontpage', { timeout: 60_000 }, () => {
     );
 
     expect(
-      await screen.findByRole('heading', { name: 'career.highlights.cards.mostTrades.title' })
+      await screen.findByRole(
+        'heading',
+        { name: 'career.highlights.cards.mostTrades.title' },
+        { timeout: 15_000 }
+      )
     ).toBeInTheDocument();
     expect(
       screen.getByRole('heading', { name: 'career.highlights.cards.mostClaims.title' })
@@ -323,8 +334,11 @@ describe('AppComponent — mobile frontpage', { timeout: 60_000 }, () => {
     ).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('tab', { name: 'career.tabs.goalies' }));
+    await vi.waitFor(() => {
+      expect(router.url).toBe('/career/goalies');
+    }, { timeout: 15_000 });
 
-    expect(await screen.findByLabelText('table.playerSearch')).toBeInTheDocument();
+    expect(await screen.findByLabelText('table.playerSearch', {}, { timeout: 15_000 })).toBeInTheDocument();
   });
 
   it('hides the settings drawer controls on mobile draft routes and shows draft tabs instead', async () => {

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -138,7 +138,7 @@ describe('AppComponent — desktop frontpage', { timeout: 60_000 }, () => {
     await vi.waitFor(() => {
       expect(screen.queryByRole('button', { name: 'helpDialog.close' })).not.toBeInTheDocument();
     });
-  });
+  }, 90_000);
 
   it('shows the update snackbar, reopens it after Escape dismissal, and triggers reload from the snackbar action', async () => {
     const activateAndReload = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);

--- a/src/app/career/highlights/career-highlights.component.spec.ts
+++ b/src/app/career/highlights/career-highlights.component.spec.ts
@@ -207,7 +207,9 @@ describe('CareerHighlightsComponent', () => {
     expect(await within(sameTeamPlayedCard!).findByText('D Victor Hedman')).toBeInTheDocument();
     expect(getCareerHighlights).toHaveBeenCalledWith('same-team-seasons-played', 0, 10);
 
-    fireEvent.click(within(mostTeamsCard!).getByRole('button', { name: 'tableCard.nextPage' }));
+    fireEvent.click(within(mostTeamsCard!).getByRole('button', {
+      name: /career\.highlights\.cards\.mostTeamsPlayed\.title.*tableCard\.next/,
+    }));
 
     expect(await within(mostTeamsCard!).findByText('F Anthony Duclair')).toBeInTheDocument();
     expect(within(mostTeamsCard!).queryByText('F Jamie Benn')).not.toBeInTheDocument();

--- a/src/app/draft/statistics/draft-statistics.component.html
+++ b/src/app/draft/statistics/draft-statistics.component.html
@@ -3,24 +3,77 @@
     {{ 'draft.tabs.statistics' | translate }}
   </h3>
 
-  <div class="draft-statistics-grid">
-    @for (card of cards; track card.id) {
-      <app-table-card
-        class="draft-statistics-card"
-        [titleKey]="card.titleKey"
-        [descriptionKey]="card.descriptionKey"
-        primaryColumnLabelKey="draft.statistics.columns.team"
-        [valueColumnLabelKey]="card.valueColumnLabelKey"
-        [showDetails]="false"
-        [rows]="card.rows"
-        [loading]="loading"
-        [apiError]="apiError"
-        [skip]="card.skip"
-        [take]="pageSize"
-        [total]="card.total"
-        (previousPageRequested)="loadPreviousPage(card.id)"
-        (nextPageRequested)="loadNextPage(card.id)"
-      />
-    }
+  <div class="draft-statistics-toolbar">
+    <p class="draft-statistics-intro">
+      {{ 'draft.statistics.intro' | translate }}
+    </p>
+
+    <mat-form-field class="draft-statistics-highlight-field" appearance="outline" subscriptSizing="dynamic">
+      <mat-label>{{ 'draft.statistics.highlightTeam.label' | translate }}</mat-label>
+      <mat-select
+        [value]="highlightedTeamId"
+        [disabled]="loading || apiError || teams.length === 0"
+        (selectionChange)="onHighlightedTeamChange($event)"
+      >
+        <mat-option [value]="null">
+          {{ 'draft.statistics.highlightTeam.clear' | translate }}
+        </mat-option>
+        @for (team of teams; track team.id) {
+          <mat-option [value]="team.id">
+            {{ team.name }}
+          </mat-option>
+        }
+      </mat-select>
+    </mat-form-field>
   </div>
+
+  <nav class="draft-statistics-jump-nav" [attr.aria-label]="'draft.statistics.jumpNavAriaLabel' | translate">
+    @for (section of sectionLinks; track section.id) {
+      <button
+        class="draft-statistics-jump-link"
+        type="button"
+        (click)="scrollToSection(section.anchorId)"
+      >
+        {{ section.titleKey | translate }}
+      </button>
+    }
+  </nav>
+
+  @for (section of sections; track section.id) {
+    <section
+      class="draft-statistics-section"
+      [attr.id]="section.anchorId"
+      [attr.aria-labelledby]="section.headingId"
+    >
+      <header class="draft-statistics-section-header">
+        <h4 class="draft-statistics-section-title" [id]="section.headingId">
+          {{ section.titleKey | translate }}
+        </h4>
+        <p class="draft-statistics-section-description">
+          {{ section.descriptionKey | translate }}
+        </p>
+      </header>
+
+      <div class="draft-statistics-grid">
+        @for (card of section.cards; track card.id) {
+          <app-table-card
+            class="draft-statistics-card"
+            [titleKey]="card.titleKey"
+            [descriptionKey]="card.descriptionKey"
+            primaryColumnLabelKey="draft.statistics.columns.team"
+            [valueColumnLabelKey]="card.valueColumnLabelKey"
+            [showDetails]="false"
+            [rows]="card.rows"
+            [loading]="loading"
+            [apiError]="apiError"
+            [skip]="card.skip"
+            [take]="pageSize"
+            [total]="card.total"
+            (previousPageRequested)="loadPreviousPage(card.id)"
+            (nextPageRequested)="loadNextPage(card.id)"
+          />
+        }
+      </div>
+    </section>
+  }
 </section>

--- a/src/app/draft/statistics/draft-statistics.component.scss
+++ b/src/app/draft/statistics/draft-statistics.component.scss
@@ -4,11 +4,104 @@
 
 .draft-statistics {
   width: 100%;
+  padding-bottom: 24px;
+}
+
+.draft-statistics-toolbar {
+  display: grid;
+  grid-template-columns: minmax(0, 1.5fr) minmax(16rem, 24rem);
+  gap: 16px;
+  align-items: start;
+  margin: 20px 24px 0;
+  padding: 18px 20px;
+  border: 1px solid var(--mat-sys-outline-variant);
+  border-radius: 24px;
+  background:
+    linear-gradient(180deg,
+      color-mix(in srgb, var(--mat-sys-surface-container) 92%, transparent) 0%,
+      color-mix(in srgb, var(--mat-sys-surface) 94%, transparent) 100%);
+}
+
+.draft-statistics-intro {
+  margin: 0;
+  color: var(--mat-sys-on-surface-variant);
+  line-height: 1.6;
+}
+
+.draft-statistics-highlight-field {
+  min-width: 0;
+}
+
+.draft-statistics-jump-nav {
+  position: sticky;
+  top: 8px;
+  z-index: 3;
+  display: flex;
+  gap: 10px;
+  margin: 16px 24px 0;
+  padding: 8px;
+  overflow-x: auto;
+  overflow-y: hidden;
+  border: 1px solid color-mix(in srgb, var(--mat-sys-outline) 65%, transparent);
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--mat-sys-surface) 88%, transparent);
+  backdrop-filter: blur(14px);
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+
+.draft-statistics-jump-nav::-webkit-scrollbar {
+  display: none;
+}
+
+.draft-statistics-jump-link {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.55rem 1rem;
+  border-radius: 999px;
+  color: var(--mat-sys-on-surface-variant);
+  font-size: 0.92rem;
+  font-weight: 600;
+  border: 0;
+  background: transparent;
+  cursor: pointer;
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.draft-statistics-jump-link:hover,
+.draft-statistics-jump-link:focus-visible {
+  background: color-mix(in srgb, var(--mat-sys-primary) 12%, transparent);
+  color: var(--mat-sys-on-surface);
+  outline: none;
+}
+
+.draft-statistics-section {
+  margin: 20px 24px 0;
+  scroll-margin-top: 80px;
+}
+
+.draft-statistics-section-header {
+  margin-bottom: 14px;
+}
+
+.draft-statistics-section-title {
+  margin: 0;
+  color: var(--mat-sys-on-surface);
+  font-size: 1.15rem;
+  line-height: 1.35;
+}
+
+.draft-statistics-section-description {
+  margin: 6px 0 0;
+  color: var(--mat-sys-on-surface-variant);
+  line-height: 1.55;
 }
 
 .draft-statistics-grid {
   display: grid;
-  margin: 20px 24px 24px;
   gap: 20px;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   align-items: stretch;
@@ -19,14 +112,36 @@
 }
 
 @media (max-width: 900px) {
+  .draft-statistics-toolbar {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
   .draft-statistics-grid {
     grid-template-columns: minmax(0, 1fr);
   }
 }
 
 @media (max-width: 480px) {
+  .draft-statistics {
+    padding-bottom: 8px;
+  }
+
+  .draft-statistics-toolbar {
+    margin: 12px 8px 0;
+    padding: 14px;
+    gap: 12px;
+  }
+
+  .draft-statistics-jump-nav {
+    margin: 12px 8px 0;
+    top: 6px;
+  }
+
+  .draft-statistics-section {
+    margin: 14px 8px 0;
+  }
+
   .draft-statistics-grid {
-    margin: 12px 8px 8px;
     gap: 12px;
   }
 }

--- a/src/app/draft/statistics/draft-statistics.component.spec.ts
+++ b/src/app/draft/statistics/draft-statistics.component.spec.ts
@@ -48,6 +48,10 @@ function createEntryDraftGroup(index: number): EntryDraftTeamGroup {
 const statisticsGroupsFixture = Array.from({ length: 12 }, (_, index) => createEntryDraftGroup(index));
 
 describe('DraftStatisticsComponent', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
   function createFooterVisibilityMock() {
     return {
       currentCycle: vi.fn(() => 9),
@@ -83,11 +87,20 @@ describe('DraftStatisticsComponent', () => {
     });
   }
 
-  it('renders all draft statistics cards and paginates the ranked teams', async () => {
+  it('renders grouped draft statistics cards and paginates the ranked teams', async () => {
     const footerVisibilityService = createFooterVisibilityMock();
 
     const { fixture } = await renderComponent({ footerVisibilityService });
 
+    expect(
+      await screen.findByRole('heading', { name: 'draft.statistics.sections.pickVolume.title' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: 'draft.statistics.sections.outcomes.title' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: 'draft.statistics.sections.rounds.title' }),
+    ).toBeInTheDocument();
     expect(
       await screen.findByRole('heading', { name: 'draft.statistics.cards.totalPicks.title' }),
     ).toBeInTheDocument();
@@ -98,6 +111,8 @@ describe('DraftStatisticsComponent', () => {
     expect(
       screen.getByRole('heading', { name: 'draft.statistics.cards.playedForDraftingTeamPercent.title' }),
     ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'draft.statistics.sections.pickVolume.title' })).toBeInTheDocument();
+    expect(screen.getByRole('combobox', { name: 'draft.statistics.highlightTeam.label' })).toBeInTheDocument();
     expect(fixture.componentInstance.cards.map((card) => card.id)).toEqual([
       ...DRAFT_STATISTICS_CARD_IDS,
     ]);
@@ -115,7 +130,8 @@ describe('DraftStatisticsComponent', () => {
 
     const totalPicksQueries = within(totalPicksCard as HTMLElement);
     expect(totalPicksQueries.getByText(totalPicksState!.rows[0].primaryText)).toBeInTheDocument();
-    expect(totalPicksQueries.queryByText(totalPicksState!.allRows[10].primaryText)).not.toBeInTheDocument();
+    expect(totalPicksQueries.getByText('1. Team 1')).toBeInTheDocument();
+    expect(totalPicksQueries.queryByText('11. Team 11')).not.toBeInTheDocument();
 
     const playedInLeaguePercentCard = screen
       .getByRole('heading', { name: 'draft.statistics.cards.playedInLeaguePercent.title' })
@@ -129,15 +145,92 @@ describe('DraftStatisticsComponent', () => {
     expect(playedForDraftingTeamPercentCard).not.toBeNull();
     expect(within(playedForDraftingTeamPercentCard as HTMLElement).getByText('30 %')).toBeInTheDocument();
 
-    fireEvent.click(totalPicksQueries.getByRole('button', { name: 'tableCard.nextPage' }));
+    fireEvent.click(totalPicksQueries.getByRole('button', {
+      name: /draft\.statistics\.cards\.totalPicks\.title.*tableCard\.next/,
+    }));
 
     await waitForBehaviorAssertion(fixture, () => {
       const pagedCard = fixture.componentInstance.cards.find((card) => card.id === 'total-picks');
       expect(pagedCard?.skip).toBe(10);
-      expect(totalPicksQueries.getByText(totalPicksState!.allRows[10].primaryText)).toBeInTheDocument();
+      expect(totalPicksQueries.getByText('11. Team 11')).toBeInTheDocument();
     });
 
     expect(footerVisibilityService.markReady).toHaveBeenCalledWith(9);
+  });
+
+  it('highlights a selected team and jumps cards to the matching ranking page', async () => {
+    const { fixture } = await renderComponent();
+
+    fireEvent.click(screen.getByRole('combobox', { name: 'draft.statistics.highlightTeam.label' }));
+    fireEvent.click(await screen.findByRole('option', { name: 'Team 12' }));
+
+    const totalPicksCard = screen.getByRole('heading', { name: 'draft.statistics.cards.totalPicks.title' })
+      .closest('app-table-card');
+    expect(totalPicksCard).not.toBeNull();
+
+    await waitForBehaviorAssertion(fixture, () => {
+      const cardState = fixture.componentInstance.cards.find((card) => card.id === 'total-picks');
+      expect(fixture.componentInstance.highlightedTeamId).toBe('12');
+      expect(cardState?.skip).toBe(10);
+      expect(cardState?.rows.some((row) => row.primaryText === '12. Team 12' && row.emphasized)).toBe(true);
+      expect(within(totalPicksCard as HTMLElement).getByText('12. Team 12').closest('tr')).toHaveClass('table-card-row--emphasized');
+    });
+
+    expect(JSON.parse(localStorage.getItem('fantrax.settings') ?? '{}')).toMatchObject({
+      draftStatisticsHighlightedTeamId: '12',
+    });
+  });
+
+  it('restores the highlighted team from persisted settings', async () => {
+    localStorage.setItem('fantrax.settings', JSON.stringify({
+      selectedTeamId: '1',
+      startFromSeason: null,
+      topControlsExpanded: true,
+      season: null,
+      reportType: 'regular',
+      draftStatisticsHighlightedTeamId: '12',
+    }));
+
+    const { fixture } = await renderComponent();
+    const totalPicksCard = await screen.findByRole('heading', { name: 'draft.statistics.cards.totalPicks.title' })
+      .then((heading) => heading.closest('app-table-card'));
+
+    expect(totalPicksCard).not.toBeNull();
+
+    await waitForBehaviorAssertion(fixture, () => {
+      const cardState = fixture.componentInstance.cards.find((card) => card.id === 'total-picks');
+      expect(screen.getByRole('combobox', { name: 'draft.statistics.highlightTeam.label' })).toHaveTextContent('Team 12');
+      expect(cardState?.skip).toBe(10);
+      expect(within(totalPicksCard as HTMLElement).getByText('12. Team 12').closest('tr')).toHaveClass('table-card-row--emphasized');
+    });
+  });
+
+  it('keeps section jumps on the current route and scrolls to the target section', async () => {
+    const { fixture } = await renderComponent();
+    const outcomesSection = fixture.nativeElement.querySelector('#draft-statistics-section-outcomes') as HTMLElement | null;
+
+    expect(outcomesSection).not.toBeNull();
+
+    const scrollIntoView = vi.fn();
+    Object.defineProperty(outcomesSection, 'scrollIntoView', {
+      value: scrollIntoView,
+      configurable: true,
+    });
+
+    const replaceStateSpy = vi.spyOn(window.history, 'replaceState');
+
+    fireEvent.click(screen.getByRole('button', { name: 'draft.statistics.sections.outcomes.title' }));
+
+    expect(replaceStateSpy).toHaveBeenCalledWith(
+      null,
+      '',
+      `${window.location.pathname}${window.location.search}#draft-statistics-section-outcomes`,
+    );
+    expect(scrollIntoView).toHaveBeenCalledWith({
+      block: 'start',
+      inline: 'nearest',
+      behavior: 'smooth',
+    });
   });
 
   it('shows a loading state until the statistics response resolves', async () => {

--- a/src/app/draft/statistics/draft-statistics.component.ts
+++ b/src/app/draft/statistics/draft-statistics.component.ts
@@ -1,4 +1,4 @@
-import { isPlatformBrowser } from '@angular/common';
+import { DOCUMENT, isPlatformBrowser } from '@angular/common';
 import {
   ChangeDetectionStrategy,
   ChangeDetectorRef,
@@ -9,16 +9,21 @@ import {
   inject,
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatSelectChange, MatSelectModule } from '@angular/material/select';
 import { TranslateModule } from '@ngx-translate/core';
 
 import { ApiService, EntryDraftTeamGroup } from '@services/api.service';
 import { FooterVisibilityService } from '@services/footer-visibility.service';
+import { SettingsService } from '@services/settings.service';
 import { TableCardComponent } from '@shared/table-card/table-card.component';
 import { TableCardRow } from '@shared/table-card/table-card.types';
 
 import {
   DRAFT_STATISTICS_CARD_IDS,
   DraftStatisticsCardId,
+  DRAFT_STATISTICS_SECTIONS,
+  DraftStatisticsSectionId,
 } from './draft-statistics.constants';
 
 const PAGE_SIZE = 10;
@@ -44,7 +49,11 @@ type DraftStatisticDefinition = {
   readonly formatValue?: (value: number) => number | string;
 };
 
-type RankedTableCardRow = TableCardRow & {
+type DraftStatisticSourceRow = {
+  readonly key: string;
+  readonly teamId: string;
+  readonly teamName: string;
+  readonly value: number | string;
   readonly rawValue: number;
 };
 
@@ -53,11 +62,31 @@ type DraftStatisticsCard = {
   readonly titleKey: string;
   readonly descriptionKey: string;
   readonly valueColumnLabelKey: string;
-  readonly allRows: readonly RankedTableCardRow[];
+  readonly allRows: readonly DraftStatisticSourceRow[];
   readonly rows: readonly TableCardRow[];
   readonly skip: number;
   readonly total: number;
 };
+
+type DraftStatisticsSection = {
+  readonly id: DraftStatisticsSectionId;
+  readonly titleKey: string;
+  readonly descriptionKey: string;
+  readonly anchorId: string;
+  readonly headingId: string;
+  readonly cards: readonly DraftStatisticsCard[];
+};
+
+type DraftStatisticsTeamOption = {
+  readonly id: string;
+  readonly name: string;
+};
+
+const draftStatisticsSectionDefinitions = DRAFT_STATISTICS_SECTIONS.map((section) => ({
+  ...section,
+  anchorId: `draft-statistics-section-${section.id}`,
+  headingId: `draft-statistics-section-${section.id}-heading`,
+}));
 
 const draftStatisticDefinitionsById: Record<
   DraftStatisticsCardId,
@@ -168,28 +197,43 @@ const draftStatisticDefinitions: readonly DraftStatisticDefinition[] = DRAFT_STA
 @Component({
   selector: 'app-draft-statistics',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [TableCardComponent, TranslateModule],
+  imports: [
+    MatFormFieldModule,
+    MatSelectModule,
+    TableCardComponent,
+    TranslateModule,
+  ],
   templateUrl: './draft-statistics.component.html',
   styleUrl: './draft-statistics.component.scss',
 })
 export class DraftStatisticsComponent implements OnInit {
+  private readonly document = inject(DOCUMENT);
   private readonly apiService = inject(ApiService);
   private readonly changeDetectorRef = inject(ChangeDetectorRef);
   private readonly destroyRef = inject(DestroyRef);
   private readonly footerVisibilityService = inject(FooterVisibilityService);
+  private readonly settingsService = inject(SettingsService);
   private readonly platformId = inject(PLATFORM_ID);
 
   readonly pageSize = PAGE_SIZE;
+  readonly sectionLinks = draftStatisticsSectionDefinitions;
 
-  cards: DraftStatisticsCard[] = this.createInitialCards();
+  sections: DraftStatisticsSection[] = this.createInitialSections();
+  teams: DraftStatisticsTeamOption[] = [];
   loading = true;
   apiError = false;
+  highlightedTeamId: string | null = null;
   private footerVisibilityCycle = 0;
+
+  get cards(): DraftStatisticsCard[] {
+    return this.sections.flatMap((section) => [...section.cards]);
+  }
 
   ngOnInit(): void {
     this.footerVisibilityCycle = this.footerVisibilityService.currentCycle();
     this.loading = true;
     this.apiError = false;
+    this.highlightedTeamId = this.settingsService.draftStatisticsHighlightedTeamId;
 
     if (!isPlatformBrowser(this.platformId)) {
       this.footerVisibilityService.markReady(this.footerVisibilityCycle);
@@ -200,19 +244,73 @@ export class DraftStatisticsComponent implements OnInit {
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
         next: (groups) => {
-          this.cards = this.buildCards(groups);
+          this.teams = this.buildTeamOptions(groups);
+          if (this.highlightedTeamId !== null && !this.teams.some((team) => team.id === this.highlightedTeamId)) {
+            this.highlightedTeamId = null;
+            this.settingsService.setDraftStatisticsHighlightedTeamId(null);
+          }
+          this.sections = this.buildSections(groups);
           this.loading = false;
           this.changeDetectorRef.markForCheck();
           this.footerVisibilityService.markReady(this.footerVisibilityCycle);
         },
         error: () => {
-          this.cards = this.createInitialCards();
+          this.sections = this.createInitialSections();
+          this.teams = [];
+          this.highlightedTeamId = null;
           this.apiError = true;
           this.loading = false;
           this.changeDetectorRef.markForCheck();
           this.footerVisibilityService.markReady(this.footerVisibilityCycle);
         },
       });
+  }
+
+  onHighlightedTeamChange(event: MatSelectChange): void {
+    const selectedTeamId = typeof event.value === 'string' && event.value.length > 0
+      ? event.value
+      : null;
+
+    this.highlightedTeamId = selectedTeamId;
+    this.settingsService.setDraftStatisticsHighlightedTeamId(selectedTeamId);
+    this.sections = this.sections.map((section) => ({
+      ...section,
+      cards: section.cards.map((card) => {
+        const nextSkip = selectedTeamId === null
+          ? 0
+          : this.getTeamPageSkip(card.allRows, selectedTeamId);
+
+        return {
+          ...card,
+          skip: nextSkip,
+          rows: this.buildVisibleRows(card.allRows, nextSkip),
+        };
+      }),
+    }));
+    this.changeDetectorRef.markForCheck();
+  }
+
+  scrollToSection(anchorId: string): void {
+    if (!isPlatformBrowser(this.platformId)) {
+      return;
+    }
+
+    const sectionElement = this.document.getElementById(anchorId);
+    if (!sectionElement) {
+      return;
+    }
+
+    const location = this.document.defaultView?.location;
+    if (location) {
+      const nextUrl = `${location.pathname}${location.search}#${anchorId}`;
+      this.document.defaultView?.history.replaceState(null, '', nextUrl);
+    }
+
+    sectionElement.scrollIntoView({
+      block: 'start',
+      inline: 'nearest',
+      behavior: 'smooth',
+    });
   }
 
   loadPreviousPage(cardId: DraftStatisticsCardId): void {
@@ -223,9 +321,18 @@ export class DraftStatisticsComponent implements OnInit {
     this.updateCardPage(cardId, PAGE_SIZE);
   }
 
-  private createInitialCards(): DraftStatisticsCard[] {
-    return draftStatisticDefinitions.map((definition) => ({
-      id: definition.id,
+  private createInitialSections(): DraftStatisticsSection[] {
+    return draftStatisticsSectionDefinitions.map((section) => ({
+      ...section,
+      cards: section.cardIds.map((cardId) => this.createInitialCard(cardId)),
+    }));
+  }
+
+  private createInitialCard(cardId: DraftStatisticsCardId): DraftStatisticsCard {
+    const definition = draftStatisticDefinitionsById[cardId];
+
+    return {
+      id: cardId,
       titleKey: definition.titleKey,
       descriptionKey: definition.descriptionKey,
       valueColumnLabelKey: definition.valueColumnLabelKey,
@@ -233,33 +340,60 @@ export class DraftStatisticsComponent implements OnInit {
       rows: [],
       skip: 0,
       total: 0,
+    };
+  }
+
+  private buildSections(groups: EntryDraftTeamGroup[]): DraftStatisticsSection[] {
+    const cardsById = Object.fromEntries(
+      draftStatisticDefinitions.map((definition) => [
+        definition.id,
+        this.buildCard(groups, definition),
+      ]),
+    ) as Record<DraftStatisticsCardId, DraftStatisticsCard>;
+
+    return draftStatisticsSectionDefinitions.map((section) => ({
+      ...section,
+      cards: section.cardIds.map((cardId) => cardsById[cardId]),
     }));
   }
 
-  private buildCards(groups: EntryDraftTeamGroup[]): DraftStatisticsCard[] {
-    return draftStatisticDefinitions.map((definition) => {
-      const allRows = groups
-        .map((group) => this.buildRow(group, definition))
-        .filter((row): row is RankedTableCardRow => row !== null)
-        .sort((left, right) => this.compareRows(left, right, definition.direction));
+  private buildCard(
+    groups: EntryDraftTeamGroup[],
+    definition: DraftStatisticDefinition,
+  ): DraftStatisticsCard {
+    const allRows = groups
+      .map((group) => this.buildSourceRow(group, definition))
+      .filter((row): row is DraftStatisticSourceRow => row !== null)
+      .sort((left, right) => this.compareRows(left, right, definition.direction));
+    const initialSkip = this.highlightedTeamId === null
+      ? 0
+      : this.getTeamPageSkip(allRows, this.highlightedTeamId);
 
-      return {
-        id: definition.id,
-        titleKey: definition.titleKey,
-        descriptionKey: definition.descriptionKey,
-        valueColumnLabelKey: definition.valueColumnLabelKey,
-        allRows,
-        rows: allRows.slice(0, PAGE_SIZE),
-        skip: 0,
-        total: allRows.length,
-      };
-    });
+    return {
+      id: definition.id,
+      titleKey: definition.titleKey,
+      descriptionKey: definition.descriptionKey,
+      valueColumnLabelKey: definition.valueColumnLabelKey,
+      allRows,
+      rows: this.buildVisibleRows(allRows, initialSkip),
+      skip: initialSkip,
+      total: allRows.length,
+    };
   }
 
-  private buildRow(
+  private buildTeamOptions(groups: EntryDraftTeamGroup[]): DraftStatisticsTeamOption[] {
+    return groups
+      .map((group) => ({
+        id: group.team.id,
+        name: group.team.name,
+      }))
+      .sort((left, right) => left.name.localeCompare(right.name, 'fi'));
+  }
+
+  private buildSourceRow(
     group: EntryDraftTeamGroup,
     definition: DraftStatisticDefinition,
-  ): RankedTableCardRow | null {
+  ): DraftStatisticSourceRow | null {
     const rawValue = definition.valueFor(group);
 
     if (rawValue === null) {
@@ -268,15 +402,30 @@ export class DraftStatisticsComponent implements OnInit {
 
     return {
       key: `${definition.id}:${group.team.id}`,
-      primaryText: group.team.name,
+      teamId: group.team.id,
+      teamName: group.team.name,
       value: definition.formatValue ? definition.formatValue(rawValue) : rawValue,
       rawValue,
     };
   }
 
+  private buildVisibleRows(
+    allRows: readonly DraftStatisticSourceRow[],
+    skip: number,
+  ): TableCardRow[] {
+    return allRows
+      .slice(skip, skip + PAGE_SIZE)
+      .map((row, index) => ({
+        key: row.key,
+        primaryText: `${skip + index + 1}. ${row.teamName}`,
+        value: row.value,
+        emphasized: row.teamId === this.highlightedTeamId,
+      }));
+  }
+
   private compareRows(
-    left: RankedTableCardRow,
-    right: RankedTableCardRow,
+    left: DraftStatisticSourceRow,
+    right: DraftStatisticSourceRow,
     direction: SortDirection,
   ): number {
     const valueDifference = direction === 'asc'
@@ -287,26 +436,42 @@ export class DraftStatisticsComponent implements OnInit {
       return valueDifference;
     }
 
-    return left.primaryText.localeCompare(right.primaryText, 'fi');
+    return left.teamName.localeCompare(right.teamName, 'fi');
+  }
+
+  private getTeamPageSkip(
+    allRows: readonly DraftStatisticSourceRow[],
+    teamId: string,
+  ): number {
+    const teamIndex = allRows.findIndex((row) => row.teamId === teamId);
+
+    if (teamIndex < 0) {
+      return 0;
+    }
+
+    return Math.floor(teamIndex / PAGE_SIZE) * PAGE_SIZE;
   }
 
   private updateCardPage(cardId: DraftStatisticsCardId, offset: number): void {
-    this.cards = this.cards.map((card) => {
-      if (card.id !== cardId) {
-        return card;
-      }
+    this.sections = this.sections.map((section) => ({
+      ...section,
+      cards: section.cards.map((card) => {
+        if (card.id !== cardId) {
+          return card;
+        }
 
-      const maxSkip = card.total <= PAGE_SIZE
-        ? 0
-        : Math.floor((card.total - 1) / PAGE_SIZE) * PAGE_SIZE;
-      const nextSkip = Math.min(Math.max(card.skip + offset, 0), maxSkip);
+        const maxSkip = card.total <= PAGE_SIZE
+          ? 0
+          : Math.floor((card.total - 1) / PAGE_SIZE) * PAGE_SIZE;
+        const nextSkip = Math.min(Math.max(card.skip + offset, 0), maxSkip);
 
-      return {
-        ...card,
-        skip: nextSkip,
-        rows: card.allRows.slice(nextSkip, nextSkip + PAGE_SIZE),
-      };
-    });
+        return {
+          ...card,
+          skip: nextSkip,
+          rows: this.buildVisibleRows(card.allRows, nextSkip),
+        };
+      }),
+    }));
     this.changeDetectorRef.markForCheck();
   }
 }

--- a/src/app/draft/statistics/draft-statistics.constants.ts
+++ b/src/app/draft/statistics/draft-statistics.constants.ts
@@ -15,3 +15,47 @@ export const DRAFT_STATISTICS_CARD_IDS = [
 ] as const;
 
 export type DraftStatisticsCardId = (typeof DRAFT_STATISTICS_CARD_IDS)[number];
+
+export const DRAFT_STATISTICS_SECTIONS = [
+  {
+    id: 'pick-volume',
+    titleKey: 'draft.statistics.sections.pickVolume.title',
+    descriptionKey: 'draft.statistics.sections.pickVolume.description',
+    cardIds: [
+      'total-picks',
+      'own-picks',
+      'traded-picks',
+      'players-per-draft',
+    ],
+  },
+  {
+    id: 'outcomes',
+    titleKey: 'draft.statistics.sections.outcomes.title',
+    descriptionKey: 'draft.statistics.sections.outcomes.description',
+    cardIds: [
+      'average-position',
+      'played-in-league',
+      'played-in-league-percent',
+      'played-for-drafting-team-percent',
+    ],
+  },
+  {
+    id: 'rounds',
+    titleKey: 'draft.statistics.sections.rounds.title',
+    descriptionKey: 'draft.statistics.sections.rounds.description',
+    cardIds: [
+      'round-1',
+      'round-2',
+      'round-3',
+      'round-4',
+      'round-5',
+    ],
+  },
+] as const satisfies readonly {
+  readonly id: string;
+  readonly titleKey: string;
+  readonly descriptionKey: string;
+  readonly cardIds: readonly DraftStatisticsCardId[];
+}[];
+
+export type DraftStatisticsSectionId = (typeof DRAFT_STATISTICS_SECTIONS)[number]['id'];

--- a/src/app/services/settings.service.ts
+++ b/src/app/services/settings.service.ts
@@ -8,6 +8,7 @@ export type AppSettings = {
   topControlsExpanded: boolean;
   season: number | null;
   reportType: ReportType;
+  draftStatisticsHighlightedTeamId: string | null;
 };
 
 @Injectable({
@@ -47,6 +48,10 @@ export class SettingsService {
     return this.settingsSignal().reportType;
   }
 
+  get draftStatisticsHighlightedTeamId(): string | null {
+    return this.settingsSignal().draftStatisticsHighlightedTeamId;
+  }
+
   setSelectedTeamId(teamId: string): void {
     if (!teamId || teamId === this.selectedTeamId) return;
     this.updateSettings({ selectedTeamId: teamId });
@@ -71,6 +76,11 @@ export class SettingsService {
   setReportType(reportType: ReportType): void {
     if (reportType === this.settingsSignal().reportType) return;
     this.updateSettings({ reportType });
+  }
+
+  setDraftStatisticsHighlightedTeamId(teamId: string | null): void {
+    if (teamId === this.settingsSignal().draftStatisticsHighlightedTeamId) return;
+    this.updateSettings({ draftStatisticsHighlightedTeamId: teamId });
   }
 
   private updateSettings(patch: Partial<AppSettings>): void {
@@ -106,8 +116,20 @@ export class SettingsService {
             : null;
 
         const reportType = this.parseReportType(parsed.reportType);
+        const draftStatisticsHighlightedTeamId =
+          typeof parsed.draftStatisticsHighlightedTeamId === 'string'
+            && parsed.draftStatisticsHighlightedTeamId.trim().length > 0
+            ? parsed.draftStatisticsHighlightedTeamId
+            : null;
 
-        return { selectedTeamId, startFromSeason, topControlsExpanded, season, reportType };
+        return {
+          selectedTeamId,
+          startFromSeason,
+          topControlsExpanded,
+          season,
+          reportType,
+          draftStatisticsHighlightedTeamId,
+        };
       }
     } catch {
       // ignore parse errors
@@ -119,6 +141,7 @@ export class SettingsService {
       topControlsExpanded: this.defaultTopControlsExpanded,
       season: null,
       reportType: 'regular',
+      draftStatisticsHighlightedTeamId: null,
     };
     this.persist(defaults);
     return defaults;

--- a/src/app/shared/table-card/table-card.component.html
+++ b/src/app/shared/table-card/table-card.component.html
@@ -4,11 +4,11 @@
   [class.table-card--without-details]="!showDetails()"
 >
   <mat-card-header>
-    <h3 mat-card-title>
+    <h3 [id]="titleId" mat-card-title>
       {{ titleKey() | translate }}
     </h3>
-    @if (!descriptionRequiresParams() || descriptionParams()) {
-    <p mat-card-subtitle>
+    @if (hasDescription()) {
+    <p [id]="descriptionId" mat-card-subtitle>
       {{ descriptionKey() | translate : descriptionParams() }}
     </p>
     }
@@ -43,7 +43,7 @@
     }
 
     <div class="table-shell">
-      <table class="table-card-table">
+      <table class="table-card-table" [attr.aria-labelledby]="tableAriaLabelledBy()">
         <thead>
           <tr>
             <th scope="col" class="name-column">
@@ -65,7 +65,11 @@
 
         <tbody>
           @for (row of rows(); track row.key; let rowIndex = $index) {
-          <tr [attr.data-row-index]="rowIndex" tabindex="-1">
+          <tr
+            [attr.data-row-index]="rowIndex"
+            tabindex="-1"
+            [class.table-card-row--emphasized]="row.emphasized"
+          >
             <td class="primary-cell">
               {{ row.primaryText }}
             </td>
@@ -92,9 +96,12 @@
   @if (!deferred()) {
   <mat-card-actions class="card-actions">
     <button mat-stroked-button type="button" (click)="previousPageRequested.emit()"
-      [disabled]="loading() || !hasPreviousPage()" [attr.aria-label]="'tableCard.previousPage' | translate">
-      <mat-icon>chevron_left</mat-icon>
-      {{ 'tableCard.previous' | translate }}
+      [disabled]="loading() || !hasPreviousPage()"
+      [attr.aria-labelledby]="previousButtonAriaLabelledBy">
+      <mat-icon aria-hidden="true">chevron_left</mat-icon>
+      <span [id]="previousButtonTextId">
+        {{ 'tableCard.previous' | translate }}
+      </span>
     </button>
 
     <div class="page-summary" aria-live="polite">
@@ -110,9 +117,11 @@
     </div>
 
     <button mat-stroked-button type="button" (click)="nextPageRequested.emit()" [disabled]="loading() || !hasNextPage()"
-      [attr.aria-label]="'tableCard.nextPage' | translate">
-      {{ 'tableCard.next' | translate }}
-      <mat-icon>chevron_right</mat-icon>
+      [attr.aria-labelledby]="nextButtonAriaLabelledBy">
+      <span [id]="nextButtonTextId">
+        {{ 'tableCard.next' | translate }}
+      </span>
+      <mat-icon aria-hidden="true">chevron_right</mat-icon>
     </button>
   </mat-card-actions>
   }

--- a/src/app/shared/table-card/table-card.component.scss
+++ b/src/app/shared/table-card/table-card.component.scss
@@ -64,7 +64,7 @@ mat-card-header {
 
 .table-shell {
   min-height: 440px;
-  overflow-x: none;
+  overflow-x: clip;
 }
 
 .table-card-table {
@@ -95,6 +95,20 @@ mat-card-header {
 
 .table-card-table tbody tr:last-child td {
   border-bottom: 0;
+}
+
+.table-card-table tbody tr.table-card-row--emphasized td {
+  background: color-mix(in srgb, var(--mat-sys-primary-container) 72%, transparent);
+}
+
+.table-card-table tbody tr.table-card-row--emphasized td:first-child {
+  box-shadow: inset 3px 0 0 var(--mat-sys-primary);
+}
+
+.table-card-table tbody tr.table-card-row--emphasized .primary-cell,
+.table-card-table tbody tr.table-card-row--emphasized .value-column {
+  color: var(--mat-sys-on-primary-container);
+  font-weight: 700;
 }
 
 .table-card-table tbody tr:focus {

--- a/src/app/shared/table-card/table-card.component.spec.ts
+++ b/src/app/shared/table-card/table-card.component.spec.ts
@@ -70,12 +70,24 @@ describe('TableCardComponent', () => {
     expect(
       await screen.findByRole('heading', { name: 'career.highlights.cards.mostTeamsPlayed.title' })
     ).toBeInTheDocument();
-    expect(screen.getByRole('table')).toBeInTheDocument();
+    expect(
+      screen.getByRole('table', {
+        name: /career\.highlights\.cards\.mostTeamsPlayed\.title.*career\.highlights\.cards\.mostTeamsPlayed\.description/,
+      }),
+    ).toBeInTheDocument();
     expect(screen.getByText('F Jamie Benn')).toBeInTheDocument();
     expect(screen.getByText('5')).toBeInTheDocument();
     expect(screen.getByText('tableCard.paginationSummary')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'tableCard.previousPage' })).toBeDisabled();
-    expect(screen.getByRole('button', { name: 'tableCard.nextPage' })).toBeEnabled();
+    expect(
+      screen.getByRole('button', {
+        name: /career\.highlights\.cards\.mostTeamsPlayed\.title.*tableCard\.previous/,
+      }),
+    ).toBeDisabled();
+    expect(
+      screen.getByRole('button', {
+        name: /career\.highlights\.cards\.mostTeamsPlayed\.title.*tableCard\.next/,
+      }),
+    ).toBeEnabled();
   });
 
   it('shows an empty-state message when there are no rows and the card is not loading', async () => {

--- a/src/app/shared/table-card/table-card.component.ts
+++ b/src/app/shared/table-card/table-card.component.ts
@@ -8,6 +8,8 @@ import { TranslateModule } from '@ngx-translate/core';
 
 import { TableCardRow } from './table-card.types';
 
+let nextTableCardInstanceId = 0;
+
 @Component({
   selector: 'app-table-card',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -23,6 +25,8 @@ import { TableCardRow } from './table-card.types';
   styleUrl: './table-card.component.scss',
 })
 export class TableCardComponent {
+  private readonly instanceId = `table-card-${nextTableCardInstanceId += 1}`;
+
   readonly titleKey = input.required<string>();
   readonly descriptionKey = input.required<string>();
   readonly descriptionRequiresParams = input(false);
@@ -46,6 +50,18 @@ export class TableCardComponent {
   readonly hasNextPage = computed(() => this.skip() + this.rows().length < this.total());
   readonly pageStart = computed(() => (this.hasRows() ? this.skip() + 1 : 0));
   readonly pageEnd = computed(() => (this.hasRows() ? this.skip() + this.rows().length : 0));
+  readonly hasDescription = computed(
+    () => !this.descriptionRequiresParams() || Boolean(this.descriptionParams()),
+  );
+  readonly titleId = `${this.instanceId}-title`;
+  readonly descriptionId = `${this.instanceId}-description`;
+  readonly previousButtonTextId = `${this.instanceId}-previous-text`;
+  readonly nextButtonTextId = `${this.instanceId}-next-text`;
+  readonly tableAriaLabelledBy = computed(() => (
+    this.hasDescription() ? `${this.titleId} ${this.descriptionId}` : this.titleId
+  ));
+  readonly previousButtonAriaLabelledBy = `${this.titleId} ${this.previousButtonTextId}`;
+  readonly nextButtonAriaLabelledBy = `${this.titleId} ${this.nextButtonTextId}`;
 
   getDetailsTooltip(row: TableCardRow): string {
     const detailLines = row.detailLines ?? [];

--- a/src/app/shared/table-card/table-card.types.ts
+++ b/src/app/shared/table-card/table-card.types.ts
@@ -2,6 +2,7 @@ export interface TableCardRow {
   readonly key: string;
   readonly primaryText: string;
   readonly value: number | string;
+  readonly emphasized?: boolean;
   readonly detailHeader?: string;
   readonly detailLines?: readonly string[];
   readonly detailLabel?: string;

--- a/src/app/shared/top-controls/team-switcher/team-switcher.component.spec.ts
+++ b/src/app/shared/top-controls/team-switcher/team-switcher.component.spec.ts
@@ -26,7 +26,7 @@ describe('TeamSwitcherComponent — desktop user flow', () => {
         await render(AppComponent, getBehaviorTestConfig({ isMobile: false }));
 
         const firstPlayerName = slicedPlayers[0].name;
-        await screen.findByText(firstPlayerName, {}, { timeout: 5000 });
+        await screen.findByText(firstPlayerName, {}, { timeout: 15000 });
 
         const reportCombobox = screen.getByRole('combobox', { name: /reportType\.selector/ });
         fireEvent.click(reportCombobox);


### PR DESCRIPTION
Summary
- Grouped draft statistics cards into clearer sections with a sticky jump bar for faster scanning.
- Added a persistent "Korosta joukkue" control that highlights the selected team across cards and jumps each card to the relevant ranking page.
- Added inline rank numbers before team names in the draft statistics view.
- Improved shared table-card accessibility by labeling each table from its card heading and making pager controls context-aware.
- Fixed the shared table-card horizontal overflow behavior so career highlights no longer show the unwanted touchpad-triggered scrollbar.

Testing
- npm run verify
