### PR TITLE
Polishments: Make highlight card screens follow common pattern and little fixes to cards

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,5 +59,6 @@ If a proposed change would alter user-visible application behavior or semantics,
 ## Playwright Rules
 - For local `npm run e2e` or other local Playwright test runs, prefer running outside the sandbox. In this repo the sandboxed path is not reliable for the Playwright web server / browser flow, while the non-sandbox path works consistently better.
 - Keep Playwright focused on automated E2E and perf-audit coverage; do not route ad hoc manual browser inspection through Playwright MCP anymore.
+- If a real `CI=true` Playwright run is needed locally and `http://localhost:4200` is already occupied by the user's frontend session, ask the user to stop that server before continuing. Do not introduce alternate local-only fixture flags as a workaround.
 
 For local Playwright E2E runs, the user controls the backend on `localhost:3000`. If it is not running, ask the user to start it instead of switching to CI-mode mocking as a workaround.

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ The docs in this repo intentionally focus on project-specific architecture, work
 	- Searchable and sortable, with no stats-page filters or mobile drawer
 	- Virtualized row rendering keeps long lists responsive
 	- Player rows show position inline with name (for example `D Travis Hamonic`) while still sorting alphabetically by player name
-	- `/career/highlights` splits compact paged highlight cards into `Sekalaiset` and `Siirrot`, covering the existing general career slices plus transaction leaders for most trades, claims, drops, and same-team reunions; each card lazy-loads its dataset as it approaches the viewport
+	- `/career/highlights` groups compact paged highlight cards under sticky jump sections (`Urateot`, `Seurapolut`, `Pitkät pestit`, `Siirrot`), keeps card datasets lazy-loaded as they approach the viewport, and shows tied ranks inline before player position when values are shared
 - 📝 **Draft Pages**: Standalone `/draft/entry-drafts`, `/draft/opening-draft`, and `/draft/statistics` browse routes now live under `Varaukset`
 	- Batch 1 adds the route shell, navigation, SEO, and the shared browse scaffolding
 		- Batch 2 turns `/draft/opening-draft` into a team-by-team accordion with simple pick rows, including traded-pick owner suffixes when the original pick belonged to another team
@@ -194,7 +194,7 @@ For planning-heavy changes, save the approved implementation plan locally under 
 
 E2E tests are organized into feature-based specs under `e2e/specs/`:
 - `smoke.spec.ts` — Core page rendering and navigation
-- `career.spec.ts` — Career players/goalies/highlights tabs, highlight section switching, paging, and route shell behavior
+- `career.spec.ts` — Career players/goalies/highlights tabs, grouped highlight section navigation, paging, and route shell behavior
 - `draft.spec.ts` — Draft route redirect/tab behavior plus entry-draft and opening-draft accordion rendering
 - `leaderboards.spec.ts` — Leaderboards redirect, regular/playoff/transactions tabs, tie-rank vs incremental position logic, and expandable season details
 - `player-card.spec.ts` — Player card dialog (open/close, tabs, graphs, direct URLs)

--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ npx playwright test e2e/specs/leaderboards.spec.ts
 Important:
 
 - Do not use `CI=true` for normal local E2E runs. In this repo that switches Playwright into the fixture-backed CI flow, which is meant for CI and explicit offline debugging, not routine local verification against your real backend.
+- If you do need a real local `CI=true` run, make sure `http://localhost:4200` is free first so Playwright can start the CI-mode server instead of colliding with an already running frontend.
 - `npx playwright test --headed` still uses the same `webServer` config. It does not disable server startup by itself; it simply opens the browser UI while Playwright starts or reuses the frontend.
 - If the backend on `localhost:3000` is not running during a paired session, ask the user to start it. Do not silently swap to CI-mode mocking for routine local verification.
 

--- a/docs/codebase-structure.md
+++ b/docs/codebase-structure.md
@@ -84,6 +84,10 @@ These routes render under the lighter root shell and intentionally avoid dashboa
 
 - compact paged card/table presentation for highlight and draft statistics views
 
+### `src/app/shared/section-jump-nav/`
+
+- shared sticky browse-route pill navigation with overflow cues for horizontally scrollable section jump bars
+
 ### `src/app/shared/player-card/`
 
 - player/goalie dialog, tabbed details, graphs, deep-link support, and in-dialog navigation

--- a/docs/component-guide.md
+++ b/docs/component-guide.md
@@ -89,8 +89,14 @@ Do not collapse these into a single "universal" table component unless the produ
 ### `TableCardComponent`
 
 - Shared compact read-only card/table used by highlight and draft statistics views
-- Keep loading, empty, error, tooltip, and paging behavior consistent across consumers
-- Preserve its semantic table labeling and optional row emphasis hooks when extending browse-oriented ranking views
+- Keep loading, empty, error, tooltip, tied-rank prefix, and paging behavior consistent across consumers
+- Preserve its semantic table labeling, optional row emphasis hooks, and accessible emoji-header help when extending browse-oriented ranking views
+
+### `SectionJumpNavComponent`
+
+- Shared sticky pill navigation used by browse-route section jump bars
+- Keep overflow-fade hints, screen-reader scroll guidance, and item-click behavior consistent across consumers
+- Prefer feeding it route-specific section metadata plus a click handler instead of re-implementing horizontal-scroll cue logic in each page
 
 ### `StartFromSeasonSwitcherComponent` And `StartFromSeasonSyncService`
 

--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -231,6 +231,7 @@ npx playwright test
 - Requires the backend API on `http://localhost:3000`
 - Playwright starts `npm start` automatically when needed, or reuses an existing frontend on `http://localhost:4200`
 - Do not use `CI=true` for routine local runs; that switches to the repo's fixture-backed CI flow instead of using your live local backend
+- If you need to reproduce real CI fixture mode locally with `CI=true`, free up `http://localhost:4200` first so Playwright can start the CI-mode web server instead of reusing your dev session
 - If the backend is not running during a collaborative session, ask the user to start it before trying fallback approaches
 
 Useful local variants:

--- a/docs/project-overview.md
+++ b/docs/project-overview.md
@@ -87,7 +87,8 @@ Accessibility is a core requirement: the UI is designed to remain usable via key
    - Searchable and sortable without the stats-page controls/drawer/comparison bar
    - Player position is rendered inline with player name while sorting still uses the underlying plain `name`
    - Uses a virtualized table implementation to keep large result sets responsive
-   - The highlights tab splits compact paged table cards into `Sekalaiset` and `Siirrot`, keeping the existing general slices while adding transaction leaders for most trades, claims, drops, and same-team reunions
+   - The highlights tab groups compact paged table cards into sticky-jump sections (`Urateot`, `Seurapolut`, `Pitkät pestit`, `Siirrot`) while keeping transaction leaders for most trades, claims, drops, and same-team reunions
+   - Highlight rows show tied ranks inline before player position when multiple players share the same value
    - Highlight cards lazy-load their API data as they enter or near the viewport so the route scales better as more cards are added
 
 7. **Draft Pages** (`/draft/entry-drafts`, `/draft/opening-draft`, `/draft/statistics`)

--- a/docs/project-testing.md
+++ b/docs/project-testing.md
@@ -286,7 +286,7 @@ E2E tests are organized into feature-based spec files under `e2e/specs/`:
 - **career.spec.ts** - Career listings and highlights
   - Career route shell and global-navigation entry
   - Player/goalie/highlights tab switching
-  - Highlights section switching between `Sekalaiset` and `Siirrot`
+  - Highlights grouped-section jump navigation and card paging
   - Search and sort behavior in the virtualized career table
   - Server-paged highlight card behavior
   - Route-specific shell behavior (no stats controls/drawer)

--- a/docs/project-testing.md
+++ b/docs/project-testing.md
@@ -222,6 +222,7 @@ Local rule of thumb:
 - Prefer normal local mode against the live backend
 - Do **not** set `CI=true` for routine local verification
 - Use the CI/fixture mode only when you intentionally want the mocked CI behavior
+- If you need a real local `CI=true` run and `http://localhost:4200` is already occupied by a manually started frontend, stop that server first so Playwright can start the CI-mode web server itself
 - If the backend on `localhost:3000` is not running in a paired session, ask the user to start it instead of swapping local verification over to CI-mode fixtures
 - When Playwright assertions need visible Finnish UI copy, source shared labels from `public/i18n/fi.json` through the E2E config helpers instead of duplicating hard-coded strings in test constants
 
@@ -483,6 +484,7 @@ Re-capture fixtures when:
 
 1. **New E2E tests** need API endpoints or parameter combinations not yet captured — add matching entries to `buildFixtureList()` in `e2e/scripts/capture-fixtures.ts`, then re-run
 2. **New season starts** (regular or playoffs) — the capture script resolves season indices dynamically, so a re-run picks up the new data automatically
+3. **Existing UI behavior changes which request variant the test uses** — for example different pagination windows, `skip`/`take` values, tabs, report types, or filters. If a touched flow can change the request shape in CI fixture mode, update either the captured fixture list or the route-mock compatibility logic and verify the affected Playwright coverage in CI mode before considering the change done
 
 ```bash
 # Requires backend running on localhost:3000
@@ -490,6 +492,13 @@ npm run e2e:capture-fixtures
 ```
 
 This fetches the API responses the E2E tests depend on and saves them as JSON files in `e2e/fixtures/data/`. Commit the updated fixtures alongside your changes.
+
+CI fixture hygiene checklist:
+
+1. If a feature changes the request URL or query params used by an existing E2E path, assume fixture coverage may need attention even if no new test file was added
+2. Check `e2e/scripts/capture-fixtures.ts` and `e2e/mocks/api-mock.ts` together: the capture script defines what gets stored, while the route mock defines how runtime requests are matched back to fixtures
+3. Prefer capturing the exact new request combination when practical; use compatibility/fallback logic only when the UI legitimately aggregates data from already captured fixture pages
+4. Before closing the batch, run the relevant Playwright coverage in real CI mode when possible so fixture mismatches surface locally instead of first failing in GitHub Actions
 
 ## Writing New Tests
 

--- a/e2e/config/test-data.ts
+++ b/e2e/config/test-data.ts
@@ -49,8 +49,10 @@ export const TAB_LABELS = {
 };
 
 export const CAREER_HIGHLIGHT_SECTION_LABELS = {
-  GENERAL: fi('career.highlights.sections.general'),
-  TRANSACTIONS: fi('career.highlights.sections.transactions'),
+  ACHIEVEMENTS: fi('career.highlights.sections.achievements.title'),
+  JOURNEYS: fi('career.highlights.sections.journeys.title'),
+  LONG_STAYS: fi('career.highlights.sections.longStays.title'),
+  TRANSACTIONS: fi('career.highlights.sections.transactions.title'),
 };
 
 export const CAREER_HIGHLIGHT_CARD_LABELS = {

--- a/e2e/fixtures/test-fixture.ts
+++ b/e2e/fixtures/test-fixture.ts
@@ -4,8 +4,8 @@ import { setupApiMocks } from '../mocks/api-mock';
 /**
  * Custom Playwright test fixture that automatically sets up API mocking in CI.
  *
- * In CI (process.env.CI is set), all requests to the backend API are intercepted
- * and served from local JSON fixture files. Locally, tests hit the live backend.
+ * In CI, all requests to the backend API are intercepted and served from local
+ * JSON fixture files. Locally, tests hit the live backend.
  */
 export const test = base.extend({
   page: async ({ page }, use) => {

--- a/e2e/mocks/api-mock.ts
+++ b/e2e/mocks/api-mock.ts
@@ -47,11 +47,65 @@ function loadFixture(filename: string): string | null {
   return content;
 }
 
+function loadFixtureJson<T>(filename: string): T | null {
+  const body = loadFixture(filename);
+  return body === null ? null : JSON.parse(body) as T;
+}
+
+function buildCareerHighlightsFallback(url: URL): string | null {
+  const match = url.pathname.match(/^\/(?:api\/)?career\/highlights\/([^/]+)$/);
+  if (!match) {
+    return null;
+  }
+
+  const type = match[1];
+  const skip = Number(url.searchParams.get('skip') ?? '0');
+  const take = Number(url.searchParams.get('take') ?? '0');
+
+  if (!Number.isFinite(skip) || !Number.isFinite(take) || skip !== 0 || take <= 0) {
+    return null;
+  }
+
+  type CareerHighlightsFixture = {
+    readonly items: readonly unknown[];
+    readonly skip: number;
+    readonly take: number;
+    readonly total: number;
+    readonly minAllowed?: number;
+    readonly type: string;
+  };
+
+  const page0 = loadFixtureJson<CareerHighlightsFixture>(
+    `career--highlights--${type}--skip=0--take=10.json`,
+  );
+  if (!page0) {
+    return null;
+  }
+
+  const combinedItems = [...page0.items];
+
+  if (take > combinedItems.length) {
+    const page1 = loadFixtureJson<CareerHighlightsFixture>(
+      `career--highlights--${type}--skip=10--take=10.json`,
+    );
+    if (page1) {
+      combinedItems.push(...page1.items);
+    }
+  }
+
+  return JSON.stringify({
+    ...page0,
+    skip: 0,
+    take,
+    items: combinedItems.slice(0, take),
+  });
+}
+
 /** Route handler that maps requests to fixture files */
 function handleRoute(route: Parameters<Parameters<Page['route']>[1]>[0]): Promise<void> {
   const url = new URL(route.request().url());
   const filename = urlToFixtureName(url);
-  const body = loadFixture(filename);
+  const body = loadFixture(filename) ?? buildCareerHighlightsFallback(url);
 
   if (body === null) {
     return route.fulfill({

--- a/e2e/page-objects/ComparisonBar.ts
+++ b/e2e/page-objects/ComparisonBar.ts
@@ -8,7 +8,7 @@ export class ComparisonBar {
   constructor(private page: Page) {}
 
   private get bar() {
-    return this.page.locator('[role="status"]');
+    return this.page.locator('.comparison-bar');
   }
 
   /**
@@ -55,5 +55,6 @@ export class ComparisonBar {
    */
   async clickClear(): Promise<void> {
     await this.page.getByRole('button', { name: 'Tyhjennä' }).click();
+    await this.bar.waitFor({ state: 'hidden' });
   }
 }

--- a/e2e/specs/career.spec.ts
+++ b/e2e/specs/career.spec.ts
@@ -34,18 +34,33 @@ test.describe('Career listings', () => {
     await expect(page).toHaveURL(/\/career\/highlights$/);
     await expect(highlightsTab).toHaveAttribute('aria-selected', 'true');
     const highlightCards = page.locator('app-table-card');
+    const highlightsJumpNav = page.getByRole('navigation', {
+      name: fi('career.highlights.jumpNavAriaLabel'),
+    });
     await expect(highlightCards).toHaveCount(CAREER_HIGHLIGHT_CARD_TYPES.length);
     await expect(
-      page.getByRole('button', { name: CAREER_HIGHLIGHT_SECTION_LABELS.ACHIEVEMENTS }),
+      highlightsJumpNav.getByRole('button', {
+        name: CAREER_HIGHLIGHT_SECTION_LABELS.ACHIEVEMENTS,
+        exact: true,
+      }),
     ).toBeVisible();
     await expect(
-      page.getByRole('button', { name: CAREER_HIGHLIGHT_SECTION_LABELS.JOURNEYS }),
+      highlightsJumpNav.getByRole('button', {
+        name: CAREER_HIGHLIGHT_SECTION_LABELS.JOURNEYS,
+        exact: true,
+      }),
     ).toBeVisible();
     await expect(
-      page.getByRole('button', { name: CAREER_HIGHLIGHT_SECTION_LABELS.LONG_STAYS }),
+      highlightsJumpNav.getByRole('button', {
+        name: CAREER_HIGHLIGHT_SECTION_LABELS.LONG_STAYS,
+        exact: true,
+      }),
     ).toBeVisible();
     await expect(
-      page.getByRole('button', { name: CAREER_HIGHLIGHT_SECTION_LABELS.TRANSACTIONS }),
+      highlightsJumpNav.getByRole('button', {
+        name: CAREER_HIGHLIGHT_SECTION_LABELS.TRANSACTIONS,
+        exact: true,
+      }),
     ).toBeVisible();
 
     for (let index = 0; index < CAREER_HIGHLIGHT_CARD_TYPES.length; index += 1) {
@@ -94,8 +109,12 @@ test.describe('Career listings', () => {
     await page.goto('/career/highlights');
     await expect(page).toHaveURL(/\/career\/highlights$/);
 
-    const transactionsSection = page.getByRole('button', {
+    const highlightsJumpNav = page.getByRole('navigation', {
+      name: fi('career.highlights.jumpNavAriaLabel'),
+    });
+    const transactionsSection = highlightsJumpNav.getByRole('button', {
       name: CAREER_HIGHLIGHT_SECTION_LABELS.TRANSACTIONS,
+      exact: true,
     });
 
     await transactionsSection.click();

--- a/e2e/specs/career.spec.ts
+++ b/e2e/specs/career.spec.ts
@@ -8,8 +8,7 @@ import {
   TAB_LABELS,
 } from '../config/test-data';
 import {
-  GENERAL_CAREER_HIGHLIGHT_CARD_TYPES,
-  TRANSACTION_CAREER_HIGHLIGHT_CARD_TYPES,
+  CAREER_HIGHLIGHT_CARD_TYPES,
 } from '../../src/app/career/highlights/career-highlights.constants';
 
 test.describe('Career listings', () => {
@@ -35,8 +34,21 @@ test.describe('Career listings', () => {
     await expect(page).toHaveURL(/\/career\/highlights$/);
     await expect(highlightsTab).toHaveAttribute('aria-selected', 'true');
     const highlightCards = page.locator('app-table-card');
-    await expect(highlightCards).toHaveCount(GENERAL_CAREER_HIGHLIGHT_CARD_TYPES.length);
-    for (let index = 0; index < GENERAL_CAREER_HIGHLIGHT_CARD_TYPES.length; index += 1) {
+    await expect(highlightCards).toHaveCount(CAREER_HIGHLIGHT_CARD_TYPES.length);
+    await expect(
+      page.getByRole('button', { name: CAREER_HIGHLIGHT_SECTION_LABELS.ACHIEVEMENTS }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole('button', { name: CAREER_HIGHLIGHT_SECTION_LABELS.JOURNEYS }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole('button', { name: CAREER_HIGHLIGHT_SECTION_LABELS.LONG_STAYS }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole('button', { name: CAREER_HIGHLIGHT_SECTION_LABELS.TRANSACTIONS }),
+    ).toBeVisible();
+
+    for (let index = 0; index < CAREER_HIGHLIGHT_CARD_TYPES.length; index += 1) {
       const card = highlightCards.nth(index);
       await card.scrollIntoViewIfNeeded();
       await expect(card.getByRole('table')).toBeVisible();
@@ -78,23 +90,22 @@ test.describe('Career listings', () => {
     expect(await goalieRows.count()).toBeGreaterThan(0);
   });
 
-  test('switches career highlights to transactions and renders the transaction cards', async ({ page }) => {
+  test('scrolls career highlights to the transactions section and keeps all grouped sections available', async ({ page }) => {
     await page.goto('/career/highlights');
     await expect(page).toHaveURL(/\/career\/highlights$/);
 
-    const generalSection = page.getByRole('radio', {
-      name: CAREER_HIGHLIGHT_SECTION_LABELS.GENERAL,
-    });
-    const transactionsSection = page.getByRole('radio', {
+    const transactionsSection = page.getByRole('button', {
       name: CAREER_HIGHLIGHT_SECTION_LABELS.TRANSACTIONS,
     });
 
-    await expect(generalSection).toHaveAttribute('aria-checked', 'true');
     await transactionsSection.click();
-    await expect(transactionsSection).toHaveAttribute('aria-checked', 'true');
+    await expect(page).toHaveURL(/\/career\/highlights#career-highlights-section-transactions$/);
 
     const highlightCards = page.locator('app-table-card');
-    await expect(highlightCards).toHaveCount(TRANSACTION_CAREER_HIGHLIGHT_CARD_TYPES.length);
+    await expect(highlightCards).toHaveCount(CAREER_HIGHLIGHT_CARD_TYPES.length);
+    await expect(
+      page.getByRole('heading', { level: 4, name: CAREER_HIGHLIGHT_SECTION_LABELS.TRANSACTIONS }),
+    ).toBeVisible();
     await expect(
       page.getByRole('heading', { name: CAREER_HIGHLIGHT_CARD_LABELS.MOST_TRADES })
     ).toBeVisible();
@@ -107,11 +118,14 @@ test.describe('Career listings', () => {
     await expect(
       page.getByRole('heading', { name: CAREER_HIGHLIGHT_CARD_LABELS.REUNION_KING })
     ).toBeVisible();
+    await expect(
+      page.getByRole('heading', { name: fi('career.highlights.cards.mostTeamsPlayed.title') }),
+    ).toBeVisible();
 
-    for (let index = 0; index < TRANSACTION_CAREER_HIGHLIGHT_CARD_TYPES.length; index += 1) {
-      const card = highlightCards.nth(index);
-      await card.scrollIntoViewIfNeeded();
-      await expect(card.getByRole('table')).toBeVisible();
-    }
+    const transactionsCard = page.getByRole('heading', {
+      name: CAREER_HIGHLIGHT_CARD_LABELS.MOST_TRADES,
+    }).locator('xpath=ancestor::app-table-card[1]');
+    await transactionsCard.scrollIntoViewIfNeeded();
+    await expect(transactionsCard.getByRole('table')).toBeVisible();
   });
 });

--- a/public/i18n/fi.json
+++ b/public/i18n/fi.json
@@ -24,18 +24,37 @@
     },
     "highlights": {
       "sectionTitle": "Uranostot",
-      "sectionSwitcher": {
-        "ariaLabel": "Nostoryhmä"
-      },
+      "jumpNavAriaLabel": "Uranostojen osiot",
       "sections": {
-        "general": "Sekalaiset",
-        "transactions": "Siirrot"
+        "achievements": {
+          "title": "Ura",
+          "description": "Saavutusia uran varrelta."
+        },
+        "journeys": {
+          "title": "Kiertolaiset",
+          "description": "Eniten eri seuroissa viihtyneet pelaajat."
+        },
+        "longStays": {
+          "title": "Seuraikonit",
+          "description": "Samaan seuraan jämähtäneet pelaajat."
+        },
+        "transactions": {
+          "title": "Siirrot",
+          "description": "Eniten liikkuneet pelaajat."
+        }
       },
       "columns": {
         "player": "Pelaaja",
         "teamCount": "Seurat",
         "seasonCount": "Kaudet",
         "games": "Ott."
+      },
+      "columnHelp": {
+        "cups": "Stanley Cup -sormukset",
+        "reunions": "Paluut samaan seuraan",
+        "trades": "Kaupat",
+        "claims": "Nostot",
+        "drops": "Pudotukset"
       },
       "cards": {
         "mostTeamsPlayed": {
@@ -280,6 +299,8 @@
       "details": "Lisätiedot"
     },
     "showDetails": "Näytä lisätiedot: {{label}}",
+    "rankAriaLabel": "{{rank}}. sija",
+    "tiedRankAriaLabel": "Tasajaettu {{rank}}. sija",
     "loadWhenVisible": "Kortin data ladataan, kun se tulee näkyviin.",
     "apiUnavailable": "Korttidata ei ole saatavilla juuri nyt. Yritä hetken päästä uudelleen.",
     "noResults": "Ei tuloksia.",
@@ -288,6 +309,9 @@
     "previousPage": "Näytä edelliset rivit",
     "nextPage": "Näytä seuraavat rivit",
     "paginationSummary": "{{start}}-{{end}} / {{total}}"
+  },
+  "sectionJumpNav": {
+    "horizontalScrollHint": "Vieritä sivusuunnassa nähdäksesi kaikki osiot."
   },
   "a11y": {
     "skipToTable": "Siirry taulukkoon",

--- a/src/app/app.component.mobile.spec.ts
+++ b/src/app/app.component.mobile.spec.ts
@@ -302,16 +302,18 @@ describe('AppComponent — mobile frontpage', { timeout: 60_000 }, () => {
       screen.getByRole('heading', { name: 'career.highlights.cards.stashKing.title' })
     ).toBeInTheDocument();
     expect(
-      screen.getByRole('radio', { name: 'career.highlights.sections.general' })
-    ).toHaveAttribute('aria-checked', 'true');
-    expect(
-      screen.getByRole('radio', { name: 'career.highlights.sections.transactions' })
+      screen.getByRole('button', { name: 'career.highlights.sections.achievements.title' })
     ).toBeInTheDocument();
-    expect(screen.getAllByRole('heading', { level: 3 })).toHaveLength(8);
-
-    fireEvent.click(
-      screen.getByRole('radio', { name: 'career.highlights.sections.transactions' })
+    expect(
+      screen.getByRole('button', { name: 'career.highlights.sections.journeys.title' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'career.highlights.sections.longStays.title' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'career.highlights.sections.transactions.title' })
     );
+    expect(screen.getAllByRole('heading', { level: 4 })).toHaveLength(4);
 
     expect(
       await screen.findByRole(
@@ -330,8 +332,8 @@ describe('AppComponent — mobile frontpage', { timeout: 60_000 }, () => {
       screen.getByRole('heading', { name: 'career.highlights.cards.reunionKing.title' })
     ).toBeInTheDocument();
     expect(
-      screen.queryByRole('heading', { name: 'career.highlights.cards.mostTeamsPlayed.title' })
-    ).not.toBeInTheDocument();
+      screen.getByRole('heading', { name: 'career.highlights.cards.mostTeamsPlayed.title' })
+    ).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('tab', { name: 'career.tabs.goalies' }));
     await vi.waitFor(() => {

--- a/src/app/career/highlights/career-highlights.component.html
+++ b/src/app/career/highlights/career-highlights.component.html
@@ -7,46 +7,53 @@
     {{ 'career.highlights.sectionTitle' | translate }}
   </h3>
 
-  <div class="career-highlights-controls">
-    <mat-button-toggle-group
-      class="career-highlights-section-switch"
-      [value]="selectedSection()"
-      (change)="onSectionChange($event)"
-      [attr.aria-label]="
-        'career.highlights.sectionSwitcher.ariaLabel' | translate
-      "
-    >
-      <mat-button-toggle value="general">
-        {{ 'career.highlights.sections.general' | translate }}
-      </mat-button-toggle>
-      <mat-button-toggle value="transactions">
-        {{ 'career.highlights.sections.transactions' | translate }}
-      </mat-button-toggle>
-    </mat-button-toggle-group>
-  </div>
+  <app-section-jump-nav
+    class="career-highlights-jump-nav"
+    [items]="jumpNavItems"
+    ariaLabelKey="career.highlights.jumpNavAriaLabel"
+    (itemSelected)="scrollToSection($event)"
+  />
 
-  <div class="career-highlights-grid">
-    @for (card of cards(); track card.type) {
-      <app-table-card
-        class="career-highlights-card"
-        appActivateOnViewport
-        (appActivateOnViewportVisible)="activateCard(card.type)"
-        [titleKey]="card.state.titleKey"
-        [descriptionKey]="card.state.descriptionKey"
-        [descriptionRequiresParams]="card.state.descriptionRequiresParams"
-        [descriptionParams]="card.state.descriptionParams"
-        primaryColumnLabelKey="career.highlights.columns.player"
-        [valueColumnLabelKey]="card.state.valueColumnLabelKey"
-        [deferred]="!card.state.activated"
-        [rows]="card.state.rows"
-        [loading]="card.state.loading"
-        [apiError]="card.state.apiError"
-        [skip]="card.state.skip"
-        [take]="card.state.take"
-        [total]="card.state.total"
-        (previousPageRequested)="loadPreviousPage(card.type)"
-        (nextPageRequested)="loadNextPage(card.type)"
-      />
-    }
-  </div>
+  @for (section of sections(); track section.id) {
+    <section
+      class="career-highlights-section"
+      [attr.id]="section.anchorId"
+      [attr.aria-labelledby]="section.headingId"
+    >
+      <header class="career-highlights-section-header">
+        <h4 class="career-highlights-section-title" [id]="section.headingId">
+          {{ section.titleKey | translate }}
+        </h4>
+        <p class="career-highlights-section-description">
+          {{ section.descriptionKey | translate }}
+        </p>
+      </header>
+
+      <div class="career-highlights-grid">
+        @for (card of section.cards; track card.type) {
+          <app-table-card
+            class="career-highlights-card"
+            appActivateOnViewport
+            (appActivateOnViewportVisible)="activateCard(card.type)"
+            [titleKey]="card.state.titleKey"
+            [descriptionKey]="card.state.descriptionKey"
+            [descriptionRequiresParams]="card.state.descriptionRequiresParams"
+            [descriptionParams]="card.state.descriptionParams"
+            primaryColumnLabelKey="career.highlights.columns.player"
+            [valueColumnLabelKey]="card.state.valueColumnLabelKey"
+            [valueColumnTooltipKey]="card.state.valueColumnTooltipKey"
+            [deferred]="!card.state.activated"
+            [rows]="card.state.rows"
+            [loading]="card.state.loading"
+            [apiError]="card.state.apiError"
+            [skip]="card.state.skip"
+            [take]="card.state.take"
+            [total]="card.state.total"
+            (previousPageRequested)="loadPreviousPage(card.type)"
+            (nextPageRequested)="loadNextPage(card.type)"
+          />
+        }
+      </div>
+    </section>
+  }
 </section>

--- a/src/app/career/highlights/career-highlights.component.scss
+++ b/src/app/career/highlights/career-highlights.component.scss
@@ -4,23 +4,37 @@
 
 .career-highlights {
   width: 100%;
+  padding-bottom: 24px;
 }
 
-.career-highlights-controls {
-  display: flex;
-  justify-content: center;
-  margin: 24px 24px 0;
-  overflow-x: auto;
+.career-highlights-jump-nav {
+  --section-jump-nav-margin: 16px 24px 0;
 }
 
-.career-highlights-section-switch {
-  flex: 0 0 auto;
-  max-width: 100%;
+.career-highlights-section {
+  margin: 20px 24px 0;
+  scroll-margin-top: 80px;
+}
+
+.career-highlights-section-header {
+  margin-bottom: 14px;
+}
+
+.career-highlights-section-title {
+  margin: 0;
+  color: var(--mat-sys-on-surface);
+  font-size: 1.15rem;
+  line-height: 1.35;
+}
+
+.career-highlights-section-description {
+  margin: 6px 0 0;
+  color: var(--mat-sys-on-surface-variant);
+  line-height: 1.55;
 }
 
 .career-highlights-grid {
   display: grid;
-  margin: 20px 24px 24px;
   gap: 20px;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   align-items: stretch;
@@ -37,12 +51,20 @@
 }
 
 @media (max-width: 480px) {
-  .career-highlights-controls {
-    margin: 12px 8px 0;
+  .career-highlights {
+    padding-bottom: 8px;
+  }
+
+  .career-highlights-jump-nav {
+    --section-jump-nav-margin: 12px 8px 0;
+    --section-jump-nav-sticky-top: 6px;
+  }
+
+  .career-highlights-section {
+    margin: 14px 8px 0;
   }
 
   .career-highlights-grid {
-    margin: 12px 8px 8px;
     gap: 12px;
   }
 }

--- a/src/app/career/highlights/career-highlights.component.spec.ts
+++ b/src/app/career/highlights/career-highlights.component.spec.ts
@@ -20,7 +20,8 @@ import {
   sameTeamSeasonsHighlightsPage0Fixture,
 } from '../../testing/behavior-test-utils';
 import {
-  GENERAL_CAREER_HIGHLIGHT_CARD_TYPES,
+  CAREER_HIGHLIGHT_CARD_TYPES,
+  CAREER_HIGHLIGHT_SECTIONS,
 } from './career-highlights.constants';
 import { CareerHighlightsComponent } from './career-highlights.component';
 
@@ -71,6 +72,16 @@ class FakeIntersectionObserver {
   }
 }
 
+const mostTeamsPlayedHighlightsFullFixture = {
+  ...mostTeamsPlayedHighlightsPage0Fixture,
+  skip: 0,
+  take: 21,
+  items: [
+    ...mostTeamsPlayedHighlightsPage0Fixture.items,
+    ...mostTeamsPlayedHighlightsPage1Fixture.items,
+  ],
+};
+
 describe('CareerHighlightsComponent', () => {
   beforeEach(() => {
     FakeIntersectionObserver.instances = [];
@@ -84,15 +95,15 @@ describe('CareerHighlightsComponent', () => {
     vi.unstubAllGlobals();
   });
 
-  it('loads only activated cards first and fetches additional cards when they approach the viewport', async () => {
+  it('renders grouped sections, lazy-loads cards on viewport entry, and applies tied ranks across paged career rows', async () => {
     const getCareerHighlights = vi.fn(
-      (type: CareerHighlightType, skip = 0) => {
+      (type: CareerHighlightType, _skip = 0, take = 10) => {
         switch (type) {
           case 'most-teams-played':
             return of(
-              skip >= 10
-                ? mostTeamsPlayedHighlightsPage1Fixture
-                : mostTeamsPlayedHighlightsPage0Fixture
+              take > 11
+                ? mostTeamsPlayedHighlightsFullFixture
+                : mostTeamsPlayedHighlightsPage0Fixture,
             );
           case 'most-teams-owned':
             return of(mostTeamsOwnedHighlightsPage0Fixture);
@@ -115,7 +126,7 @@ describe('CareerHighlightsComponent', () => {
           case 'reunion-king':
             return of(reunionKingHighlightsPage0Fixture);
         }
-      }
+      },
     );
 
     await render(CareerHighlightsComponent, {
@@ -133,79 +144,54 @@ describe('CareerHighlightsComponent', () => {
     });
 
     expect(
-      await screen.findByRole('heading', { name: 'career.highlights.cards.mostTeamsPlayed.title' })
+      await screen.findByRole('button', {
+        name: 'career.highlights.sections.achievements.title',
+      }),
     ).toBeInTheDocument();
     expect(
-      screen.getByRole('heading', {
-        name: 'career.highlights.cards.mostTeamsOwned.title',
-      })
+      screen.getByRole('button', {
+        name: 'career.highlights.sections.journeys.title',
+      }),
     ).toBeInTheDocument();
     expect(
-      screen.getByRole('heading', {
-        name: 'career.highlights.cards.mostStanleyCups.title',
-      })
+      screen.getByRole('button', {
+        name: 'career.highlights.sections.longStays.title',
+      }),
     ).toBeInTheDocument();
     expect(
-      screen.getByRole('heading', {
-        name: 'career.highlights.cards.regularGrinderWithoutPlayoffs.title',
-      })
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole('heading', {
-        name: 'career.highlights.cards.sameTeamSeasonsPlayed.title',
-      })
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole('heading', {
-        name: 'career.highlights.cards.sameTeamSeasonsOwned.title',
-      })
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole('heading', {
-        name: 'career.highlights.cards.stashKing.title',
-      })
+      screen.getByRole('button', {
+        name: 'career.highlights.sections.transactions.title',
+      }),
     ).toBeInTheDocument();
 
     await vi.waitFor(() => {
-      expect(FakeIntersectionObserver.instances).toHaveLength(GENERAL_CAREER_HIGHLIGHT_CARD_TYPES.length);
+      expect(FakeIntersectionObserver.instances).toHaveLength(CAREER_HIGHLIGHT_CARD_TYPES.length);
     });
 
     expect(getCareerHighlights).not.toHaveBeenCalled();
-    expect(screen.getAllByText('tableCard.loadWhenVisible')).toHaveLength(GENERAL_CAREER_HIGHLIGHT_CARD_TYPES.length);
+    expect(screen.getAllByText('tableCard.loadWhenVisible')).toHaveLength(
+      CAREER_HIGHLIGHT_CARD_TYPES.length,
+    );
 
     FakeIntersectionObserver.instances[0]?.trigger();
-    FakeIntersectionObserver.instances[2]?.trigger();
+    FakeIntersectionObserver.instances[9]?.trigger();
 
-    const mostTeamsCardTitle = screen.getByRole('heading', {
+    const mostTeamsCard = screen.getByRole('heading', {
       name: 'career.highlights.cards.mostTeamsPlayed.title',
-    });
-    const stanleyCupCardTitle = screen.getByRole('heading', {
+    }).closest('mat-card') as HTMLElement | null;
+    const stanleyCupCard = screen.getByRole('heading', {
       name: 'career.highlights.cards.mostStanleyCups.title',
-    });
-    const mostTeamsCard = mostTeamsCardTitle.closest('mat-card') as HTMLElement | null;
-    const stanleyCupCard = stanleyCupCardTitle.closest('mat-card') as HTMLElement | null;
+    }).closest('mat-card') as HTMLElement | null;
 
     expect(mostTeamsCard).not.toBeNull();
     expect(stanleyCupCard).not.toBeNull();
     expect(await within(mostTeamsCard!).findByText('F Jamie Benn')).toBeInTheDocument();
+    expect(within(mostTeamsCard!).getAllByText('T1.')).toHaveLength(2);
     expect(await within(stanleyCupCard!).findByText('F Patrick Maroon')).toBeInTheDocument();
-    expect(getCareerHighlights).toHaveBeenCalledTimes(2);
-    expect(getCareerHighlights).toHaveBeenNthCalledWith(1, 'most-stanley-cups', 0, 10);
-    expect(getCareerHighlights).toHaveBeenNthCalledWith(2, 'most-teams-played', 0, 10);
-    expect(within(stanleyCupCard!).getByText('💍')).toBeInTheDocument();
-    expect(within(stanleyCupCard!).getByText('3')).toBeInTheDocument();
-    expect(within(stanleyCupCard!).queryByText('D Victor Hedman')).not.toBeInTheDocument();
+    expect(within(stanleyCupCard!).getByLabelText('career.highlights.columnHelp.cups')).toBeInTheDocument();
 
-    FakeIntersectionObserver.instances[4]?.trigger();
-
-    const sameTeamPlayedCardTitle = screen.getByRole('heading', {
-      name: 'career.highlights.cards.sameTeamSeasonsPlayed.title',
-    });
-    const sameTeamPlayedCard = sameTeamPlayedCardTitle.closest('mat-card') as HTMLElement | null;
-
-    expect(sameTeamPlayedCard).not.toBeNull();
-    expect(await within(sameTeamPlayedCard!).findByText('D Victor Hedman')).toBeInTheDocument();
-    expect(getCareerHighlights).toHaveBeenCalledWith('same-team-seasons-played', 0, 10);
+    expect(getCareerHighlights).toHaveBeenNthCalledWith(1, 'most-stanley-cups', 0, 11);
+    expect(getCareerHighlights).toHaveBeenNthCalledWith(2, 'most-teams-played', 0, 11);
 
     fireEvent.click(within(mostTeamsCard!).getByRole('button', {
       name: /career\.highlights\.cards\.mostTeamsPlayed\.title.*tableCard\.next/,
@@ -213,10 +199,11 @@ describe('CareerHighlightsComponent', () => {
 
     expect(await within(mostTeamsCard!).findByText('F Anthony Duclair')).toBeInTheDocument();
     expect(within(mostTeamsCard!).queryByText('F Jamie Benn')).not.toBeInTheDocument();
-    expect(getCareerHighlights).toHaveBeenCalledWith('most-teams-played', 10, 10);
+    expect(within(mostTeamsCard!).getAllByText('T7.')).toHaveLength(2);
+    expect(getCareerHighlights).toHaveBeenLastCalledWith('most-teams-played', 0, 21);
   });
 
-  it('switches to transactions, keeps reunion-king last, and preserves tooltip content order', async () => {
+  it('keeps all grouped sections visible, scrolls jump navigation to the target section, and preserves transaction tooltip ordering', async () => {
     const getCareerHighlights = vi.fn((type: CareerHighlightType) => {
       switch (type) {
         case 'most-teams-played':
@@ -259,80 +246,66 @@ describe('CareerHighlightsComponent', () => {
     });
 
     await vi.waitFor(() => {
-      expect(FakeIntersectionObserver.instances).toHaveLength(GENERAL_CAREER_HIGHLIGHT_CARD_TYPES.length);
+      expect(FakeIntersectionObserver.instances).toHaveLength(CAREER_HIGHLIGHT_CARD_TYPES.length);
     });
 
-    fireEvent.click(
-      screen.getByRole('radio', {
-        name: 'career.highlights.sections.transactions',
-      }),
+    expect(
+      screen.getAllByRole('heading', { level: 4 }).map((heading) => heading.textContent?.trim()),
+    ).toEqual(CAREER_HIGHLIGHT_SECTIONS.map((section) => section.titleKey));
+
+    const transactionsSection = view.fixture.nativeElement.querySelector(
+      '#career-highlights-section-transactions',
+    ) as HTMLElement | null;
+
+    expect(transactionsSection).not.toBeNull();
+
+    const scrollIntoView = vi.fn();
+    Object.defineProperty(transactionsSection, 'scrollIntoView', {
+      value: scrollIntoView,
+      configurable: true,
+    });
+
+    const replaceStateSpy = vi.spyOn(window.history, 'replaceState');
+
+    fireEvent.click(screen.getByRole('button', {
+      name: 'career.highlights.sections.transactions.title',
+    }));
+
+    expect(replaceStateSpy).toHaveBeenCalledWith(
+      null,
+      '',
+      `${window.location.pathname}${window.location.search}#career-highlights-section-transactions`,
     );
-
-    expect(
-      screen.queryByRole('heading', {
-        name: 'career.highlights.cards.mostTeamsPlayed.title',
-      }),
-    ).not.toBeInTheDocument();
-    expect(
-      await screen.findByRole('heading', {
-        name: 'career.highlights.cards.mostTrades.title',
-      }),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole('heading', {
-        name: 'career.highlights.cards.mostClaims.title',
-      }),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole('heading', {
-        name: 'career.highlights.cards.mostDrops.title',
-      }),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole('heading', {
-        name: 'career.highlights.cards.reunionKing.title',
-      }),
-    ).toBeInTheDocument();
-    expect(screen.getAllByText('tableCard.loadWhenVisible')).toHaveLength(4);
-    expect(
-      screen.getAllByRole('heading', { level: 3 }).map((heading) => heading.textContent?.trim()),
-    ).toEqual([
-      'career.highlights.sectionTitle',
-      'career.highlights.cards.mostTrades.title',
-      'career.highlights.cards.mostClaims.title',
-      'career.highlights.cards.mostDrops.title',
-      'career.highlights.cards.reunionKing.title',
-    ]);
-
-    const transactionObservers = FakeIntersectionObserver.instances.slice(-4);
-    transactionObservers[0]?.trigger();
-    transactionObservers[3]?.trigger();
-
-    const tradesCardTitle = screen.getByRole('heading', {
-      name: 'career.highlights.cards.mostTrades.title',
+    expect(scrollIntoView).toHaveBeenCalledWith({
+      block: 'start',
+      inline: 'nearest',
+      behavior: 'smooth',
     });
-    const tradesCard = tradesCardTitle.closest('mat-card') as HTMLElement | null;
+
+    FakeIntersectionObserver.instances[2]?.trigger();
+    FakeIntersectionObserver.instances[5]?.trigger();
+
+    const tradesCard = screen.getByRole('heading', {
+      name: 'career.highlights.cards.mostTrades.title',
+    }).closest('mat-card') as HTMLElement | null;
 
     expect(tradesCard).not.toBeNull();
     expect(await within(tradesCard!).findByText('F Mike Hoffman')).toBeInTheDocument();
     expect(within(tradesCard!).getByText('6')).toBeInTheDocument();
-    expect(getCareerHighlights).toHaveBeenCalledWith('most-trades', 0, 10);
+    expect(getCareerHighlights).toHaveBeenCalledWith('most-trades', 0, 11);
+    expect(getCareerHighlights).toHaveBeenCalledWith('reunion-king', 0, 11);
 
-    const tradesState = view.fixture.componentInstance
-      .cards()
-      .find((card) => card.type === 'most-trades')?.state;
+    const transactionSection = view.fixture.componentInstance.sections().find(
+      (section) => section.id === 'transactions',
+    );
+    const tradesState = transactionSection?.cards.find((card) => card.type === 'most-trades')?.state;
+    const reunionState = transactionSection?.cards.find((card) => card.type === 'reunion-king')?.state;
 
     expect(tradesState?.rows[0]?.detailLines).toEqual([
       'Colorado Avalanche 3',
       'Dallas Stars 2',
       'Carolina Hurricanes 1',
     ]);
-
-    const reunionState = view.fixture.componentInstance
-      .cards()
-      .find((card) => card.type === 'reunion-king')?.state;
-
-    expect(getCareerHighlights).toHaveBeenCalledWith('reunion-king', 0, 10);
     expect(reunionState?.descriptionParams).toEqual({ minAllowed: 2 });
     expect(reunionState?.rows[0]).toMatchObject({
       primaryText: 'F Mikael Granlund',
@@ -369,15 +342,15 @@ describe('CareerHighlightsComponent', () => {
                           ? stashKingHighlightsPage0Fixture
                           : type === 'most-trades'
                             ? mostTradesHighlightsPage0Fixture
-                          : type === 'most-claims'
+                            : type === 'most-claims'
                               ? mostClaimsHighlightsPage0Fixture
                               : type === 'most-drops'
                                 ? mostDropsHighlightsPage0Fixture
                                 : type === 'reunion-king'
                                   ? reunionKingHighlightsPage0Fixture
-                    : type === 'same-team-seasons-played'
-                      ? sameTeamSeasonsHighlightsPage0Fixture
-                      : mostTeamsPlayedHighlightsPage0Fixture
+                                  : type === 'same-team-seasons-played'
+                                    ? sameTeamSeasonsHighlightsPage0Fixture
+                                    : mostTeamsPlayedHighlightsPage0Fixture,
                 ),
           },
         },
@@ -385,25 +358,21 @@ describe('CareerHighlightsComponent', () => {
     });
 
     await vi.waitFor(() => {
-      expect(FakeIntersectionObserver.instances).toHaveLength(7);
+      expect(FakeIntersectionObserver.instances).toHaveLength(CAREER_HIGHLIGHT_CARD_TYPES.length);
     });
 
-    FakeIntersectionObserver.instances[2]?.trigger();
-    FakeIntersectionObserver.instances[5]?.trigger();
+    FakeIntersectionObserver.instances[7]?.trigger();
+    FakeIntersectionObserver.instances[9]?.trigger();
 
-    const mostTeamsPlayedCardTitle = await screen.findByRole('heading', {
+    const mostTeamsPlayedCard = await screen.findByRole('heading', {
       name: 'career.highlights.cards.mostTeamsPlayed.title',
-    });
-    const mostTeamsOwnedCardTitle = screen.getByRole('heading', {
+    }).then((heading) => heading.closest('mat-card')) as HTMLElement | null;
+    const mostTeamsOwnedCard = screen.getByRole('heading', {
       name: 'career.highlights.cards.mostTeamsOwned.title',
-    });
-    const sameTeamOwnedCardTitle = screen.getByRole('heading', {
+    }).closest('mat-card') as HTMLElement | null;
+    const sameTeamOwnedCard = screen.getByRole('heading', {
       name: 'career.highlights.cards.sameTeamSeasonsOwned.title',
-    });
-
-    const mostTeamsPlayedCard = mostTeamsPlayedCardTitle.closest('mat-card') as HTMLElement | null;
-    const mostTeamsOwnedCard = mostTeamsOwnedCardTitle.closest('mat-card') as HTMLElement | null;
-    const sameTeamOwnedCard = sameTeamOwnedCardTitle.closest('mat-card') as HTMLElement | null;
+    }).closest('mat-card') as HTMLElement | null;
 
     expect(mostTeamsPlayedCard).not.toBeNull();
     expect(mostTeamsOwnedCard).not.toBeNull();

--- a/src/app/career/highlights/career-highlights.component.ts
+++ b/src/app/career/highlights/career-highlights.component.ts
@@ -1,18 +1,16 @@
+import { DOCUMENT, isPlatformBrowser } from '@angular/common';
 import {
   ChangeDetectionStrategy,
   Component,
   DestroyRef,
-  WritableSignal,
   OnInit,
+  PLATFORM_ID,
+  WritableSignal,
   computed,
   inject,
   signal,
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import {
-  MatButtonToggleChange,
-  MatButtonToggleModule,
-} from '@angular/material/button-toggle';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 
 import {
@@ -27,20 +25,22 @@ import {
   CareerTransactionHighlightPage,
 } from '@services/api.service';
 import { FooterVisibilityService } from '@services/footer-visibility.service';
+import { SectionJumpNavComponent } from '@shared/section-jump-nav/section-jump-nav.component';
 import { TableCardComponent } from '@shared/table-card/table-card.component';
 import { TableCardRow } from '@shared/table-card/table-card.types';
+import { deriveTiedRanks, formatTiedRankLabel } from '@shared/utils/rank.utils';
 import { formatPlayoffYear } from '@shared/utils/season.utils';
 
 import { ActivateOnViewportDirective } from './activate-on-viewport.directive';
 import {
-  CAREER_HIGHLIGHT_CARD_TYPES_BY_SECTION,
-  CareerHighlightSection,
+  CAREER_HIGHLIGHT_SECTIONS,
+  CareerHighlightSectionId,
   CareerHighlightsUiType,
 } from './career-highlights.constants';
 import { formatReunionDetailLines } from './career-highlights.utils';
 import {
   CareerHighlightCardState,
-  CareerHighlightCardView,
+  CareerHighlightSectionView,
   HighlightDescriptionParams,
 } from './career-highlights.types';
 
@@ -52,13 +52,20 @@ type HighlightCardConfig = Pick<
   | 'descriptionKey'
   | 'descriptionRequiresParams'
   | 'valueColumnLabelKey'
+  | 'valueColumnTooltipKey'
 > & {
-  readonly section: CareerHighlightSection;
+  readonly sectionId: CareerHighlightSectionId;
   readonly type: CareerHighlightsUiType;
 };
 
+const careerHighlightSectionDefinitions = CAREER_HIGHLIGHT_SECTIONS.map((section) => ({
+  ...section,
+  anchorId: `career-highlights-section-${section.id}`,
+  headingId: `career-highlights-section-${section.id}-heading`,
+}));
+
 const MOST_TEAMS_PLAYED_CONFIG: HighlightCardConfig = {
-  section: 'general',
+  sectionId: 'journeys',
   type: 'most-teams-played',
   titleKey: 'career.highlights.cards.mostTeamsPlayed.title',
   descriptionKey: 'career.highlights.cards.mostTeamsPlayed.description',
@@ -67,7 +74,7 @@ const MOST_TEAMS_PLAYED_CONFIG: HighlightCardConfig = {
 };
 
 const SAME_TEAM_SEASONS_PLAYED_CONFIG: HighlightCardConfig = {
-  section: 'general',
+  sectionId: 'long-stays',
   type: 'same-team-seasons-played',
   titleKey: 'career.highlights.cards.sameTeamSeasonsPlayed.title',
   descriptionKey: 'career.highlights.cards.sameTeamSeasonsPlayed.description',
@@ -76,7 +83,7 @@ const SAME_TEAM_SEASONS_PLAYED_CONFIG: HighlightCardConfig = {
 };
 
 const MOST_TEAMS_OWNED_CONFIG: HighlightCardConfig = {
-  section: 'general',
+  sectionId: 'journeys',
   type: 'most-teams-owned',
   titleKey: 'career.highlights.cards.mostTeamsOwned.title',
   descriptionKey: 'career.highlights.cards.mostTeamsOwned.description',
@@ -85,16 +92,17 @@ const MOST_TEAMS_OWNED_CONFIG: HighlightCardConfig = {
 };
 
 const MOST_STANLEY_CUPS_CONFIG: HighlightCardConfig = {
-  section: 'general',
+  sectionId: 'achievements',
   type: 'most-stanley-cups',
   titleKey: 'career.highlights.cards.mostStanleyCups.title',
   descriptionKey: 'career.highlights.cards.mostStanleyCups.description',
   descriptionRequiresParams: true,
   valueColumnLabelKey: '💍',
+  valueColumnTooltipKey: 'career.highlights.columnHelp.cups',
 };
 
 const REGULAR_GRINDER_WITHOUT_PLAYOFFS_CONFIG: HighlightCardConfig = {
-  section: 'general',
+  sectionId: 'achievements',
   type: 'regular-grinder-without-playoffs',
   titleKey: 'career.highlights.cards.regularGrinderWithoutPlayoffs.title',
   descriptionKey:
@@ -104,7 +112,7 @@ const REGULAR_GRINDER_WITHOUT_PLAYOFFS_CONFIG: HighlightCardConfig = {
 };
 
 const SAME_TEAM_SEASONS_OWNED_CONFIG: HighlightCardConfig = {
-  section: 'general',
+  sectionId: 'long-stays',
   type: 'same-team-seasons-owned',
   titleKey: 'career.highlights.cards.sameTeamSeasonsOwned.title',
   descriptionKey: 'career.highlights.cards.sameTeamSeasonsOwned.description',
@@ -113,16 +121,17 @@ const SAME_TEAM_SEASONS_OWNED_CONFIG: HighlightCardConfig = {
 };
 
 const REUNION_KING_CONFIG: HighlightCardConfig = {
-  section: 'transactions',
+  sectionId: 'transactions',
   type: 'reunion-king',
   titleKey: 'career.highlights.cards.reunionKing.title',
   descriptionKey: 'career.highlights.cards.reunionKing.description',
   descriptionRequiresParams: true,
   valueColumnLabelKey: '♻️',
+  valueColumnTooltipKey: 'career.highlights.columnHelp.reunions',
 };
 
 const STASH_KING_CONFIG: HighlightCardConfig = {
-  section: 'general',
+  sectionId: 'long-stays',
   type: 'stash-king',
   titleKey: 'career.highlights.cards.stashKing.title',
   descriptionKey: 'career.highlights.cards.stashKing.description',
@@ -131,50 +140,34 @@ const STASH_KING_CONFIG: HighlightCardConfig = {
 };
 
 const MOST_TRADES_CONFIG: HighlightCardConfig = {
-  section: 'transactions',
+  sectionId: 'transactions',
   type: 'most-trades',
   titleKey: 'career.highlights.cards.mostTrades.title',
   descriptionKey: 'career.highlights.cards.mostTrades.description',
   descriptionRequiresParams: true,
   valueColumnLabelKey: '🤝',
+  valueColumnTooltipKey: 'career.highlights.columnHelp.trades',
 };
 
 const MOST_CLAIMS_CONFIG: HighlightCardConfig = {
-  section: 'transactions',
+  sectionId: 'transactions',
   type: 'most-claims',
   titleKey: 'career.highlights.cards.mostClaims.title',
   descriptionKey: 'career.highlights.cards.mostClaims.description',
   descriptionRequiresParams: true,
   valueColumnLabelKey: '✅',
+  valueColumnTooltipKey: 'career.highlights.columnHelp.claims',
 };
 
 const MOST_DROPS_CONFIG: HighlightCardConfig = {
-  section: 'transactions',
+  sectionId: 'transactions',
   type: 'most-drops',
   titleKey: 'career.highlights.cards.mostDrops.title',
   descriptionKey: 'career.highlights.cards.mostDrops.description',
   descriptionRequiresParams: true,
   valueColumnLabelKey: '❌',
+  valueColumnTooltipKey: 'career.highlights.columnHelp.drops',
 };
-
-const highlightCardConfigsByType: Record<CareerHighlightsUiType, HighlightCardConfig> = {
-  'most-stanley-cups': MOST_STANLEY_CUPS_CONFIG,
-  'regular-grinder-without-playoffs': REGULAR_GRINDER_WITHOUT_PLAYOFFS_CONFIG,
-  'most-teams-played': MOST_TEAMS_PLAYED_CONFIG,
-  'most-teams-owned': MOST_TEAMS_OWNED_CONFIG,
-  'same-team-seasons-played': SAME_TEAM_SEASONS_PLAYED_CONFIG,
-  'same-team-seasons-owned': SAME_TEAM_SEASONS_OWNED_CONFIG,
-  'stash-king': STASH_KING_CONFIG,
-  'most-trades': MOST_TRADES_CONFIG,
-  'most-claims': MOST_CLAIMS_CONFIG,
-  'most-drops': MOST_DROPS_CONFIG,
-  'reunion-king': REUNION_KING_CONFIG,
-};
-
-const HIGHLIGHT_CARD_CONFIGS: readonly HighlightCardConfig[] = [
-  ...CAREER_HIGHLIGHT_CARD_TYPES_BY_SECTION.general.map((type) => highlightCardConfigsByType[type]),
-  ...CAREER_HIGHLIGHT_CARD_TYPES_BY_SECTION.transactions.map((type) => highlightCardConfigsByType[type]),
-];
 
 function createInitialCardState(
   config: HighlightCardConfig,
@@ -184,6 +177,7 @@ function createInitialCardState(
     descriptionKey: config.descriptionKey,
     descriptionRequiresParams: config.descriptionRequiresParams,
     valueColumnLabelKey: config.valueColumnLabelKey,
+    valueColumnTooltipKey: config.valueColumnTooltipKey,
     activated: false,
     rows: [],
     loading: false,
@@ -199,7 +193,7 @@ function createInitialCardState(
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
     ActivateOnViewportDirective,
-    MatButtonToggleModule,
+    SectionJumpNavComponent,
     TableCardComponent,
     TranslateModule,
   ],
@@ -207,12 +201,18 @@ function createInitialCardState(
   styleUrl: './career-highlights.component.scss',
 })
 export class CareerHighlightsComponent implements OnInit {
+  private readonly document = inject(DOCUMENT);
   private readonly apiService = inject(ApiService);
   private readonly destroyRef = inject(DestroyRef);
   private readonly footerVisibilityService = inject(FooterVisibilityService);
+  private readonly platformId = inject(PLATFORM_ID);
   private readonly translate = inject(TranslateService);
 
-  readonly selectedSection = signal<CareerHighlightSection>('general');
+  readonly sectionLinks = careerHighlightSectionDefinitions;
+  readonly jumpNavItems = careerHighlightSectionDefinitions.map((section) => ({
+    id: section.anchorId,
+    labelKey: section.titleKey,
+  }));
 
   private readonly cardSignals: Record<
     CareerHighlightsUiType,
@@ -241,13 +241,14 @@ export class CareerHighlightsComponent implements OnInit {
       'most-drops': signal(createInitialCardState(MOST_DROPS_CONFIG)),
     };
 
-  readonly cards = computed<readonly CareerHighlightCardView[]>(() =>
-    HIGHLIGHT_CARD_CONFIGS
-      .filter((config) => config.section === this.selectedSection())
-      .map((config) => ({
-        type: config.type,
-        state: this.cardSignals[config.type](),
+  readonly sections = computed<readonly CareerHighlightSectionView[]>(() =>
+    careerHighlightSectionDefinitions.map((section) => ({
+      ...section,
+      cards: section.cardTypes.map((type) => ({
+        type,
+        state: this.cardSignals[type](),
       })),
+    })),
   );
 
   private footerVisibilityCycle = 0;
@@ -257,8 +258,27 @@ export class CareerHighlightsComponent implements OnInit {
     this.footerVisibilityCycle = this.footerVisibilityService.currentCycle();
   }
 
-  onSectionChange(event: MatButtonToggleChange): void {
-    this.selectedSection.set(event.value as CareerHighlightSection);
+  scrollToSection(anchorId: string): void {
+    if (!isPlatformBrowser(this.platformId)) {
+      return;
+    }
+
+    const sectionElement = this.document.getElementById(anchorId);
+    if (!sectionElement) {
+      return;
+    }
+
+    const location = this.document.defaultView?.location;
+    if (location) {
+      const nextUrl = `${location.pathname}${location.search}#${anchorId}`;
+      this.document.defaultView?.history.replaceState(null, '', nextUrl);
+    }
+
+    sectionElement.scrollIntoView({
+      block: 'start',
+      inline: 'nearest',
+      behavior: 'smooth',
+    });
   }
 
   loadPreviousPage(type: CareerHighlightsUiType): void {
@@ -309,6 +329,8 @@ export class CareerHighlightsComponent implements OnInit {
     initialLoad = false,
   ): void {
     const cardSignal = this.getCardSignal(type);
+    const pageSize = cardSignal().take;
+    const requestTake = targetSkip + pageSize + 1;
 
     cardSignal.update((current) => ({
       ...current,
@@ -317,18 +339,18 @@ export class CareerHighlightsComponent implements OnInit {
     }));
 
     this.apiService
-      .getCareerHighlights(type, targetSkip, cardSignal().take)
+      .getCareerHighlights(type, 0, requestTake)
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
         next: (page) => {
           cardSignal.update((current) => ({
             ...current,
-            rows: this.normalizeRows(page),
+            rows: this.normalizeRows(page, targetSkip, pageSize),
             descriptionParams: this.descriptionParamsFor(page),
             loading: false,
             apiError: false,
-            skip: page.skip,
-            take: page.take,
+            skip: targetSkip,
+            take: pageSize,
             total: page.total,
           }));
           this.markInitialLoadReady(initialLoad);
@@ -344,11 +366,20 @@ export class CareerHighlightsComponent implements OnInit {
       });
   }
 
-  private normalizeRows(page: CareerHighlightPage): TableCardRow[] {
+  private normalizeRows(
+    page: CareerHighlightPage,
+    visibleSkip: number,
+    visibleTake: number,
+  ): TableCardRow[] {
     if (this.isTeamCountPage(page)) {
-      return page.items.map((item) => ({
+      return this.sliceVisibleRows(
+        deriveTiedRanks(page.items, (left, right) => left.teamCount === right.teamCount),
+        visibleSkip,
+        visibleTake,
+      ).map((item) => ({
         key: `${item.id}:${item.teams.map((team) => team.id).join(',')}`,
-        primaryText: `${item.position} ${item.name}`,
+        rank: this.buildRankLabel(item.displayRank, item.tieRank),
+        primaryText: this.buildPrimaryText(item.name, item.position),
         value: item.teamCount,
         detailLines: item.teams.map((team) => team.name),
         detailLabel: item.name,
@@ -356,9 +387,14 @@ export class CareerHighlightsComponent implements OnInit {
     }
 
     if (this.isSameTeamPage(page)) {
-      return page.items.map((item) => ({
+      return this.sliceVisibleRows(
+        deriveTiedRanks(page.items, (left, right) => left.seasonCount === right.seasonCount),
+        visibleSkip,
+        visibleTake,
+      ).map((item) => ({
         key: `${item.id}:${item.team.id}`,
-        primaryText: `${item.position} ${item.name}`,
+        rank: this.buildRankLabel(item.displayRank, item.tieRank),
+        primaryText: this.buildPrimaryText(item.name, item.position),
         value: item.seasonCount,
         detailLines: [item.team.name],
         detailLabel: item.name,
@@ -366,9 +402,14 @@ export class CareerHighlightsComponent implements OnInit {
     }
 
     if (this.isStanleyCupPage(page)) {
-      return page.items.map((item) => ({
+      return this.sliceVisibleRows(
+        deriveTiedRanks(page.items, (left, right) => left.cupCount === right.cupCount),
+        visibleSkip,
+        visibleTake,
+      ).map((item) => ({
         key: item.id,
-        primaryText: `${item.position} ${item.name}`,
+        rank: this.buildRankLabel(item.displayRank, item.tieRank),
+        primaryText: this.buildPrimaryText(item.name, item.position),
         value: item.cupCount,
         detailLines: item.cups.map(
           (cup) => `${formatPlayoffYear(cup.season)} ${cup.team.name}`,
@@ -378,9 +419,14 @@ export class CareerHighlightsComponent implements OnInit {
     }
 
     if (this.isReunionPage(page)) {
-      return page.items.map((item) => ({
+      return this.sliceVisibleRows(
+        deriveTiedRanks(page.items, (left, right) => left.reunionCount === right.reunionCount),
+        visibleSkip,
+        visibleTake,
+      ).map((item) => ({
         key: `${item.id}:${item.team.id}`,
-        primaryText: `${item.position} ${item.name}`,
+        rank: this.buildRankLabel(item.displayRank, item.tieRank),
+        primaryText: this.buildPrimaryText(item.name, item.position),
         value: item.reunionCount,
         detailHeader: item.team.name,
         detailLines: formatReunionDetailLines(
@@ -397,9 +443,14 @@ export class CareerHighlightsComponent implements OnInit {
     }
 
     if (this.isRegularGrinderPage(page)) {
-      return page.items.map((item) => ({
+      return this.sliceVisibleRows(
+        deriveTiedRanks(page.items, (left, right) => left.regularGames === right.regularGames),
+        visibleSkip,
+        visibleTake,
+      ).map((item) => ({
         key: item.id,
-        primaryText: `${item.position} ${item.name}`,
+        rank: this.buildRankLabel(item.displayRank, item.tieRank),
+        primaryText: this.buildPrimaryText(item.name, item.position),
         value: item.regularGames,
         detailLines: item.teams.map((team) => team.name),
         detailLabel: item.name,
@@ -407,9 +458,14 @@ export class CareerHighlightsComponent implements OnInit {
     }
 
     if (this.isStashPage(page)) {
-      return page.items.map((item) => ({
+      return this.sliceVisibleRows(
+        deriveTiedRanks(page.items, (left, right) => left.seasonCount === right.seasonCount),
+        visibleSkip,
+        visibleTake,
+      ).map((item) => ({
         key: `${item.id}:${item.team.id}`,
-        primaryText: `${item.position} ${item.name}`,
+        rank: this.buildRankLabel(item.displayRank, item.tieRank),
+        primaryText: this.buildPrimaryText(item.name, item.position),
         value: item.seasonCount,
         detailLines: [item.team.name],
         detailLabel: item.name,
@@ -417,9 +473,17 @@ export class CareerHighlightsComponent implements OnInit {
     }
 
     if (this.isTransactionPage(page)) {
-      return page.items.map((item) => ({
+      return this.sliceVisibleRows(
+        deriveTiedRanks(
+          page.items,
+          (left, right) => left.transactionCount === right.transactionCount,
+        ),
+        visibleSkip,
+        visibleTake,
+      ).map((item) => ({
         key: `${page.type}:${item.id}`,
-        primaryText: `${item.position} ${item.name}`,
+        rank: this.buildRankLabel(item.displayRank, item.tieRank),
+        primaryText: this.buildPrimaryText(item.name, item.position),
         value: item.transactionCount,
         detailLines: item.teams.map((team) => `${team.name} ${team.count}`),
         detailLabel: item.name,
@@ -427,6 +491,28 @@ export class CareerHighlightsComponent implements OnInit {
     }
 
     return [];
+  }
+
+  private sliceVisibleRows<T>(
+    rows: readonly T[],
+    visibleSkip: number,
+    visibleTake: number,
+  ): readonly T[] {
+    return rows.slice(visibleSkip, visibleSkip + visibleTake);
+  }
+
+  private buildPrimaryText(name: string, position: string): string {
+    return `${position} ${name}`;
+  }
+
+  private buildRankLabel(rank: number, tieRank: boolean): TableCardRow['rank'] {
+    return {
+      text: formatTiedRankLabel(rank, tieRank),
+      ariaLabel: this.translate.instant(
+        tieRank ? 'tableCard.tiedRankAriaLabel' : 'tableCard.rankAriaLabel',
+        { rank },
+      ),
+    };
   }
 
   private descriptionParamsFor(

--- a/src/app/career/highlights/career-highlights.constants.ts
+++ b/src/app/career/highlights/career-highlights.constants.ts
@@ -1,8 +1,14 @@
-export const GENERAL_CAREER_HIGHLIGHT_CARD_TYPES = [
+export const ACHIEVEMENTS_CAREER_HIGHLIGHT_CARD_TYPES = [
   'most-stanley-cups',
   'regular-grinder-without-playoffs',
+] as const;
+
+export const JOURNEYS_CAREER_HIGHLIGHT_CARD_TYPES = [
   'most-teams-played',
   'most-teams-owned',
+] as const;
+
+export const LONG_STAYS_CAREER_HIGHLIGHT_CARD_TYPES = [
   'same-team-seasons-played',
   'same-team-seasons-owned',
   'stash-king',
@@ -15,15 +21,51 @@ export const TRANSACTION_CAREER_HIGHLIGHT_CARD_TYPES = [
   'reunion-king',
 ] as const;
 
-export const CAREER_HIGHLIGHT_CARD_TYPES_BY_SECTION = {
-  general: GENERAL_CAREER_HIGHLIGHT_CARD_TYPES,
-  transactions: TRANSACTION_CAREER_HIGHLIGHT_CARD_TYPES,
-} as const;
-
-export const CAREER_HIGHLIGHT_CARD_TYPES = [
-  ...GENERAL_CAREER_HIGHLIGHT_CARD_TYPES,
-  ...TRANSACTION_CAREER_HIGHLIGHT_CARD_TYPES,
+export const GENERAL_CAREER_HIGHLIGHT_CARD_TYPES = [
+  ...ACHIEVEMENTS_CAREER_HIGHLIGHT_CARD_TYPES,
+  ...JOURNEYS_CAREER_HIGHLIGHT_CARD_TYPES,
+  ...LONG_STAYS_CAREER_HIGHLIGHT_CARD_TYPES,
 ] as const;
 
-export type CareerHighlightSection = keyof typeof CAREER_HIGHLIGHT_CARD_TYPES_BY_SECTION;
+export const CAREER_HIGHLIGHT_CARD_TYPES = [
+  ...ACHIEVEMENTS_CAREER_HIGHLIGHT_CARD_TYPES,
+  ...TRANSACTION_CAREER_HIGHLIGHT_CARD_TYPES,
+  ...LONG_STAYS_CAREER_HIGHLIGHT_CARD_TYPES,
+  ...JOURNEYS_CAREER_HIGHLIGHT_CARD_TYPES,
+] as const;
+
 export type CareerHighlightsUiType = (typeof CAREER_HIGHLIGHT_CARD_TYPES)[number];
+
+export const CAREER_HIGHLIGHT_SECTIONS = [
+  {
+    id: 'achievements',
+    titleKey: 'career.highlights.sections.achievements.title',
+    descriptionKey: 'career.highlights.sections.achievements.description',
+    cardTypes: ACHIEVEMENTS_CAREER_HIGHLIGHT_CARD_TYPES,
+  },
+  {
+    id: 'transactions',
+    titleKey: 'career.highlights.sections.transactions.title',
+    descriptionKey: 'career.highlights.sections.transactions.description',
+    cardTypes: TRANSACTION_CAREER_HIGHLIGHT_CARD_TYPES,
+  },
+  {
+    id: 'long-stays',
+    titleKey: 'career.highlights.sections.longStays.title',
+    descriptionKey: 'career.highlights.sections.longStays.description',
+    cardTypes: LONG_STAYS_CAREER_HIGHLIGHT_CARD_TYPES,
+  },
+  {
+    id: 'journeys',
+    titleKey: 'career.highlights.sections.journeys.title',
+    descriptionKey: 'career.highlights.sections.journeys.description',
+    cardTypes: JOURNEYS_CAREER_HIGHLIGHT_CARD_TYPES,
+  },
+] as const satisfies readonly {
+  readonly id: string;
+  readonly titleKey: string;
+  readonly descriptionKey: string;
+  readonly cardTypes: readonly CareerHighlightsUiType[];
+}[];
+
+export type CareerHighlightSectionId = (typeof CAREER_HIGHLIGHT_SECTIONS)[number]['id'];

--- a/src/app/career/highlights/career-highlights.types.ts
+++ b/src/app/career/highlights/career-highlights.types.ts
@@ -2,7 +2,7 @@ import { TableCardRow } from '@shared/table-card/table-card.types';
 import type { CareerHighlightsUiType } from './career-highlights.constants';
 
 export type {
-  CareerHighlightSection,
+  CareerHighlightSectionId,
   CareerHighlightsUiType,
 } from './career-highlights.constants';
 export type HighlightDescriptionParams = Readonly<Record<string, number | string>>;
@@ -13,6 +13,7 @@ export interface CareerHighlightCardState {
   readonly descriptionRequiresParams: boolean;
   readonly descriptionParams?: HighlightDescriptionParams;
   readonly valueColumnLabelKey: string;
+  readonly valueColumnTooltipKey?: string;
   readonly activated: boolean;
   readonly rows: readonly TableCardRow[];
   readonly loading: boolean;
@@ -25,4 +26,13 @@ export interface CareerHighlightCardState {
 export interface CareerHighlightCardView {
   readonly type: CareerHighlightsUiType;
   readonly state: CareerHighlightCardState;
+}
+
+export interface CareerHighlightSectionView {
+  readonly id: string;
+  readonly titleKey: string;
+  readonly descriptionKey: string;
+  readonly anchorId: string;
+  readonly headingId: string;
+  readonly cards: readonly CareerHighlightCardView[];
 }

--- a/src/app/draft/statistics/draft-statistics.component.html
+++ b/src/app/draft/statistics/draft-statistics.component.html
@@ -27,17 +27,12 @@
     </mat-form-field>
   </div>
 
-  <nav class="draft-statistics-jump-nav" [attr.aria-label]="'draft.statistics.jumpNavAriaLabel' | translate">
-    @for (section of sectionLinks; track section.id) {
-      <button
-        class="draft-statistics-jump-link"
-        type="button"
-        (click)="scrollToSection(section.anchorId)"
-      >
-        {{ section.titleKey | translate }}
-      </button>
-    }
-  </nav>
+  <app-section-jump-nav
+    class="draft-statistics-jump-nav"
+    [items]="jumpNavItems"
+    ariaLabelKey="draft.statistics.jumpNavAriaLabel"
+    (itemSelected)="scrollToSection($event)"
+  />
 
   @for (section of sections; track section.id) {
     <section

--- a/src/app/draft/statistics/draft-statistics.component.scss
+++ b/src/app/draft/statistics/draft-statistics.component.scss
@@ -33,49 +33,7 @@
 }
 
 .draft-statistics-jump-nav {
-  position: sticky;
-  top: 8px;
-  z-index: 3;
-  display: flex;
-  gap: 10px;
-  margin: 16px 24px 0;
-  padding: 8px;
-  overflow-x: auto;
-  overflow-y: hidden;
-  border: 1px solid color-mix(in srgb, var(--mat-sys-outline) 65%, transparent);
-  border-radius: 999px;
-  background: color-mix(in srgb, var(--mat-sys-surface) 88%, transparent);
-  backdrop-filter: blur(14px);
-  scrollbar-width: none;
-  -ms-overflow-style: none;
-}
-
-.draft-statistics-jump-nav::-webkit-scrollbar {
-  display: none;
-}
-
-.draft-statistics-jump-link {
-  flex: 0 0 auto;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  padding: 0.55rem 1rem;
-  border-radius: 999px;
-  color: var(--mat-sys-on-surface-variant);
-  font-size: 0.92rem;
-  font-weight: 600;
-  border: 0;
-  background: transparent;
-  cursor: pointer;
-  text-decoration: none;
-  white-space: nowrap;
-}
-
-.draft-statistics-jump-link:hover,
-.draft-statistics-jump-link:focus-visible {
-  background: color-mix(in srgb, var(--mat-sys-primary) 12%, transparent);
-  color: var(--mat-sys-on-surface);
-  outline: none;
+  --section-jump-nav-margin: 16px 24px 0;
 }
 
 .draft-statistics-section {
@@ -133,8 +91,8 @@
   }
 
   .draft-statistics-jump-nav {
-    margin: 12px 8px 0;
-    top: 6px;
+    --section-jump-nav-margin: 12px 8px 0;
+    --section-jump-nav-sticky-top: 6px;
   }
 
   .draft-statistics-section {

--- a/src/app/draft/statistics/draft-statistics.component.spec.ts
+++ b/src/app/draft/statistics/draft-statistics.component.spec.ts
@@ -13,6 +13,8 @@ import { DRAFT_STATISTICS_CARD_IDS } from './draft-statistics.constants';
 import { DraftStatisticsComponent } from './draft-statistics.component';
 
 function createEntryDraftGroup(index: number): EntryDraftTeamGroup {
+  const totalPicksByIndex = [20, 19, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10];
+
   return {
     team: {
       id: `${index + 1}`,
@@ -22,15 +24,15 @@ function createEntryDraftGroup(index: number): EntryDraftTeamGroup {
       highestPick: null,
       averageDraftPosition: index + 1,
       amounts: {
-        total: 20 - index,
+        total: totalPicksByIndex[index],
         ownPicks: 15 - index,
         tradedPicks: 5,
         playersPerDraftAverage: 6 - index * 0.1,
         playedInLeague: 12 - index,
-        playedInLeaguePercent: Number(((12 - index) / (20 - index)).toFixed(3)),
+        playedInLeaguePercent: Number(((12 - index) / totalPicksByIndex[index]).toFixed(3)),
         playedForDraftingTeam: 6 - Math.floor(index / 2),
         playedForDraftingTeamPercent: Number(
-          ((6 - Math.floor(index / 2)) / (20 - index)).toFixed(3),
+          ((6 - Math.floor(index / 2)) / totalPicksByIndex[index]).toFixed(3),
         ),
       },
       rounds: {
@@ -130,8 +132,9 @@ describe('DraftStatisticsComponent', () => {
 
     const totalPicksQueries = within(totalPicksCard as HTMLElement);
     expect(totalPicksQueries.getByText(totalPicksState!.rows[0].primaryText)).toBeInTheDocument();
-    expect(totalPicksQueries.getByText('1. Team 1')).toBeInTheDocument();
-    expect(totalPicksQueries.queryByText('11. Team 11')).not.toBeInTheDocument();
+    expect(totalPicksQueries.getByText('1.')).toBeInTheDocument();
+    expect(totalPicksQueries.getAllByText('T2.')).toHaveLength(2);
+    expect(totalPicksQueries.queryByText('Team 11')).not.toBeInTheDocument();
 
     const playedInLeaguePercentCard = screen
       .getByRole('heading', { name: 'draft.statistics.cards.playedInLeaguePercent.title' })
@@ -152,7 +155,8 @@ describe('DraftStatisticsComponent', () => {
     await waitForBehaviorAssertion(fixture, () => {
       const pagedCard = fixture.componentInstance.cards.find((card) => card.id === 'total-picks');
       expect(pagedCard?.skip).toBe(10);
-      expect(totalPicksQueries.getByText('11. Team 11')).toBeInTheDocument();
+      expect(totalPicksQueries.getByText('11.')).toBeInTheDocument();
+      expect(totalPicksQueries.getByText('Team 11')).toBeInTheDocument();
     });
 
     expect(footerVisibilityService.markReady).toHaveBeenCalledWith(9);
@@ -170,10 +174,12 @@ describe('DraftStatisticsComponent', () => {
 
     await waitForBehaviorAssertion(fixture, () => {
       const cardState = fixture.componentInstance.cards.find((card) => card.id === 'total-picks');
+      const highlightedRow = within(totalPicksCard as HTMLElement).getByText('Team 12').closest('tr');
       expect(fixture.componentInstance.highlightedTeamId).toBe('12');
       expect(cardState?.skip).toBe(10);
-      expect(cardState?.rows.some((row) => row.primaryText === '12. Team 12' && row.emphasized)).toBe(true);
-      expect(within(totalPicksCard as HTMLElement).getByText('12. Team 12').closest('tr')).toHaveClass('table-card-row--emphasized');
+      expect(cardState?.rows.some((row) => row.primaryText === 'Team 12' && row.rank?.text === '12.' && row.emphasized)).toBe(true);
+      expect(highlightedRow).toHaveClass('table-card-row--emphasized');
+      expect(within(highlightedRow as HTMLElement).getByText('12.')).toBeInTheDocument();
     });
 
     expect(JSON.parse(localStorage.getItem('fantrax.settings') ?? '{}')).toMatchObject({
@@ -199,9 +205,11 @@ describe('DraftStatisticsComponent', () => {
 
     await waitForBehaviorAssertion(fixture, () => {
       const cardState = fixture.componentInstance.cards.find((card) => card.id === 'total-picks');
+      const highlightedRow = within(totalPicksCard as HTMLElement).getByText('Team 12').closest('tr');
       expect(screen.getByRole('combobox', { name: 'draft.statistics.highlightTeam.label' })).toHaveTextContent('Team 12');
       expect(cardState?.skip).toBe(10);
-      expect(within(totalPicksCard as HTMLElement).getByText('12. Team 12').closest('tr')).toHaveClass('table-card-row--emphasized');
+      expect(highlightedRow).toHaveClass('table-card-row--emphasized');
+      expect(within(highlightedRow as HTMLElement).getByText('12.')).toBeInTheDocument();
     });
   });
 

--- a/src/app/draft/statistics/draft-statistics.component.ts
+++ b/src/app/draft/statistics/draft-statistics.component.ts
@@ -11,13 +11,15 @@ import {
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatSelectChange, MatSelectModule } from '@angular/material/select';
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateModule, TranslateService } from '@ngx-translate/core';
 
 import { ApiService, EntryDraftTeamGroup } from '@services/api.service';
 import { FooterVisibilityService } from '@services/footer-visibility.service';
 import { SettingsService } from '@services/settings.service';
+import { SectionJumpNavComponent } from '@shared/section-jump-nav/section-jump-nav.component';
 import { TableCardComponent } from '@shared/table-card/table-card.component';
 import { TableCardRow } from '@shared/table-card/table-card.types';
+import { deriveTiedRanks, formatTiedRankLabel } from '@shared/utils/rank.utils';
 
 import {
   DRAFT_STATISTICS_CARD_IDS,
@@ -55,6 +57,8 @@ type DraftStatisticSourceRow = {
   readonly teamName: string;
   readonly value: number | string;
   readonly rawValue: number;
+  readonly displayRank: number;
+  readonly tieRank: boolean;
 };
 
 type DraftStatisticsCard = {
@@ -200,6 +204,7 @@ const draftStatisticDefinitions: readonly DraftStatisticDefinition[] = DRAFT_STA
   imports: [
     MatFormFieldModule,
     MatSelectModule,
+    SectionJumpNavComponent,
     TableCardComponent,
     TranslateModule,
   ],
@@ -214,9 +219,14 @@ export class DraftStatisticsComponent implements OnInit {
   private readonly footerVisibilityService = inject(FooterVisibilityService);
   private readonly settingsService = inject(SettingsService);
   private readonly platformId = inject(PLATFORM_ID);
+  private readonly translate = inject(TranslateService);
 
   readonly pageSize = PAGE_SIZE;
   readonly sectionLinks = draftStatisticsSectionDefinitions;
+  readonly jumpNavItems = draftStatisticsSectionDefinitions.map((section) => ({
+    id: section.anchorId,
+    labelKey: section.titleKey,
+  }));
 
   sections: DraftStatisticsSection[] = this.createInitialSections();
   teams: DraftStatisticsTeamOption[] = [];
@@ -361,10 +371,13 @@ export class DraftStatisticsComponent implements OnInit {
     groups: EntryDraftTeamGroup[],
     definition: DraftStatisticDefinition,
   ): DraftStatisticsCard {
-    const allRows = groups
+    const allRows = deriveTiedRanks(
+      groups
       .map((group) => this.buildSourceRow(group, definition))
       .filter((row): row is DraftStatisticSourceRow => row !== null)
-      .sort((left, right) => this.compareRows(left, right, definition.direction));
+      .sort((left, right) => this.compareRows(left, right, definition.direction)),
+      (left, right) => left.rawValue === right.rawValue,
+    );
     const initialSkip = this.highlightedTeamId === null
       ? 0
       : this.getTeamPageSkip(allRows, this.highlightedTeamId);
@@ -406,6 +419,8 @@ export class DraftStatisticsComponent implements OnInit {
       teamName: group.team.name,
       value: definition.formatValue ? definition.formatValue(rawValue) : rawValue,
       rawValue,
+      displayRank: 0,
+      tieRank: false,
     };
   }
 
@@ -415,9 +430,10 @@ export class DraftStatisticsComponent implements OnInit {
   ): TableCardRow[] {
     return allRows
       .slice(skip, skip + PAGE_SIZE)
-      .map((row, index) => ({
+      .map((row) => ({
         key: row.key,
-        primaryText: `${skip + index + 1}. ${row.teamName}`,
+        rank: this.buildRankLabel(row.displayRank, row.tieRank),
+        primaryText: row.teamName,
         value: row.value,
         emphasized: row.teamId === this.highlightedTeamId,
       }));
@@ -473,5 +489,15 @@ export class DraftStatisticsComponent implements OnInit {
       }),
     }));
     this.changeDetectorRef.markForCheck();
+  }
+
+  private buildRankLabel(rank: number, tieRank: boolean): TableCardRow['rank'] {
+    return {
+      text: formatTiedRankLabel(rank, tieRank),
+      ariaLabel: this.translate.instant(
+        tieRank ? 'tableCard.tiedRankAriaLabel' : 'tableCard.rankAriaLabel',
+        { rank },
+      ),
+    };
   }
 }

--- a/src/app/shared/section-jump-nav/section-jump-nav.component.html
+++ b/src/app/shared/section-jump-nav/section-jump-nav.component.html
@@ -1,0 +1,32 @@
+<nav
+  class="section-jump-nav"
+  [class.section-jump-nav--can-scroll-start]="canScrollStart()"
+  [class.section-jump-nav--can-scroll-end]="canScrollEnd()"
+  [attr.aria-label]="ariaLabelKey() | translate"
+  [attr.aria-describedby]="hasOverflow() ? instructionsId : null"
+>
+  <span
+    [id]="instructionsId"
+    class="sr-only"
+  >
+    {{ scrollHintKey() | translate }}
+  </span>
+
+  <div
+    #scrollContainer
+    class="section-jump-nav-scroll"
+    (scroll)="onScroll()"
+  >
+    @for (item of items(); track item.id) {
+      <button
+        class="section-jump-nav-link"
+        [class.section-jump-nav-link--active]="item.id === activeItemId()"
+        [attr.data-nav-item-id]="item.id"
+        type="button"
+        (click)="onItemClick(item.id)"
+      >
+        {{ item.labelKey | translate }}
+      </button>
+    }
+  </div>
+</nav>

--- a/src/app/shared/section-jump-nav/section-jump-nav.component.scss
+++ b/src/app/shared/section-jump-nav/section-jump-nav.component.scss
@@ -1,0 +1,98 @@
+:host {
+  --section-jump-nav-margin: 16px 24px 0;
+  --section-jump-nav-sticky-top: 8px;
+  --section-jump-nav-z-index: 3;
+  --section-jump-nav-surface: color-mix(in srgb, var(--mat-sys-surface) 88%, transparent);
+  --section-jump-nav-fade-width: 3rem;
+
+  position: sticky;
+  top: var(--section-jump-nav-sticky-top);
+  z-index: var(--section-jump-nav-z-index);
+  display: block;
+  margin: var(--section-jump-nav-margin);
+}
+
+.section-jump-nav {
+  position: relative;
+  border: 1px solid color-mix(in srgb, var(--mat-sys-outline) 65%, transparent);
+  border-radius: 999px;
+  background: var(--section-jump-nav-surface);
+  backdrop-filter: blur(14px);
+}
+
+.section-jump-nav::before,
+.section-jump-nav::after {
+  content: '';
+  position: absolute;
+  top: 1px;
+  bottom: 1px;
+  width: var(--section-jump-nav-fade-width);
+  border-radius: inherit;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 120ms ease-out;
+}
+
+.section-jump-nav::before {
+  left: 1px;
+  background: linear-gradient(
+    90deg,
+    var(--section-jump-nav-surface) 15%,
+    color-mix(in srgb, var(--mat-sys-surface) 0%, transparent) 100%
+  );
+}
+
+.section-jump-nav::after {
+  right: 1px;
+  background: linear-gradient(
+    270deg,
+    var(--section-jump-nav-surface) 15%,
+    color-mix(in srgb, var(--mat-sys-surface) 0%, transparent) 100%
+  );
+}
+
+.section-jump-nav--can-scroll-start::before,
+.section-jump-nav--can-scroll-end::after {
+  opacity: 1;
+}
+
+.section-jump-nav-scroll {
+  display: flex;
+  gap: 10px;
+  padding: 8px;
+  overflow-x: auto;
+  overflow-y: hidden;
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+  scroll-behavior: smooth;
+  touch-action: pan-x;
+}
+
+.section-jump-nav-scroll::-webkit-scrollbar {
+  display: none;
+}
+
+.section-jump-nav-link {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.55rem 1rem;
+  border: 0;
+  border-radius: 999px;
+  background: transparent;
+  color: var(--mat-sys-on-surface-variant);
+  cursor: pointer;
+  font-size: 0.92rem;
+  font-weight: 600;
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.section-jump-nav-link:hover,
+.section-jump-nav-link:focus-visible,
+.section-jump-nav-link--active {
+  background: color-mix(in srgb, var(--mat-sys-primary) 12%, transparent);
+  color: var(--mat-sys-on-surface);
+  outline: none;
+}

--- a/src/app/shared/section-jump-nav/section-jump-nav.component.spec.ts
+++ b/src/app/shared/section-jump-nav/section-jump-nav.component.spec.ts
@@ -1,0 +1,155 @@
+import { Component, ViewChild } from '@angular/core';
+import { fireEvent, render, screen } from '@testing-library/angular';
+import { TranslateModule } from '@ngx-translate/core';
+
+import {
+  SectionJumpNavComponent,
+  SectionJumpNavItem,
+} from './section-jump-nav.component';
+
+@Component({
+  standalone: true,
+  imports: [SectionJumpNavComponent],
+  template: `
+    <app-section-jump-nav
+      [items]="items"
+      [ariaLabelKey]="ariaLabelKey"
+      [activeItemId]="activeItemId"
+      (itemSelected)="selectedItemId = $event"
+    />
+  `,
+})
+class SectionJumpNavHostComponent {
+  @ViewChild(SectionJumpNavComponent)
+  sectionJumpNavComponent?: SectionJumpNavComponent;
+
+  readonly ariaLabelKey = 'career.highlights.jumpNavAriaLabel';
+  readonly items: readonly SectionJumpNavItem[] = [
+    { id: 'one', labelKey: 'career.highlights.sections.achievements.title' },
+    { id: 'two', labelKey: 'career.highlights.sections.transactions.title' },
+    { id: 'three', labelKey: 'career.highlights.sections.longStays.title' },
+  ];
+  activeItemId: string | null = null;
+  selectedItemId: string | null = null;
+}
+
+describe('SectionJumpNavComponent', () => {
+  async function setup() {
+    return render(SectionJumpNavHostComponent, {
+      imports: [TranslateModule.forRoot()],
+    });
+  }
+
+  function defineScrollerDimensions(
+    scroller: HTMLElement,
+    dimensions: { clientWidth: number; scrollWidth: number; scrollLeft?: number },
+  ) {
+    Object.defineProperty(scroller, 'clientWidth', {
+      configurable: true,
+      value: dimensions.clientWidth,
+    });
+    Object.defineProperty(scroller, 'scrollWidth', {
+      configurable: true,
+      value: dimensions.scrollWidth,
+    });
+    Object.defineProperty(scroller, 'scrollLeft', {
+      configurable: true,
+      writable: true,
+      value: dimensions.scrollLeft ?? 0,
+    });
+  }
+
+  it('renders the configured jump buttons', async () => {
+    await setup();
+
+    expect(
+      await screen.findByRole('button', {
+        name: 'career.highlights.sections.achievements.title',
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', {
+        name: 'career.highlights.sections.transactions.title',
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('navigation', {
+        name: 'career.highlights.jumpNavAriaLabel',
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it('adds overflow fades and the scroll hint when the nav content exceeds the viewport', async () => {
+    const view = await setup();
+    const nav = screen.getByRole('navigation', {
+      name: 'career.highlights.jumpNavAriaLabel',
+    });
+    const scroller = view.container.querySelector('.section-jump-nav-scroll') as HTMLElement | null;
+
+    expect(scroller).not.toBeNull();
+
+    defineScrollerDimensions(scroller as HTMLElement, {
+      clientWidth: 180,
+      scrollWidth: 420,
+      scrollLeft: 0,
+    });
+
+    view.fixture.componentInstance.sectionJumpNavComponent?.refreshOverflowState();
+    view.fixture.detectChanges();
+
+    expect(nav).toHaveClass('section-jump-nav--can-scroll-end');
+    expect(nav).not.toHaveClass('section-jump-nav--can-scroll-start');
+    expect(nav).toHaveAttribute(
+      'aria-describedby',
+      view.fixture.componentInstance.sectionJumpNavComponent?.instructionsId,
+    );
+
+    Object.defineProperty(scroller as HTMLElement, 'scrollLeft', {
+      configurable: true,
+      writable: true,
+      value: 80,
+    });
+    fireEvent.scroll(scroller as HTMLElement);
+    view.fixture.detectChanges();
+
+    expect(nav).toHaveClass('section-jump-nav--can-scroll-start');
+    expect(nav).toHaveClass('section-jump-nav--can-scroll-end');
+  });
+
+  it('emits the clicked item id and keeps active items styled for future reuse', async () => {
+    const view = await setup();
+    const scroller = view.container.querySelector('.section-jump-nav-scroll') as HTMLElement | null;
+
+    expect(scroller).not.toBeNull();
+
+    defineScrollerDimensions(scroller as HTMLElement, {
+      clientWidth: 180,
+      scrollWidth: 420,
+      scrollLeft: 0,
+    });
+
+    const activeButton = screen.getByRole('button', {
+      name: 'career.highlights.sections.transactions.title',
+    });
+    const scrollIntoView = vi.fn();
+    Object.defineProperty(activeButton, 'scrollIntoView', {
+      configurable: true,
+      value: scrollIntoView,
+    });
+
+    view.fixture.componentInstance.activeItemId = 'two';
+    view.fixture.detectChanges();
+
+    expect(activeButton).toHaveClass('section-jump-nav-link--active');
+
+    fireEvent.click(activeButton);
+    view.fixture.detectChanges();
+
+    expect(view.fixture.componentInstance.selectedItemId).toBe('two');
+    expect(scrollIntoView).toHaveBeenCalledWith({
+      block: 'nearest',
+      inline: 'center',
+      behavior: 'smooth',
+    });
+  });
+});

--- a/src/app/shared/section-jump-nav/section-jump-nav.component.ts
+++ b/src/app/shared/section-jump-nav/section-jump-nav.component.ts
@@ -1,0 +1,147 @@
+import {
+  AfterViewInit,
+  ChangeDetectionStrategy,
+  Component,
+  DestroyRef,
+  ElementRef,
+  HostListener,
+  ViewChild,
+  effect,
+  inject,
+  input,
+  output,
+  signal,
+} from '@angular/core';
+import { TranslateModule } from '@ngx-translate/core';
+
+let nextSectionJumpNavId = 0;
+
+export interface SectionJumpNavItem {
+  readonly id: string;
+  readonly labelKey: string;
+}
+
+@Component({
+  selector: 'app-section-jump-nav',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [TranslateModule],
+  templateUrl: './section-jump-nav.component.html',
+  styleUrl: './section-jump-nav.component.scss',
+})
+export class SectionJumpNavComponent implements AfterViewInit {
+  private readonly destroyRef = inject(DestroyRef);
+
+  @ViewChild('scrollContainer', { read: ElementRef })
+  private scrollContainerRef?: ElementRef<HTMLElement>;
+
+  readonly items = input.required<readonly SectionJumpNavItem[]>();
+  readonly ariaLabelKey = input.required<string>();
+  readonly scrollHintKey = input('sectionJumpNav.horizontalScrollHint');
+  readonly activeItemId = input<string | null>(null);
+
+  readonly itemSelected = output<string>();
+
+  readonly canScrollStart = signal(false);
+  readonly canScrollEnd = signal(false);
+  readonly hasOverflow = signal(false);
+  readonly instructionsId = `section-jump-nav-instructions-${nextSectionJumpNavId += 1}`;
+
+  private viewInitialized = false;
+  private syncPending = false;
+  private destroyed = false;
+
+  constructor() {
+    this.destroyRef.onDestroy(() => {
+      this.destroyed = true;
+    });
+
+    effect(() => {
+      this.items();
+      this.activeItemId();
+      this.scheduleSync();
+    });
+  }
+
+  ngAfterViewInit(): void {
+    this.viewInitialized = true;
+    this.scheduleSync();
+  }
+
+  onScroll(): void {
+    this.refreshOverflowState();
+  }
+
+  onItemClick(itemId: string): void {
+    this.itemSelected.emit(itemId);
+    this.scrollItemIntoView(itemId, 'smooth');
+    this.refreshOverflowState();
+  }
+
+  @HostListener('window:resize')
+  onWindowResize(): void {
+    this.scheduleSync();
+  }
+
+  refreshOverflowState(): void {
+    const container = this.scrollContainerRef?.nativeElement;
+    if (!container) {
+      return;
+    }
+
+    const maxScrollLeft = Math.max(container.scrollWidth - container.clientWidth, 0);
+    const scrollLeft = Math.max(container.scrollLeft, 0);
+    const threshold = 2;
+    const hasOverflow = maxScrollLeft > threshold;
+
+    this.hasOverflow.set(hasOverflow);
+    this.canScrollStart.set(hasOverflow && scrollLeft > threshold);
+    this.canScrollEnd.set(hasOverflow && maxScrollLeft - scrollLeft > threshold);
+  }
+
+  private scheduleSync(): void {
+    if (!this.viewInitialized || this.syncPending) {
+      return;
+    }
+
+    this.syncPending = true;
+    queueMicrotask(() => {
+      this.syncPending = false;
+
+      if (this.destroyed) {
+        return;
+      }
+
+      this.refreshOverflowState();
+
+      const activeItemId = this.activeItemId();
+      if (!activeItemId) {
+        return;
+      }
+
+      this.scrollItemIntoView(activeItemId, 'auto');
+      this.refreshOverflowState();
+    });
+  }
+
+  private scrollItemIntoView(itemId: string, behavior: ScrollBehavior): void {
+    const container = this.scrollContainerRef?.nativeElement;
+    if (!container) {
+      return;
+    }
+
+    const escapedItemId = itemId.replaceAll('"', '\\"');
+    const itemButton = container.querySelector<HTMLElement>(
+      `[data-nav-item-id="${escapedItemId}"]`,
+    );
+
+    if (typeof itemButton?.scrollIntoView !== 'function') {
+      return;
+    }
+
+    itemButton.scrollIntoView({
+      block: 'nearest',
+      inline: 'center',
+      behavior,
+    });
+  }
+}

--- a/src/app/shared/table-card/table-card.component.html
+++ b/src/app/shared/table-card/table-card.component.html
@@ -49,8 +49,26 @@
             <th scope="col" class="name-column">
               {{ primaryColumnLabelKey() | translate }}
             </th>
-            <th scope="col" class="value-column">
+            <th
+              scope="col"
+              class="value-column"
+              [attr.aria-label]="
+                hasValueColumnHelp() ? (valueColumnAssistiveLabelKey() | translate) : null
+              "
+            >
+              @if (hasValueColumnHelp()) {
+              <span
+                class="table-card-column-label"
+                [class.table-card-column-label--focusable]="valueColumnTooltipEnabled()"
+                [matTooltip]="valueColumnTooltipKey() ? (valueColumnTooltipKey() | translate) : ''"
+                [matTooltipDisabled]="!valueColumnTooltipEnabled()"
+                [attr.tabindex]="valueColumnTooltipEnabled() ? '0' : null"
+              >
+                {{ valueColumnLabelKey() | translate }}
+              </span>
+              } @else {
               {{ valueColumnLabelKey() | translate }}
+              }
             </th>
             @if (showDetails()) {
             <th scope="col" class="info-column">
@@ -71,7 +89,21 @@
             [class.table-card-row--emphasized]="row.emphasized"
           >
             <td class="primary-cell">
-              {{ row.primaryText }}
+              <div class="primary-cell-content">
+                @if (row.rank; as rank) {
+                <span class="primary-rank">
+                  @if (rank.ariaLabel) {
+                  <span class="sr-only">{{ rank.ariaLabel }}</span>
+                  <span aria-hidden="true">{{ rank.text }}</span>
+                  } @else {
+                  {{ rank.text }}
+                  }
+                </span>
+                }
+                <span class="primary-text">
+                  {{ row.primaryText }}
+                </span>
+              </div>
             </td>
             <td class="value-column">
               {{ row.value }}

--- a/src/app/shared/table-card/table-card.component.scss
+++ b/src/app/shared/table-card/table-card.component.scss
@@ -111,6 +111,10 @@ mat-card-header {
   font-weight: 700;
 }
 
+.table-card-table tbody tr.table-card-row--emphasized .primary-rank {
+  color: inherit;
+}
+
 .table-card-table tbody tr:focus {
   outline: 2px solid var(--mat-sys-primary);
   outline-offset: -2px;
@@ -122,6 +126,24 @@ mat-card-header {
   font-weight: normal;
 }
 
+.primary-cell-content {
+  display: flex;
+  align-items: baseline;
+  gap: 0.45rem;
+}
+
+.primary-rank {
+  flex: 0 0 auto;
+  color: var(--mat-sys-on-surface-variant);
+  font-size: 0.8rem;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+}
+
+.primary-text {
+  min-width: 0;
+}
+
 .name-column {
   text-align: left;
 }
@@ -130,6 +152,25 @@ mat-card-header {
   width: 92px;
   text-align: center;
   white-space: nowrap;
+}
+
+.table-card-column-label {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 1.5rem;
+  border-radius: 999px;
+}
+
+.table-card-column-label--focusable {
+  padding: 0.1rem 0.3rem;
+}
+
+.table-card-column-label--focusable:hover,
+.table-card-column-label--focusable:focus-visible {
+  background: color-mix(in srgb, var(--mat-sys-primary) 12%, transparent);
+  color: var(--mat-sys-on-surface);
+  outline: none;
 }
 
 .table-card--without-details .value-column {
@@ -193,6 +234,9 @@ mat-card-header {
 }
 
 @media (max-width: 480px) {
+  .table-card-table td {
+    padding-inline: 0.3rem;
+  }
 
   .value-column,
   .info-column {

--- a/src/app/shared/table-card/table-card.component.spec.ts
+++ b/src/app/shared/table-card/table-card.component.spec.ts
@@ -19,6 +19,7 @@ import { TableCardRow } from './table-card.types';
       [descriptionParams]="descriptionParams"
       [primaryColumnLabelKey]="primaryColumnLabelKey"
       [valueColumnLabelKey]="valueColumnLabelKey"
+      [valueColumnTooltipKey]="valueColumnTooltipKey"
       [showDetails]="showDetails"
       [deferred]="deferred"
       [rows]="rows"
@@ -37,6 +38,7 @@ class TableCardHostComponent {
   descriptionParams: Readonly<Record<string, number | string>> | undefined = undefined;
   primaryColumnLabelKey = 'career.highlights.columns.player';
   valueColumnLabelKey = 'career.highlights.columns.teamCount';
+  valueColumnTooltipKey: string | undefined = undefined;
   showDetails = true;
   deferred = false;
   loading = false;
@@ -88,6 +90,30 @@ describe('TableCardComponent', () => {
         name: /career\.highlights\.cards\.mostTeamsPlayed\.title.*tableCard\.next/,
       }),
     ).toBeEnabled();
+  });
+
+  it('renders tied-rank prefixes and accessible emoji value headers when configured', async () => {
+    await setup({
+      valueColumnLabelKey: '💍',
+      valueColumnTooltipKey: 'career.highlights.columnHelp.cups',
+      rows: [
+        {
+          key: 'row-1',
+          rank: {
+            text: 'T2.',
+            ariaLabel: 'tableCard.tiedRankAriaLabel',
+          },
+          primaryText: 'F Jamie Benn',
+          value: 3,
+          detailLines: ['Colorado Avalanche'],
+          detailLabel: 'Jamie Benn',
+        },
+      ],
+    });
+
+    expect(await screen.findAllByText('T2.')).toHaveLength(1);
+    expect(screen.getByText('F Jamie Benn')).toBeInTheDocument();
+    expect(screen.getByLabelText('career.highlights.columnHelp.cups')).toBeInTheDocument();
   });
 
   it('shows an empty-state message when there are no rows and the card is not loading', async () => {

--- a/src/app/shared/table-card/table-card.component.ts
+++ b/src/app/shared/table-card/table-card.component.ts
@@ -33,6 +33,8 @@ export class TableCardComponent {
   readonly descriptionParams = input<Readonly<Record<string, number | string>> | undefined>();
   readonly primaryColumnLabelKey = input.required<string>();
   readonly valueColumnLabelKey = input.required<string>();
+  readonly valueColumnTooltipKey = input<string | undefined>();
+  readonly valueColumnAriaLabelKey = input<string | undefined>();
   readonly showDetails = input(true);
   readonly deferred = input(false);
   readonly rows = input.required<readonly TableCardRow[]>();
@@ -52,6 +54,15 @@ export class TableCardComponent {
   readonly pageEnd = computed(() => (this.hasRows() ? this.skip() + this.rows().length : 0));
   readonly hasDescription = computed(
     () => !this.descriptionRequiresParams() || Boolean(this.descriptionParams()),
+  );
+  readonly valueColumnAssistiveLabelKey = computed(
+    () => this.valueColumnAriaLabelKey() ?? this.valueColumnTooltipKey(),
+  );
+  readonly hasValueColumnHelp = computed(
+    () => Boolean(this.valueColumnAssistiveLabelKey()),
+  );
+  readonly valueColumnTooltipEnabled = computed(
+    () => Boolean(this.valueColumnTooltipKey()),
   );
   readonly titleId = `${this.instanceId}-title`;
   readonly descriptionId = `${this.instanceId}-description`;

--- a/src/app/shared/table-card/table-card.types.ts
+++ b/src/app/shared/table-card/table-card.types.ts
@@ -1,5 +1,11 @@
+export interface TableCardRankLabel {
+  readonly text: string;
+  readonly ariaLabel?: string;
+}
+
 export interface TableCardRow {
   readonly key: string;
+  readonly rank?: TableCardRankLabel;
   readonly primaryText: string;
   readonly value: number | string;
   readonly emphasized?: boolean;

--- a/src/app/shared/utils/rank.utils.ts
+++ b/src/app/shared/utils/rank.utils.ts
@@ -1,0 +1,30 @@
+export type TiedRankInfo = {
+  readonly displayRank: number;
+  readonly tieRank: boolean;
+};
+
+export function deriveTiedRanks<T>(
+  entries: readonly T[],
+  isTied: (left: T, right: T) => boolean,
+): Array<T & TiedRankInfo> {
+  const rankedEntries: Array<T & TiedRankInfo> = [];
+
+  for (const [index, entry] of entries.entries()) {
+    const previousEntry = index > 0 ? entries[index - 1] : undefined;
+    const nextEntry = index + 1 < entries.length ? entries[index + 1] : undefined;
+    const tiedWithPrevious = previousEntry !== undefined && isTied(entry, previousEntry);
+    const tiedWithNext = nextEntry !== undefined && isTied(entry, nextEntry);
+
+    rankedEntries.push({
+      ...entry,
+      displayRank: tiedWithPrevious ? rankedEntries[index - 1].displayRank : index + 1,
+      tieRank: tiedWithPrevious || tiedWithNext,
+    });
+  }
+
+  return rankedEntries;
+}
+
+export function formatTiedRankLabel(rank: number, tieRank: boolean): string {
+  return `${tieRank ? 'T' : ''}${rank}.`;
+}


### PR DESCRIPTION
Summary
- polish draft statistics and career highlights usability
- add reusable shared section jump nav with mobile overflow cues
- replace running ranks with tied-rank labels in shared card tables
- tighten small-mobile table cell padding so tied ranks fit better

Testing
- npm run verify

Notes
- verified mobile card spacing visually in light/dark
- build passes with an existing non-blocking stylesheet budget warning for table-card.component.scss
