### PR TITLE
Feature: Unify draft settings with the shared drawer

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ The docs in this repo intentionally focus on project-specific architecture, work
 	- Team-by-team draft history and summary views
 	- Played-status markers show whether drafted players reached the drafting team or elsewhere in the league
 	- Draft statistics cards are grouped into sectioned rankings with jump navigation
+	- The shared team setting opens or highlights the selected team by default across draft views, with a draft-only drawer toggle to disable that behavior
 - ⚙️ **Shared Settings Drawer**: The same settings entry point is available across stats, career, draft, and leaderboard routes
 - 🗂️ **Global Navigation**: Bottom sheet menu for switching between views (hockey stats, player careers, leaderboards, info/help)
 	- Keyboard navigation is supported inside the menu
@@ -214,6 +215,7 @@ Important:
 - If you do need a real local `CI=true` run, make sure `http://localhost:4200` is free first so Playwright can start the CI-mode server instead of colliding with an already running frontend.
 - `npx playwright test --headed` still uses the same `webServer` config. It does not disable server startup by itself; it simply opens the browser UI while Playwright starts or reuses the frontend.
 - If the backend on `localhost:3000` is not running during a paired session, ask the user to start it. Do not silently swap to CI-mode mocking for routine local verification.
+- When a Playwright selector needs visible Finnish UI copy, use `fi('...')` from `e2e/config/i18n.ts` or shared labels from `e2e/config/test-data.ts` instead of hard-coding Finnish strings in specs.
 
 ### Test Coverage Summary
 

--- a/docs/codebase-structure.md
+++ b/docs/codebase-structure.md
@@ -80,6 +80,8 @@ They still inherit the root-shell settings button plus the base drawer sections.
 
 - shared drawer content used by the root shell across every route
 - always renders the base sections and appends mode-specific sections from one centralized extension point
+- draft routes add a separate drawer section for the selected-team-highlight toggle after the shared team switcher section
+- new drawer groups should be added here as sibling `.settings-drawer-section` wrappers so spacing, borders, and future drawer-wide styling changes stay centralized
 
 ### `src/app/shared/stats-table/`
 

--- a/docs/component-guide.md
+++ b/docs/component-guide.md
@@ -63,8 +63,13 @@ In this repo, shared controls such as team, season, report, and settings control
 ### Preserve Drawer Grouping
 
 - The shared drawer always shows the base section (`TeamSwitcherComponent` plus last-updated metadata)
+- Draft routes render `DraftTeamHighlightToggleComponent` in its own drawer section after the team selector so draft mode keeps the same section styling conventions as stats mode
 - `TopControlsComponent` and `SettingsPanelComponent` are stats-mode extensions rendered only when a route opts into stats drawer mode
 - Keep the team section, stats-range section, and stats-filter section aligned across player and goalie contexts
+- When adding a new logical drawer block, wrap it in a top-level `.settings-drawer-section` inside [`src/app/shared/settings-drawer/settings-drawer.component.html`](/Users/maestor/Projects/fantrax-stats-parser-ui/src/app/shared/settings-drawer/settings-drawer.component.html) instead of faking section spacing or divider lines inside the child component
+- Prefer the drawer's shared section chrome as the default:
+  add a new section wrapper first, then add a targeted `settings-drawer-section--*` modifier only if the shared section padding/border behavior genuinely needs an exception
+- Shared `mat-slide-toggle` spacing now lives in [`src/styles.scss`](/Users/maestor/Projects/fantrax-stats-parser-ui/src/styles.scss); keep the global 12px control/label gap and do not add per-component label-padding hacks
 
 ### Keep The Table Components Separate
 

--- a/docs/project-overview.md
+++ b/docs/project-overview.md
@@ -62,6 +62,7 @@ Accessibility is a core requirement: the UI is designed to remain usable via key
 
     - **Base settings**
        - Team selector
+       - Draft routes only: toggle for disabling selected-team highlight/open-by-default behavior
        - Last updated timestamp
     - **Stats ranges**
        - Start-from-season selector (lower bound for combined stats)
@@ -102,6 +103,8 @@ Accessibility is a core requirement: the UI is designed to remain usable via key
    - Entry-draft pick rows add `🟢` / `🟡` played-status markers to show whether a drafted player reached the drafting team or played elsewhere in the league
    - Expanded draft panels auto-align their sticky header to the top of the viewport when opened, while `ArrowDown` still explicitly enters the panel body; once inside, `ArrowUp` / `ArrowDown` / `Home` / `End` / `PageUp` / `PageDown` browse within it and `Escape` collapses the panel while returning focus to the team header
    - `/draft/statistics` reuses the shared card-table UI to rank teams across entry-draft summary metrics, including separate played-percentage rankings, with local 10-row paging
+   - By default, all three draft views follow the shared selected-team setting: entry/opening draft expand that team automatically and draft statistics emphasizes it plus jumps each card to the matching page
+   - Draft routes expose a drawer-only toggle that disables that selected-team emphasis/auto-open behavior without affecting the actual shared team selection
 
 8. **Data Management**
    - Caching service to reduce API calls

--- a/docs/project-testing.md
+++ b/docs/project-testing.md
@@ -224,7 +224,9 @@ Local rule of thumb:
 - Use the CI/fixture mode only when you intentionally want the mocked CI behavior
 - If you need a real local `CI=true` run and `http://localhost:4200` is already occupied by a manually started frontend, stop that server first so Playwright can start the CI-mode web server itself
 - If the backend on `localhost:3000` is not running in a paired session, ask the user to start it instead of swapping local verification over to CI-mode fixtures
-- When Playwright assertions need visible Finnish UI copy, source shared labels from `public/i18n/fi.json` through the E2E config helpers instead of duplicating hard-coded strings in test constants
+- When Playwright assertions need visible Finnish UI copy, source shared labels from `public/i18n/fi.json` through `e2e/config/i18n.ts` or shared constants in `e2e/config/test-data.ts`
+- Do **not** hard-code Finnish literals directly in Playwright specs for headings, tabs, buttons, drawer labels, or other user-facing UI text; use `fi('...')` or shared test-data exports instead so tests stay aligned with translations
+- For short shared words that appear inside longer labels, combine the translation helper with stricter selectors such as `exact: true`, a role level, or a narrower container instead of falling back to hard-coded localized text
 
 **Basic commands:**
 

--- a/docs/project-testing.md
+++ b/docs/project-testing.md
@@ -227,6 +227,7 @@ Local rule of thumb:
 - When Playwright assertions need visible Finnish UI copy, source shared labels from `public/i18n/fi.json` through `e2e/config/i18n.ts` or shared constants in `e2e/config/test-data.ts`
 - Do **not** hard-code Finnish literals directly in Playwright specs for headings, tabs, buttons, drawer labels, or other user-facing UI text; use `fi('...')` or shared test-data exports instead so tests stay aligned with translations
 - For short shared words that appear inside longer labels, combine the translation helper with stricter selectors such as `exact: true`, a role level, or a narrower container instead of falling back to hard-coded localized text
+- When a route can auto-open accordions or panels from persisted/shared settings, do **not** assume a collapsed starting state in Playwright. CI starts from the app defaults, so draft list views already open the default selected team unless the test explicitly changes that setting first
 
 **Basic commands:**
 

--- a/docs/service-guide.md
+++ b/docs/service-guide.md
@@ -17,7 +17,7 @@ Services in this application handle data fetching, business logic, state managem
 
 **Responsibilities**:
 - Store user settings in a single `localStorage` key: `fantrax.settings`
-- Provide the currently used reactive settings reads for team id, start-from season, season/report filters, and draft statistics highlighting
+- Provide the currently used reactive settings reads for team id, start-from season, season/report filters, and the draft-only "disable selected-team highlight" toggle
 - Validate all fields on load; invalid or missing fields fall back to defaults
 
 **Notes**:
@@ -25,6 +25,7 @@ Services in this application handle data fetching, business logic, state managem
 - When the selected team changes, `startFromSeason` clears immediately; stats routes resolve it back to that team's oldest available season when stats mode becomes active
 - Storage failures are ignored (privacy mode, quota, etc.)
 - `season` defaults to `null` (all seasons); `reportType` defaults to `'regular'`
+- `disableDraftSelectedTeamHighlight` defaults to `false`; when enabled, draft views stop auto-opening/highlighting the selected team
 - Settings are validated field-by-field on load; invalid or missing fields fall back to defaults
 
 **Key API**:
@@ -33,16 +34,19 @@ class SettingsService {
   readonly selectedTeamId$: Observable<string>;
   readonly selectedTeamIdSignal: Signal<string>;
   readonly startFromSeason$: Observable<number | undefined>;
+  readonly disableDraftSelectedTeamHighlightSignal: Signal<boolean>;
 
   get selectedTeamId(): string;
   get startFromSeason(): number | undefined;
   get season(): number | undefined;
   get reportType(): ReportType;
+  get disableDraftSelectedTeamHighlight(): boolean;
 
   setSelectedTeamId(teamId: string): void;
   setStartFromSeason(season: number | undefined): void;
   setSeason(season: number | null): void;
   setReportType(reportType: ReportType): void;
+  setDisableDraftSelectedTeamHighlight(disabled: boolean): void;
 }
 ```
 
@@ -53,6 +57,7 @@ export type AppSettings = {
   startFromSeason: number | null;
   season: number | null;
   reportType: ReportType;
+  disableDraftSelectedTeamHighlight: boolean;
 };
 ```
 

--- a/e2e/config/test-data.ts
+++ b/e2e/config/test-data.ts
@@ -32,6 +32,10 @@ export const FILTER_LABELS = {
   POSITION_DEFENSE: fi('positionFilter.defensemen'),
 };
 
+export const FILTER_VALUES = {
+  ALL_SEASONS: fi('season.allSeasons'),
+};
+
 export const A11Y_LABELS = {
   OPEN_SETTINGS_DRAWER: fi('a11y.openSettingsDrawer'),
   CLOSE_SETTINGS_DRAWER: fi('a11y.closeSettingsDrawer'),

--- a/e2e/helpers/filters.ts
+++ b/e2e/helpers/filters.ts
@@ -5,8 +5,8 @@ import { SettingsDrawer } from '../page-objects/SettingsDrawer';
 
 async function withVisibleControl(
   page: Page,
-  control: Locator,
-  action: () => Promise<void>,
+  resolveControl: (drawer: SettingsDrawer) => Locator,
+  action: (control: Locator) => Promise<void>,
 ): Promise<void> {
   const drawer = new SettingsDrawer(page);
   const wasOpen = await drawer.isOpen();
@@ -15,10 +15,12 @@ async function withVisibleControl(
     await drawer.open();
   }
 
+  const control = resolveControl(drawer);
+
   try {
     await control.waitFor({ state: 'visible', timeout: 5_000 });
     await control.scrollIntoViewIfNeeded();
-    await action();
+    await action(control);
   } finally {
     if (!wasOpen) {
       await drawer.close();
@@ -30,10 +32,7 @@ async function withVisibleControl(
  * Select a team from the dropdown
  */
 export async function selectTeam(page: Page, teamName: string): Promise<void> {
-  const teamSelector = page.getByRole('combobox', {
-    name: FILTER_LABELS.TEAM,
-  });
-  await withVisibleControl(page, teamSelector, async () => {
+  await withVisibleControl(page, (drawer) => drawer.combobox(FILTER_LABELS.TEAM), async (teamSelector) => {
     await teamSelector.click();
     await page.getByRole('option', { name: teamName }).click();
     await waitForFilterUpdate(page);
@@ -47,10 +46,7 @@ export async function selectSeason(
   page: Page,
   season: string
 ): Promise<void> {
-  const seasonSelector = page.getByRole('combobox', {
-    name: FILTER_LABELS.SEASON,
-  });
-  await withVisibleControl(page, seasonSelector, async () => {
+  await withVisibleControl(page, (drawer) => drawer.combobox(FILTER_LABELS.SEASON), async (seasonSelector) => {
     await seasonSelector.click();
     await page.getByRole('option', { name: season }).click();
     await waitForFilterUpdate(page);
@@ -64,10 +60,7 @@ export async function selectStartFromSeason(
   page: Page,
   season: string
 ): Promise<void> {
-  const startFromSelector = page.getByRole('combobox', {
-    name: FILTER_LABELS.START_FROM,
-  });
-  await withVisibleControl(page, startFromSelector, async () => {
+  await withVisibleControl(page, (drawer) => drawer.combobox(FILTER_LABELS.START_FROM), async (startFromSelector) => {
     await startFromSelector.click();
     await page.getByRole('option', { name: season }).click();
     await waitForFilterUpdate(page);
@@ -78,9 +71,8 @@ export async function selectStartFromSeason(
  * Toggle stats per game switch
  */
 export async function toggleStatsPerGame(page: Page): Promise<void> {
-  const switchButton = page.locator('mat-slide-toggle button[role="switch"]');
-  await withVisibleControl(page, switchButton, async () => {
-    await switchButton.dispatchEvent('click');
+  await withVisibleControl(page, (drawer) => drawer.switch(FILTER_LABELS.STATS_PER_GAME), async (switchButton) => {
+    await switchButton.click();
     await waitForFilterUpdate(page);
   });
 }
@@ -92,8 +84,7 @@ export async function setMinGames(
   page: Page,
   value: number
 ): Promise<void> {
-  const sliderInput = page.locator('#min-games-slider input[type="range"]');
-  await withVisibleControl(page, sliderInput, async () => {
+  await withVisibleControl(page, (drawer) => drawer.locator('#min-games-slider input[type="range"]'), async (sliderInput) => {
     await sliderInput.fill(String(value));
     await waitForFilterUpdate(page);
   });
@@ -118,9 +109,7 @@ export async function selectPosition(
       buttonName = FILTER_LABELS.POSITION_DEFENSE;
       break;
   }
-  const toggle = page.getByRole('radio', { name: buttonName });
-
-  await withVisibleControl(page, toggle, async () => {
+  await withVisibleControl(page, (drawer) => drawer.radio(buttonName), async (toggle) => {
     await toggle.click();
     await waitForFilterUpdate(page);
   });
@@ -137,10 +126,7 @@ export async function switchReportType(
     type === 'regular'
       ? FILTER_LABELS.REPORT_TYPE_REGULAR
       : FILTER_LABELS.REPORT_TYPE_PLAYOFFS;
-  const reportTypeSelector = page.getByRole('combobox', {
-    name: FILTER_LABELS.REPORT_TYPE,
-  });
-  await withVisibleControl(page, reportTypeSelector, async () => {
+  await withVisibleControl(page, (drawer) => drawer.combobox(FILTER_LABELS.REPORT_TYPE), async (reportTypeSelector) => {
     await reportTypeSelector.click();
     await page.getByRole('option', { name: label }).click();
     await waitForFilterUpdate(page);

--- a/e2e/page-objects/SettingsDrawer.ts
+++ b/e2e/page-objects/SettingsDrawer.ts
@@ -1,4 +1,4 @@
-import { Page } from '@playwright/test';
+import { Locator, Page } from '@playwright/test';
 import { A11Y_LABELS } from '../config/test-data';
 import {
   selectTeam as helperSelectTeam,
@@ -14,16 +14,75 @@ import {
 export class SettingsDrawer {
   constructor(private page: Page) {}
 
+  private get settingsButton() {
+    return this.page.getByLabel(A11Y_LABELS.OPEN_SETTINGS_DRAWER);
+  }
+
+  private get openedDrawerRoot() {
+    return this.page.locator('mat-sidenav.settings-drawer.mat-drawer-opened');
+  }
+
+  private get openedDrawerContent() {
+    return this.openedDrawerRoot.locator('app-settings-drawer');
+  }
+
+  private get closeButton() {
+    return this.openedDrawerRoot.getByLabel(A11Y_LABELS.CLOSE_SETTINGS_DRAWER).first();
+  }
+
+  combobox(name: string): Locator {
+    return this.openedDrawerContent.getByRole('combobox', { name });
+  }
+
+  radio(name: string): Locator {
+    return this.openedDrawerContent.getByRole('radio', { name });
+  }
+
+  switch(name: string): Locator {
+    return this.openedDrawerContent.getByRole('switch', { name });
+  }
+
+  labelledControl(name: string): Locator {
+    return this.openedDrawerContent.getByLabel(name);
+  }
+
+  locator(selector: string): Locator {
+    return this.openedDrawerContent.locator(selector);
+  }
+
+  private async waitForOpenState(expectedOpen: boolean): Promise<void> {
+    await this.page.waitForFunction(
+      (open) => {
+        const drawer = document.querySelector('mat-sidenav.settings-drawer');
+        return drawer?.classList.contains('mat-drawer-opened') === open;
+      },
+      expectedOpen,
+      { timeout: 5_000 },
+    );
+  }
+
   /**
    * Open the shared settings drawer
    */
   async open(): Promise<void> {
-    const settingsButton = this.page.getByLabel(A11Y_LABELS.OPEN_SETTINGS_DRAWER);
-    await settingsButton.click();
-    // Wait for the drawer to be visibly open before interacting with its contents.
-    await this.page
-      .locator('mat-sidenav.mat-drawer-opened')
-      .waitFor({ state: 'visible', timeout: 5000 });
+    if (await this.isOpen()) {
+      return;
+    }
+
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      await this.settingsButton.click();
+
+      try {
+        await this.waitForOpenState(true);
+        await this.closeButton.waitFor({ state: 'visible', timeout: 5000 });
+        await this.page.waitForTimeout(150);
+        return;
+      } catch (error) {
+        if (attempt === 1) {
+          throw error;
+        }
+      }
+    }
   }
 
   /**
@@ -44,19 +103,15 @@ export class SettingsDrawer {
       await this.page.keyboard.press('Escape');
       await overlayBackdrop.waitFor({ state: 'hidden', timeout: 5_000 }).catch(() => {});
       if (!(await this.isOpen())) {
-        await this.page.waitForTimeout(300);
+        await this.page.waitForTimeout(150);
         return;
       }
     }
     // The close button inside the drawer
-    const closeButton = this.page.getByLabel(A11Y_LABELS.CLOSE_SETTINGS_DRAWER).first();
-    await closeButton.click({ timeout: 5000 });
+    await this.closeButton.click({ timeout: 5000 });
     // Wait for drawer close animation to complete
-    await this.page
-      .locator('mat-sidenav.mat-drawer-opened')
-      .waitFor({ state: 'hidden', timeout: 5000 })
-      .catch(() => {});
-    await this.page.waitForTimeout(300);
+    await this.waitForOpenState(false).catch(() => {});
+    await this.page.waitForTimeout(150);
   }
 
   /**
@@ -64,24 +119,20 @@ export class SettingsDrawer {
    */
   async closeViaEscape(): Promise<void> {
     // Ensure the drawer is visibly open before pressing Escape.
-    await this.page
-      .locator('mat-sidenav.mat-drawer-opened')
-      .waitFor({ state: 'visible', timeout: 5000 });
+    await this.closeButton.waitFor({ state: 'visible', timeout: 5000 });
     await this.page.keyboard.press('Escape');
     // Wait for drawer close animation to complete
-    await this.page
-      .locator('mat-sidenav.mat-drawer-opened')
-      .waitFor({ state: 'hidden', timeout: 5000 })
-      .catch(() => {});
-    await this.page.waitForTimeout(300);
+    await this.waitForOpenState(false).catch(() => {});
+    await this.page.waitForTimeout(150);
   }
 
   /**
    * Check if drawer is open
    */
   async isOpen(): Promise<boolean> {
-    const openDrawer = this.page.locator('mat-sidenav.mat-drawer-opened');
-    return (await openDrawer.count()) > 0;
+    return this.page.evaluate(
+      () => document.querySelector('mat-sidenav.settings-drawer')?.classList.contains('mat-drawer-opened') ?? false,
+    );
   }
 
   /**

--- a/e2e/specs/draft.spec.ts
+++ b/e2e/specs/draft.spec.ts
@@ -1,4 +1,4 @@
-import type { Page } from '@playwright/test';
+import type { Locator, Page } from '@playwright/test';
 
 import { test, expect } from '../fixtures/test-fixture';
 import { NAV_LABELS, TAB_LABELS } from '../config/test-data';
@@ -58,13 +58,23 @@ async function expectStatisticsContent(page: Page) {
   }
 }
 
+async function ensurePanelExpanded(panel: Locator): Promise<Locator> {
+  const header = panel.locator('mat-expansion-panel-header');
+
+  await expect(header).toBeVisible({ timeout: 15000 });
+
+  if ((await header.getAttribute('aria-expanded')) !== 'true') {
+    await header.click();
+  }
+
+  await expect(header).toHaveAttribute('aria-expanded', 'true');
+  return header;
+}
+
 async function expectEntryDraftContent(page: Page) {
   const panels = page.locator('mat-expansion-panel');
   const firstPanel = panels.first();
-  const firstHeader = firstPanel.locator('mat-expansion-panel-header');
-
-  await expect(firstHeader).toBeVisible({ timeout: 15000 });
-  await firstHeader.click();
+  const firstHeader = await ensurePanelExpanded(firstPanel);
 
   await expect(firstPanel.locator('.entry-summary-card').first()).toBeVisible();
   await expect(firstPanel.locator('.entry-season').first()).toBeVisible();
@@ -77,7 +87,7 @@ async function expectEntryDraftContent(page: Page) {
   const panelCount = await panels.count();
   if (panelCount > 1) {
     const secondHeader = panels.nth(1).locator('mat-expansion-panel-header');
-    await secondHeader.click();
+    await ensurePanelExpanded(panels.nth(1));
     await expect(firstHeader).toHaveAttribute('aria-expanded', 'false');
     await expect(secondHeader).toHaveAttribute('aria-expanded', 'true');
   }
@@ -93,8 +103,7 @@ async function expectOpeningDraftContent(page: Page) {
 
   for (let index = 0; index < Math.min(panelCount, 6); index += 1) {
     const panel = panels.nth(index);
-    const header = panel.locator('mat-expansion-panel-header');
-    await header.click();
+    const header = await ensurePanelExpanded(panel);
 
     await expect(panel.locator('.draft-pick-player').first()).toBeVisible();
 

--- a/e2e/specs/draft.spec.ts
+++ b/e2e/specs/draft.spec.ts
@@ -129,7 +129,9 @@ test.describe('Draft pages', () => {
 
     await expect(page).toHaveURL(/\/draft\/entry-drafts$/);
     await entryDraftResponse;
-    await expect(page.getByRole('heading', { name: 'Varaukset' })).toBeVisible();
+    await expect(
+      page.getByRole('heading', { name: fi('nav.drafts'), level: 2, exact: true }),
+    ).toBeVisible();
 
     const openingDraftTab = page.getByRole('tab', { name: TAB_LABELS.DRAFT_OPENING_DRAFT });
     const statisticsTab = page.getByRole('tab', { name: TAB_LABELS.DRAFT_STATISTICS });

--- a/e2e/specs/filters.spec.ts
+++ b/e2e/specs/filters.spec.ts
@@ -6,6 +6,7 @@ import {
   toggleStatsPerGame,
   setMinGames,
 } from '../helpers/filters';
+import { FILTER_LABELS, FILTER_VALUES } from '../config/test-data';
 import {
   waitForTableData,
   getRowCount,
@@ -24,15 +25,13 @@ test.describe('Filters', () => {
     test('season selector and start-from season filter data', async ({ page }) => {
       const settingsDrawer = new SettingsDrawer(page);
 
-      // Select "Kaikki kaudet" (all seasons)
-      await selectSeason(page, 'Kaikki kaudet');
+      // Select all seasons
+      await selectSeason(page, FILTER_VALUES.ALL_SEASONS);
       const allSeasonsData = await getRowCount(page);
 
       // Select a specific season — should have fewer rows
       await settingsDrawer.open();
-      const seasonSelector = page.getByRole('combobox', {
-        name: 'Kausivalitsin',
-      });
+      const seasonSelector = settingsDrawer.combobox(FILTER_LABELS.SEASON);
       await seasonSelector.click();
       const options = page.getByRole('option');
       const firstSeasonText = await options.nth(1).textContent();
@@ -48,11 +47,11 @@ test.describe('Filters', () => {
       await settingsDrawer.close();
 
       // Switch back to all seasons and test start-from filter
-      await selectSeason(page, 'Kaikki kaudet');
+      await selectSeason(page, FILTER_VALUES.ALL_SEASONS);
       const allSeasonsCount = await getRowCount(page);
 
       await settingsDrawer.open();
-      const startFromSelector = page.getByRole('combobox', { name: 'Alkaen kaudesta' });
+      const startFromSelector = settingsDrawer.combobox(FILTER_LABELS.START_FROM);
       await startFromSelector.click();
       const startFromOptions = page.getByRole('option');
       const startFromOption = startFromOptions.nth(5);
@@ -116,7 +115,7 @@ test.describe('Filters', () => {
 
   test.describe('Filter Combinations', () => {
     test('all seasons + stats per game + min games combination', async ({ page }) => {
-      await selectSeason(page, 'Kaikki kaudet');
+      await selectSeason(page, FILTER_VALUES.ALL_SEASONS);
       await toggleStatsPerGame(page);
       await setMinGames(page, 50);
 
@@ -134,9 +133,7 @@ test.describe('Filters', () => {
 
       // Single season + position filter
       await settingsDrawer.open();
-      const seasonSelector = page.getByRole('combobox', {
-        name: 'Kausivalitsin',
-      });
+      const seasonSelector = settingsDrawer.combobox(FILTER_LABELS.SEASON);
       await seasonSelector.click();
       await page.getByRole('option').nth(1).click();
       await waitForTableData(page);
@@ -171,27 +168,27 @@ test.describe('Filters', () => {
       await setMinGames(page, 20);
 
       await settingsDrawer.open();
-      const playerStatsToggle = page.getByLabel('Tilastot per ottelu');
-      await expect(playerStatsToggle).toBeChecked();
+      const playerStatsToggle = settingsDrawer.switch(FILTER_LABELS.STATS_PER_GAME);
+      await expect(playerStatsToggle).toHaveAttribute('aria-checked', 'true');
       await settingsDrawer.close();
 
       await switchToGoaliesTab(page);
       await waitForTableData(page);
 
       await settingsDrawer.open();
-      const goalieStatsToggle = page.getByLabel('Tilastot per ottelu');
-      await expect(goalieStatsToggle).not.toBeChecked();
+      const goalieStatsToggle = settingsDrawer.switch(FILTER_LABELS.STATS_PER_GAME);
+      await expect(goalieStatsToggle).toHaveAttribute('aria-checked', 'false');
       await settingsDrawer.close();
 
       await toggleStatsPerGame(page);
       await settingsDrawer.open();
-      await expect(goalieStatsToggle).toBeChecked();
+      await expect(goalieStatsToggle).toHaveAttribute('aria-checked', 'true');
       await settingsDrawer.close();
 
       await switchToPlayersTab(page);
       await waitForTableData(page);
       await settingsDrawer.open();
-      await expect(playerStatsToggle).toBeChecked();
+      await expect(playerStatsToggle).toHaveAttribute('aria-checked', 'true');
     });
   });
 });

--- a/e2e/specs/mobile.spec.ts
+++ b/e2e/specs/mobile.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '../fixtures/test-fixture';
 import { SettingsDrawer } from '../page-objects/SettingsDrawer';
 import { PlayerCardDialog } from '../page-objects/PlayerCardDialog';
-import { MOBILE_VIEWPORT } from '../config/test-data';
+import { FILTER_VALUES, MOBILE_VIEWPORT } from '../config/test-data';
 import { waitForTableData } from '../helpers/table';
 
 test.describe('Mobile', () => {
@@ -18,7 +18,7 @@ test.describe('Mobile', () => {
   test('player card graphs and accordion work on mobile', async ({ page }) => {
     // Select all seasons for line graphs
     await settingsDrawer.open();
-    await settingsDrawer.selectSeason('Kaikki kaudet');
+    await settingsDrawer.selectSeason(FILTER_VALUES.ALL_SEASONS);
     await settingsDrawer.close();
 
     // Open player card and go to graphs tab

--- a/e2e/specs/player-card.spec.ts
+++ b/e2e/specs/player-card.spec.ts
@@ -3,6 +3,7 @@ import { PlayerCardDialog } from '../page-objects/PlayerCardDialog';
 import { StatsTable } from '../page-objects/StatsTable';
 import { SettingsDrawer } from '../page-objects/SettingsDrawer';
 import { selectSeason } from '../helpers/filters';
+import { FILTER_LABELS, FILTER_VALUES } from '../config/test-data';
 
 test.describe('Player Card', () => {
   let playerCard: PlayerCardDialog;
@@ -35,7 +36,7 @@ test.describe('Player Card', () => {
 
   test('tabs: all seasons shows 3 tabs, single season shows 2 tabs without by-season', async ({ page }) => {
     // All seasons: 3 tabs with full navigation
-    await selectSeason(page, 'Kaikki kaudet');
+    await selectSeason(page, FILTER_VALUES.ALL_SEASONS);
 
     await playerCard.open('Jamie Benn');
     const tabs = await playerCard.getAvailableTabs();
@@ -66,9 +67,7 @@ test.describe('Player Card', () => {
 
     // Single season: 2 tabs, no by-season, no line graphs
     await settingsDrawer.open();
-    const seasonSelector = page.getByRole('combobox', {
-      name: 'Kausivalitsin',
-    });
+    const seasonSelector = settingsDrawer.combobox(FILTER_LABELS.SEASON);
     await seasonSelector.click();
     await page.getByRole('option').nth(1).click();
     await settingsDrawer.close();
@@ -87,7 +86,7 @@ test.describe('Player Card', () => {
     await page.setViewportSize({ width: 1280, height: 720 });
 
     // Ensure all seasons for line graphs
-    await selectSeason(page, 'Kaikki kaudet');
+    await selectSeason(page, FILTER_VALUES.ALL_SEASONS);
 
     await playerCard.open('Jamie Benn');
     await playerCard.switchToTab('graphs');
@@ -134,7 +133,7 @@ test.describe('Player Card', () => {
   });
 
   test('compare toggle state persists across tabs', async ({ page }) => {
-    await selectSeason(page, 'Kaikki kaudet');
+    await selectSeason(page, FILTER_VALUES.ALL_SEASONS);
 
     await playerCard.open('Jamie Benn');
 

--- a/public/i18n/fi.json
+++ b/public/i18n/fi.json
@@ -114,13 +114,11 @@
       "openingDraft": "Avausdrafti",
       "statistics": "Tilastot"
     },
+    "settings": {
+      "disableSelectedTeamHighlight": "Poista valitun joukkueen korostus"
+    },
     "statistics": {
-      "intro": "Korosta halutessasi joukkue (tallentuu selaimeen).",
       "jumpNavAriaLabel": "Draftitilastojen osiot",
-      "highlightTeam": {
-        "label": "Korosta joukkue",
-        "clear": "Ei korostusta"
-      },
       "columns": {
         "team": "Joukkue",
         "pickCount": "Varaukset",

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -385,6 +385,37 @@ describe('AppComponent — desktop frontpage', { timeout: 60_000 }, () => {
     expect(screen.getByText(/lastModified\.label/)).toBeInTheDocument();
   });
 
+  it('shows the draft-only team highlight toggle in the drawer on draft routes', async () => {
+    const { fixture } = await render(AppComponent, getBehaviorTestConfig({ isMobile: false }));
+    const router = TestBed.inject(Router);
+
+    await router.navigateByUrl('/draft/statistics');
+
+    expect(
+      await screen.findByRole('heading', { name: 'draft.statistics.cards.totalPicks.title' }, { timeout: 15_000 }),
+    ).toBeInTheDocument();
+
+    await openDashboardSettingsDrawer();
+
+    const disableHighlightToggle = await screen.findByRole('switch', {
+      name: 'draft.settings.disableSelectedTeamHighlight',
+    });
+
+    expect(screen.getByRole('combobox', { name: /team\.selector/ })).toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: 'topControls.controls' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: 'settingsPanel.settings' })).not.toBeInTheDocument();
+    expect(screen.getByText(/lastModified\.label/)).toBeInTheDocument();
+
+    fireEvent.click(disableHighlightToggle);
+
+    await waitForBehaviorAssertion(fixture, () => {
+      expect(disableHighlightToggle).toHaveAttribute('aria-checked', 'true');
+      expect(JSON.parse(localStorage.getItem('fantrax.settings') ?? '{}')).toMatchObject({
+        disableDraftSelectedTeamHighlight: true,
+      });
+    });
+  });
+
   it('persists browse-route team changes without calling stats or seasons endpoints until stats mode becomes active again', async () => {
     localStorage.setItem(
       'fantrax.settings',
@@ -554,6 +585,15 @@ describe('buildSettingsDrawerRouteConfig', () => {
     expect(buildSettingsDrawerRouteConfig('/player/colorado/jamie-benn')).toEqual({
       mode: 'stats',
       statsContext: 'player',
+    });
+  });
+
+  it('uses draft mode for draft browse routes', () => {
+    expect(buildSettingsDrawerRouteConfig('/draft/entry-drafts')).toEqual({
+      mode: 'draft',
+    });
+    expect(buildSettingsDrawerRouteConfig('/draft/statistics')).toEqual({
+      mode: 'draft',
     });
   });
 

--- a/src/app/draft/entry-drafts/entry-drafts.component.html
+++ b/src/app/draft/entry-drafts/entry-drafts.component.html
@@ -18,7 +18,13 @@
   } @else {
   <mat-accordion class="draft-accordion" displayMode="flat">
     @for (group of groups; track group.team.id) {
-    <mat-expansion-panel class="draft-panel" #panel>
+    <mat-expansion-panel
+      class="draft-panel"
+      #panel
+      [attr.data-team-id]="group.team.id"
+      [expanded]="expandedTeamId === group.team.id"
+      (expandedChange)="onPanelExpandedChange(group.team.id, $event)"
+    >
       <mat-expansion-panel-header class="draft-panel-header" draftPanelHeaderNavigation>
         <mat-panel-title class="draft-panel-title">
           {{ group.team.name }}

--- a/src/app/draft/entry-drafts/entry-drafts.component.spec.ts
+++ b/src/app/draft/entry-drafts/entry-drafts.component.spec.ts
@@ -122,6 +122,10 @@ const entryDraftGroupsFixture: EntryDraftTeamGroup[] = [
 ];
 
 describe('EntryDraftsComponent', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
   function createFooterVisibilityMock() {
     return {
       currentCycle: vi.fn(() => 7),
@@ -181,6 +185,65 @@ describe('EntryDraftsComponent', () => {
       ],
     });
   }
+
+  it('opens the shared selected team by default when draft highlighting is enabled', async () => {
+    localStorage.setItem('fantrax.settings', JSON.stringify({
+      selectedTeamId: '12',
+      startFromSeason: null,
+      season: null,
+      reportType: 'regular',
+      disableDraftSelectedTeamHighlight: false,
+    }));
+
+    await renderComponent();
+
+    expect(await screen.findByRole('button', { name: 'Anaheim Ducks' })).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.getByRole('button', { name: 'Boston Bruins' })).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('scrolls the auto-opened shared selected team header to the top without moving focus into content', async () => {
+    localStorage.setItem('fantrax.settings', JSON.stringify({
+      selectedTeamId: '12',
+      startFromSeason: null,
+      season: null,
+      reportType: 'regular',
+      disableDraftSelectedTeamHighlight: false,
+    }));
+
+    const { scrollIntoView, restore } = stubScrollIntoView();
+
+    try {
+      const { fixture } = await renderComponent();
+      const header = await screen.findByRole('button', { name: 'Anaheim Ducks' });
+
+      await waitForBehaviorAssertion(fixture, () => {
+        expect(scrollIntoView).toHaveBeenCalledWith({
+          behavior: 'smooth',
+          block: 'start',
+          inline: 'nearest',
+        });
+        expect(header).toHaveAttribute('aria-expanded', 'true');
+        expect(header).not.toHaveFocus();
+      });
+    } finally {
+      restore();
+    }
+  });
+
+  it('skips the default selected-team expansion when draft highlighting is disabled', async () => {
+    localStorage.setItem('fantrax.settings', JSON.stringify({
+      selectedTeamId: '12',
+      startFromSeason: null,
+      season: null,
+      reportType: 'regular',
+      disableDraftSelectedTeamHighlight: true,
+    }));
+
+    await renderComponent();
+
+    expect(await screen.findByRole('button', { name: 'Anaheim Ducks' })).toHaveAttribute('aria-expanded', 'false');
+    expect(screen.getByRole('button', { name: 'Boston Bruins' })).toHaveAttribute('aria-expanded', 'false');
+  });
 
   it('renders entry draft summaries in API order and sorts seasons newest-first', async () => {
     const footerVisibilityService = createFooterVisibilityMock();

--- a/src/app/draft/entry-drafts/entry-drafts.component.ts
+++ b/src/app/draft/entry-drafts/entry-drafts.component.ts
@@ -4,9 +4,14 @@ import {
   ChangeDetectorRef,
   Component,
   DestroyRef,
+  ElementRef,
   OnInit,
   PLATFORM_ID,
+  afterNextRender,
+  effect,
   inject,
+  Injector,
+  signal,
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { MatExpansionModule } from '@angular/material/expansion';
@@ -16,10 +21,12 @@ import { TranslateModule } from '@ngx-translate/core';
 
 import { ApiService, DraftPick, DraftTeamRef, EntryDraftTeamGroup } from '@services/api.service';
 import { FooterVisibilityService } from '@services/footer-visibility.service';
+import { SettingsService } from '@services/settings.service';
 import {
   DraftPanelFocusTargetDirective,
   DraftPanelHeaderNavigationDirective,
 } from '../draft-panel-navigation.directive';
+import { scheduleDraftHeaderAlignment } from '../draft-keyboard-navigation.utils';
 
 type DraftPickStatus = {
   readonly emoji: '🟢' | '🟡';
@@ -50,11 +57,37 @@ export class EntryDraftsComponent implements OnInit {
   private readonly destroyRef = inject(DestroyRef);
   private readonly footerVisibilityService = inject(FooterVisibilityService);
   private readonly platformId = inject(PLATFORM_ID);
+  private readonly settingsService = inject(SettingsService);
+  private readonly elementRef = inject(ElementRef<HTMLElement>);
+  private readonly injector = inject(Injector);
+  private readonly groupsState = signal<EntryDraftTeamGroup[]>([]);
+  private readonly selectedTeamId = this.settingsService.selectedTeamIdSignal;
+  private readonly disableDraftSelectedTeamHighlight =
+    this.settingsService.disableDraftSelectedTeamHighlightSignal;
 
   groups: EntryDraftTeamGroup[] = [];
   loading = true;
   apiError = false;
+  expandedTeamId: string | null = null;
   private footerVisibilityCycle = 0;
+
+  constructor() {
+    effect(() => {
+      const nextExpandedTeamId = this.getDefaultExpandedTeamId(
+        this.groupsState(),
+        this.selectedTeamId(),
+        this.disableDraftSelectedTeamHighlight(),
+      );
+      const expandedTeamChanged = nextExpandedTeamId !== this.expandedTeamId;
+      this.expandedTeamId = nextExpandedTeamId;
+
+      if (expandedTeamChanged && nextExpandedTeamId !== null) {
+        this.scheduleExpandedHeaderAlignment(nextExpandedTeamId);
+      }
+
+      this.changeDetectorRef.markForCheck();
+    });
+  }
 
   ngOnInit(): void {
     this.footerVisibilityCycle = this.footerVisibilityService.currentCycle();
@@ -70,13 +103,17 @@ export class EntryDraftsComponent implements OnInit {
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
         next: (groups) => {
-          this.groups = this.normalizeGroups(groups);
+          const normalizedGroups = this.normalizeGroups(groups);
+          this.groups = normalizedGroups;
+          this.groupsState.set(normalizedGroups);
           this.loading = false;
           this.changeDetectorRef.markForCheck();
           this.footerVisibilityService.markReady(this.footerVisibilityCycle);
         },
         error: () => {
           this.groups = [];
+          this.groupsState.set([]);
+          this.expandedTeamId = null;
           this.apiError = true;
           this.loading = false;
           this.changeDetectorRef.markForCheck();
@@ -111,6 +148,18 @@ export class EntryDraftsComponent implements OnInit {
     return null;
   }
 
+  onPanelExpandedChange(teamId: string, expanded: boolean): void {
+    if (expanded) {
+      this.expandedTeamId = teamId;
+      this.scheduleExpandedHeaderAlignment(teamId);
+      return;
+    }
+
+    if (this.expandedTeamId === teamId) {
+      this.expandedTeamId = null;
+    }
+  }
+
   private normalizeGroups(groups: EntryDraftTeamGroup[]): EntryDraftTeamGroup[] {
     return groups.map((group) => ({
       ...group,
@@ -121,5 +170,40 @@ export class EntryDraftsComponent implements OnInit {
           picks: [...season.picks].sort((left, right) => left.pickNumber - right.pickNumber),
         })),
     }));
+  }
+
+  private getDefaultExpandedTeamId(
+    groups: readonly EntryDraftTeamGroup[],
+    selectedTeamId: string,
+    disableDraftSelectedTeamHighlight: boolean,
+  ): string | null {
+    if (disableDraftSelectedTeamHighlight) {
+      return null;
+    }
+
+    return groups.some((group) => group.team.id === selectedTeamId) ? selectedTeamId : null;
+  }
+
+  private scheduleExpandedHeaderAlignment(teamId: string): void {
+    if (!isPlatformBrowser(this.platformId)) {
+      return;
+    }
+
+    afterNextRender(() => {
+      const header = this.getPanelHeader(teamId);
+      if (!header) {
+        return;
+      }
+
+      scheduleDraftHeaderAlignment(header);
+    }, { injector: this.injector });
+  }
+
+  private getPanelHeader(teamId: string): HTMLElement | null {
+    const hostElement = this.elementRef.nativeElement as HTMLElement;
+    const panels = Array.from(hostElement.querySelectorAll('mat-expansion-panel')) as HTMLElement[];
+    const panel = panels.find((candidate) => candidate.dataset['teamId'] === teamId);
+
+    return (panel?.querySelector('.mat-expansion-panel-header') as HTMLElement | null) ?? null;
   }
 }

--- a/src/app/draft/opening-draft/opening-draft.component.html
+++ b/src/app/draft/opening-draft/opening-draft.component.html
@@ -18,7 +18,13 @@
   } @else {
     <mat-accordion class="draft-accordion" displayMode="flat">
       @for (group of groups; track group.team.id) {
-        <mat-expansion-panel class="draft-panel" #panel>
+        <mat-expansion-panel
+          class="draft-panel"
+          #panel
+          [attr.data-team-id]="group.team.id"
+          [expanded]="expandedTeamId === group.team.id"
+          (expandedChange)="onPanelExpandedChange(group.team.id, $event)"
+        >
           <mat-expansion-panel-header class="draft-panel-header" draftPanelHeaderNavigation>
             <mat-panel-title class="draft-panel-title">
               {{ group.team.name }}

--- a/src/app/draft/opening-draft/opening-draft.component.spec.ts
+++ b/src/app/draft/opening-draft/opening-draft.component.spec.ts
@@ -13,6 +13,20 @@ import {
 } from '../../testing/behavior-test-utils';
 
 describe('OpeningDraftComponent', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  function seedCollapsedDrawerState() {
+    localStorage.setItem('fantrax.settings', JSON.stringify({
+      selectedTeamId: '99',
+      startFromSeason: null,
+      season: null,
+      reportType: 'regular',
+      disableDraftSelectedTeamHighlight: true,
+    }));
+  }
+
   function createFooterVisibilityMock() {
     return {
       currentCycle: vi.fn(() => 7),
@@ -73,7 +87,68 @@ describe('OpeningDraftComponent', () => {
     });
   }
 
+  it('opens the shared selected team by default when draft highlighting is enabled', async () => {
+    localStorage.setItem('fantrax.settings', JSON.stringify({
+      selectedTeamId: '1',
+      startFromSeason: null,
+      season: null,
+      reportType: 'regular',
+      disableDraftSelectedTeamHighlight: false,
+    }));
+
+    await renderComponent();
+
+    expect(await screen.findByRole('button', { name: 'Colorado Avalanche' })).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.getByRole('button', { name: 'Dallas Stars' })).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('scrolls the auto-opened shared selected team header to the top without moving focus into picks', async () => {
+    localStorage.setItem('fantrax.settings', JSON.stringify({
+      selectedTeamId: '1',
+      startFromSeason: null,
+      season: null,
+      reportType: 'regular',
+      disableDraftSelectedTeamHighlight: false,
+    }));
+
+    const { scrollIntoView, restore } = stubScrollIntoView();
+
+    try {
+      const { fixture } = await renderComponent();
+      const header = await screen.findByRole('button', { name: 'Colorado Avalanche' });
+
+      await waitForBehaviorAssertion(fixture, () => {
+        expect(scrollIntoView).toHaveBeenCalledWith({
+          behavior: 'smooth',
+          block: 'start',
+          inline: 'nearest',
+        });
+        expect(header).toHaveAttribute('aria-expanded', 'true');
+        expect(header).not.toHaveFocus();
+      });
+    } finally {
+      restore();
+    }
+  });
+
+  it('skips the default selected-team expansion when draft highlighting is disabled', async () => {
+    localStorage.setItem('fantrax.settings', JSON.stringify({
+      selectedTeamId: '1',
+      startFromSeason: null,
+      season: null,
+      reportType: 'regular',
+      disableDraftSelectedTeamHighlight: true,
+    }));
+
+    await renderComponent();
+
+    expect(await screen.findByRole('button', { name: 'Colorado Avalanche' })).toHaveAttribute('aria-expanded', 'false');
+    expect(screen.getByRole('button', { name: 'Dallas Stars' })).toHaveAttribute('aria-expanded', 'false');
+  });
+
   it('renders opening draft teams in API order and shows traded-pick details inside expanded panels', async () => {
+    seedCollapsedDrawerState();
+
     const footerVisibilityService = createFooterVisibilityMock();
     const { fixture } = await renderComponent({ footerVisibilityService });
 
@@ -99,6 +174,8 @@ describe('OpeningDraftComponent', () => {
   });
 
   it('moves focus from an expanded header into opening draft picks with keyboard navigation', async () => {
+    seedCollapsedDrawerState();
+
     const { container } = await renderComponent();
 
     const header = await screen.findByRole('button', { name: 'Colorado Avalanche' });
@@ -133,6 +210,8 @@ describe('OpeningDraftComponent', () => {
   });
 
   it('supports paging within opening draft picks and collapsing from the expanded header', async () => {
+    seedCollapsedDrawerState();
+
     const { container, fixture } = await renderComponent();
 
     const header = await screen.findByRole('button', { name: 'Colorado Avalanche' });
@@ -170,6 +249,8 @@ describe('OpeningDraftComponent', () => {
   });
 
   it('scrolls an expanded opening-draft header to the top without moving focus into picks', async () => {
+    seedCollapsedDrawerState();
+
     const { scrollIntoView, restore } = stubScrollIntoView();
 
     try {
@@ -192,6 +273,8 @@ describe('OpeningDraftComponent', () => {
   });
 
   it('lets Escape on a header collapse whichever opening-draft panel is currently expanded', async () => {
+    seedCollapsedDrawerState();
+
     const { fixture } = await renderComponent();
 
     const coloradoHeader = await screen.findByRole('button', { name: 'Colorado Avalanche' });
@@ -235,6 +318,8 @@ describe('OpeningDraftComponent', () => {
   });
 
   it('keeps only one opening-draft panel expanded at a time', async () => {
+    seedCollapsedDrawerState();
+
     await renderComponent();
 
     const firstPanelButton = await screen.findByRole('button', { name: 'Colorado Avalanche' });

--- a/src/app/draft/opening-draft/opening-draft.component.ts
+++ b/src/app/draft/opening-draft/opening-draft.component.ts
@@ -4,9 +4,14 @@ import {
   ChangeDetectorRef,
   Component,
   DestroyRef,
+  ElementRef,
   OnInit,
   PLATFORM_ID,
+  afterNextRender,
+  effect,
   inject,
+  Injector,
+  signal,
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { MatExpansionModule } from '@angular/material/expansion';
@@ -15,10 +20,12 @@ import { TranslateModule } from '@ngx-translate/core';
 
 import { ApiService, DraftTeamRef, OpeningDraftPick, OpeningDraftTeamGroup } from '@services/api.service';
 import { FooterVisibilityService } from '@services/footer-visibility.service';
+import { SettingsService } from '@services/settings.service';
 import {
   DraftPanelFocusTargetDirective,
   DraftPanelHeaderNavigationDirective,
 } from '../draft-panel-navigation.directive';
+import { scheduleDraftHeaderAlignment } from '../draft-keyboard-navigation.utils';
 
 @Component({
   selector: 'app-opening-draft',
@@ -33,11 +40,37 @@ export class OpeningDraftComponent implements OnInit {
   private readonly destroyRef = inject(DestroyRef);
   private readonly footerVisibilityService = inject(FooterVisibilityService);
   private readonly platformId = inject(PLATFORM_ID);
+  private readonly settingsService = inject(SettingsService);
+  private readonly elementRef = inject(ElementRef<HTMLElement>);
+  private readonly injector = inject(Injector);
+  private readonly groupsState = signal<OpeningDraftTeamGroup[]>([]);
+  private readonly selectedTeamId = this.settingsService.selectedTeamIdSignal;
+  private readonly disableDraftSelectedTeamHighlight =
+    this.settingsService.disableDraftSelectedTeamHighlightSignal;
 
   groups: OpeningDraftTeamGroup[] = [];
   loading = true;
   apiError = false;
+  expandedTeamId: string | null = null;
   private footerVisibilityCycle = 0;
+
+  constructor() {
+    effect(() => {
+      const nextExpandedTeamId = this.getDefaultExpandedTeamId(
+        this.groupsState(),
+        this.selectedTeamId(),
+        this.disableDraftSelectedTeamHighlight(),
+      );
+      const expandedTeamChanged = nextExpandedTeamId !== this.expandedTeamId;
+      this.expandedTeamId = nextExpandedTeamId;
+
+      if (expandedTeamChanged && nextExpandedTeamId !== null) {
+        this.scheduleExpandedHeaderAlignment(nextExpandedTeamId);
+      }
+
+      this.changeDetectorRef.markForCheck();
+    });
+  }
 
   ngOnInit(): void {
     this.footerVisibilityCycle = this.footerVisibilityService.currentCycle();
@@ -54,12 +87,15 @@ export class OpeningDraftComponent implements OnInit {
       .subscribe({
         next: (groups) => {
           this.groups = groups;
+          this.groupsState.set(groups);
           this.loading = false;
           this.changeDetectorRef.markForCheck();
           this.footerVisibilityService.markReady(this.footerVisibilityCycle);
         },
         error: () => {
           this.groups = [];
+          this.groupsState.set([]);
+          this.expandedTeamId = null;
           this.apiError = true;
           this.loading = false;
           this.changeDetectorRef.markForCheck();
@@ -70,5 +106,52 @@ export class OpeningDraftComponent implements OnInit {
 
   isTradedPick(team: DraftTeamRef, pick: OpeningDraftPick): boolean {
     return pick.originalOwner.id !== team.id;
+  }
+
+  onPanelExpandedChange(teamId: string, expanded: boolean): void {
+    if (expanded) {
+      this.expandedTeamId = teamId;
+      this.scheduleExpandedHeaderAlignment(teamId);
+      return;
+    }
+
+    if (this.expandedTeamId === teamId) {
+      this.expandedTeamId = null;
+    }
+  }
+
+  private getDefaultExpandedTeamId(
+    groups: readonly OpeningDraftTeamGroup[],
+    selectedTeamId: string,
+    disableDraftSelectedTeamHighlight: boolean,
+  ): string | null {
+    if (disableDraftSelectedTeamHighlight) {
+      return null;
+    }
+
+    return groups.some((group) => group.team.id === selectedTeamId) ? selectedTeamId : null;
+  }
+
+  private scheduleExpandedHeaderAlignment(teamId: string): void {
+    if (!isPlatformBrowser(this.platformId)) {
+      return;
+    }
+
+    afterNextRender(() => {
+      const header = this.getPanelHeader(teamId);
+      if (!header) {
+        return;
+      }
+
+      scheduleDraftHeaderAlignment(header);
+    }, { injector: this.injector });
+  }
+
+  private getPanelHeader(teamId: string): HTMLElement | null {
+    const hostElement = this.elementRef.nativeElement as HTMLElement;
+    const panels = Array.from(hostElement.querySelectorAll('mat-expansion-panel')) as HTMLElement[];
+    const panel = panels.find((candidate) => candidate.dataset['teamId'] === teamId);
+
+    return (panel?.querySelector('.mat-expansion-panel-header') as HTMLElement | null) ?? null;
   }
 }

--- a/src/app/draft/statistics/draft-statistics.component.html
+++ b/src/app/draft/statistics/draft-statistics.component.html
@@ -3,30 +3,6 @@
     {{ 'draft.tabs.statistics' | translate }}
   </h3>
 
-  <div class="draft-statistics-toolbar">
-    <p class="draft-statistics-intro">
-      {{ 'draft.statistics.intro' | translate }}
-    </p>
-
-    <mat-form-field class="draft-statistics-highlight-field" appearance="outline" subscriptSizing="dynamic">
-      <mat-label>{{ 'draft.statistics.highlightTeam.label' | translate }}</mat-label>
-      <mat-select
-        [value]="highlightedTeamId"
-        [disabled]="loading || apiError || teams.length === 0"
-        (selectionChange)="onHighlightedTeamChange($event)"
-      >
-        <mat-option [value]="null">
-          {{ 'draft.statistics.highlightTeam.clear' | translate }}
-        </mat-option>
-        @for (team of teams; track team.id) {
-          <mat-option [value]="team.id">
-            {{ team.name }}
-          </mat-option>
-        }
-      </mat-select>
-    </mat-form-field>
-  </div>
-
   <app-section-jump-nav
     class="draft-statistics-jump-nav"
     [items]="jumpNavItems"

--- a/src/app/draft/statistics/draft-statistics.component.scss
+++ b/src/app/draft/statistics/draft-statistics.component.scss
@@ -7,33 +7,8 @@
   padding-bottom: 24px;
 }
 
-.draft-statistics-toolbar {
-  display: grid;
-  grid-template-columns: minmax(0, 1.5fr) minmax(16rem, 24rem);
-  gap: 16px;
-  align-items: start;
-  margin: 20px 24px 0;
-  padding: 18px 20px;
-  border: 1px solid var(--mat-sys-outline-variant);
-  border-radius: 24px;
-  background:
-    linear-gradient(180deg,
-      color-mix(in srgb, var(--mat-sys-surface-container) 92%, transparent) 0%,
-      color-mix(in srgb, var(--mat-sys-surface) 94%, transparent) 100%);
-}
-
-.draft-statistics-intro {
-  margin: 0;
-  color: var(--mat-sys-on-surface-variant);
-  line-height: 1.6;
-}
-
-.draft-statistics-highlight-field {
-  min-width: 0;
-}
-
 .draft-statistics-jump-nav {
-  --section-jump-nav-margin: 16px 24px 0;
+  --section-jump-nav-margin: 20px 24px 0;
 }
 
 .draft-statistics-section {
@@ -70,10 +45,6 @@
 }
 
 @media (max-width: 900px) {
-  .draft-statistics-toolbar {
-    grid-template-columns: minmax(0, 1fr);
-  }
-
   .draft-statistics-grid {
     grid-template-columns: minmax(0, 1fr);
   }
@@ -82,12 +53,6 @@
 @media (max-width: 480px) {
   .draft-statistics {
     padding-bottom: 8px;
-  }
-
-  .draft-statistics-toolbar {
-    margin: 12px 8px 0;
-    padding: 14px;
-    gap: 12px;
   }
 
   .draft-statistics-jump-nav {

--- a/src/app/draft/statistics/draft-statistics.component.spec.ts
+++ b/src/app/draft/statistics/draft-statistics.component.spec.ts
@@ -1,10 +1,12 @@
 import { PLATFORM_ID } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
 import { fireEvent, render, screen, within } from '@testing-library/angular';
 import { TranslateModule } from '@ngx-translate/core';
 import { Subject, of, throwError } from 'rxjs';
 
 import { ApiService, EntryDraftTeamGroup } from '@services/api.service';
 import { FooterVisibilityService } from '@services/footer-visibility.service';
+import { SettingsService } from '@services/settings.service';
 import {
   provideDisabledMaterialAnimations,
   waitForBehaviorAssertion,
@@ -114,7 +116,6 @@ describe('DraftStatisticsComponent', () => {
       screen.getByRole('heading', { name: 'draft.statistics.cards.playedForDraftingTeamPercent.title' }),
     ).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'draft.statistics.sections.pickVolume.title' })).toBeInTheDocument();
-    expect(screen.getByRole('combobox', { name: 'draft.statistics.highlightTeam.label' })).toBeInTheDocument();
     expect(fixture.componentInstance.cards.map((card) => card.id)).toEqual([
       ...DRAFT_STATISTICS_CARD_IDS,
     ]);
@@ -162,12 +163,16 @@ describe('DraftStatisticsComponent', () => {
     expect(footerVisibilityService.markReady).toHaveBeenCalledWith(9);
   });
 
-  it('highlights a selected team and jumps cards to the matching ranking page', async () => {
+  it('uses the persisted shared selected team for highlight and paging on initial render', async () => {
+    localStorage.setItem('fantrax.settings', JSON.stringify({
+      selectedTeamId: '12',
+      startFromSeason: null,
+      season: null,
+      reportType: 'regular',
+      disableDraftSelectedTeamHighlight: false,
+    }));
+
     const { fixture } = await renderComponent();
-
-    fireEvent.click(screen.getByRole('combobox', { name: 'draft.statistics.highlightTeam.label' }));
-    fireEvent.click(await screen.findByRole('option', { name: 'Team 12' }));
-
     const totalPicksCard = screen.getByRole('heading', { name: 'draft.statistics.cards.totalPicks.title' })
       .closest('app-table-card');
     expect(totalPicksCard).not.toBeNull();
@@ -181,34 +186,50 @@ describe('DraftStatisticsComponent', () => {
       expect(highlightedRow).toHaveClass('table-card-row--emphasized');
       expect(within(highlightedRow as HTMLElement).getByText('12.')).toBeInTheDocument();
     });
-
-    expect(JSON.parse(localStorage.getItem('fantrax.settings') ?? '{}')).toMatchObject({
-      draftStatisticsHighlightedTeamId: '12',
-    });
   });
 
-  it('restores the highlighted team from persisted settings', async () => {
+  it('reacts to shared team-setting changes and disables highlighting when the draft toggle is enabled', async () => {
     localStorage.setItem('fantrax.settings', JSON.stringify({
       selectedTeamId: '1',
       startFromSeason: null,
       season: null,
       reportType: 'regular',
-      draftStatisticsHighlightedTeamId: '12',
+      disableDraftSelectedTeamHighlight: false,
     }));
 
     const { fixture } = await renderComponent();
-    const totalPicksCard = await screen.findByRole('heading', { name: 'draft.statistics.cards.totalPicks.title' })
+    const settingsService = TestBed.inject(SettingsService);
+    const totalPicksCard = await screen
+      .findByRole('heading', { name: 'draft.statistics.cards.totalPicks.title' })
       .then((heading) => heading.closest('app-table-card'));
 
     expect(totalPicksCard).not.toBeNull();
 
+    settingsService.setSelectedTeamId('12');
+
     await waitForBehaviorAssertion(fixture, () => {
       const cardState = fixture.componentInstance.cards.find((card) => card.id === 'total-picks');
       const highlightedRow = within(totalPicksCard as HTMLElement).getByText('Team 12').closest('tr');
-      expect(screen.getByRole('combobox', { name: 'draft.statistics.highlightTeam.label' })).toHaveTextContent('Team 12');
+      expect(JSON.parse(localStorage.getItem('fantrax.settings') ?? '{}')).toMatchObject({
+        selectedTeamId: '12',
+      });
+      expect(fixture.componentInstance.highlightedTeamId).toBe('12');
       expect(cardState?.skip).toBe(10);
       expect(highlightedRow).toHaveClass('table-card-row--emphasized');
       expect(within(highlightedRow as HTMLElement).getByText('12.')).toBeInTheDocument();
+    });
+
+    settingsService.setDisableDraftSelectedTeamHighlight(true);
+
+    await waitForBehaviorAssertion(fixture, () => {
+      const cardState = fixture.componentInstance.cards.find((card) => card.id === 'total-picks');
+      expect(fixture.componentInstance.highlightedTeamId).toBeNull();
+      expect(cardState?.skip).toBe(0);
+      expect(cardState?.rows.every((row) => !row.emphasized)).toBe(true);
+      expect(within(totalPicksCard as HTMLElement).queryByText('Team 12')).not.toBeInTheDocument();
+      expect(JSON.parse(localStorage.getItem('fantrax.settings') ?? '{}')).toMatchObject({
+        disableDraftSelectedTeamHighlight: true,
+      });
     });
   });
 

--- a/src/app/draft/statistics/draft-statistics.component.ts
+++ b/src/app/draft/statistics/draft-statistics.component.ts
@@ -6,11 +6,11 @@ import {
   DestroyRef,
   OnInit,
   PLATFORM_ID,
+  effect,
   inject,
+  signal,
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { MatFormFieldModule } from '@angular/material/form-field';
-import { MatSelectChange, MatSelectModule } from '@angular/material/select';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 
 import { ApiService, EntryDraftTeamGroup } from '@services/api.service';
@@ -79,11 +79,6 @@ type DraftStatisticsSection = {
   readonly anchorId: string;
   readonly headingId: string;
   readonly cards: readonly DraftStatisticsCard[];
-};
-
-type DraftStatisticsTeamOption = {
-  readonly id: string;
-  readonly name: string;
 };
 
 const draftStatisticsSectionDefinitions = DRAFT_STATISTICS_SECTIONS.map((section) => ({
@@ -201,13 +196,7 @@ const draftStatisticDefinitions: readonly DraftStatisticDefinition[] = DRAFT_STA
 @Component({
   selector: 'app-draft-statistics',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [
-    MatFormFieldModule,
-    MatSelectModule,
-    SectionJumpNavComponent,
-    TableCardComponent,
-    TranslateModule,
-  ],
+  imports: [SectionJumpNavComponent, TableCardComponent, TranslateModule],
   templateUrl: './draft-statistics.component.html',
   styleUrl: './draft-statistics.component.scss',
 })
@@ -220,6 +209,10 @@ export class DraftStatisticsComponent implements OnInit {
   private readonly settingsService = inject(SettingsService);
   private readonly platformId = inject(PLATFORM_ID);
   private readonly translate = inject(TranslateService);
+  private readonly draftGroups = signal<EntryDraftTeamGroup[]>([]);
+  private readonly selectedTeamId = this.settingsService.selectedTeamIdSignal;
+  private readonly disableDraftSelectedTeamHighlight =
+    this.settingsService.disableDraftSelectedTeamHighlightSignal;
 
   readonly pageSize = PAGE_SIZE;
   readonly sectionLinks = draftStatisticsSectionDefinitions;
@@ -229,11 +222,29 @@ export class DraftStatisticsComponent implements OnInit {
   }));
 
   sections: DraftStatisticsSection[] = this.createInitialSections();
-  teams: DraftStatisticsTeamOption[] = [];
   loading = true;
   apiError = false;
   highlightedTeamId: string | null = null;
   private footerVisibilityCycle = 0;
+
+  constructor() {
+    effect(() => {
+      const groups = this.draftGroups();
+      const selectedTeamId = this.selectedTeamId();
+      const disableDraftSelectedTeamHighlight = this.disableDraftSelectedTeamHighlight();
+      const highlightedTeamId = this.getEffectiveHighlightedTeamId(
+        groups,
+        selectedTeamId,
+        disableDraftSelectedTeamHighlight,
+      );
+
+      this.highlightedTeamId = highlightedTeamId;
+      this.sections = groups.length === 0
+        ? this.createInitialSections()
+        : this.buildSections(groups, highlightedTeamId);
+      this.changeDetectorRef.markForCheck();
+    });
+  }
 
   get cards(): DraftStatisticsCard[] {
     return this.sections.flatMap((section) => [...section.cards]);
@@ -243,7 +254,6 @@ export class DraftStatisticsComponent implements OnInit {
     this.footerVisibilityCycle = this.footerVisibilityService.currentCycle();
     this.loading = true;
     this.apiError = false;
-    this.highlightedTeamId = this.settingsService.draftStatisticsHighlightedTeamId;
 
     if (!isPlatformBrowser(this.platformId)) {
       this.footerVisibilityService.markReady(this.footerVisibilityCycle);
@@ -254,50 +264,19 @@ export class DraftStatisticsComponent implements OnInit {
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
         next: (groups) => {
-          this.teams = this.buildTeamOptions(groups);
-          if (this.highlightedTeamId !== null && !this.teams.some((team) => team.id === this.highlightedTeamId)) {
-            this.highlightedTeamId = null;
-            this.settingsService.setDraftStatisticsHighlightedTeamId(null);
-          }
-          this.sections = this.buildSections(groups);
+          this.draftGroups.set(groups);
           this.loading = false;
           this.changeDetectorRef.markForCheck();
           this.footerVisibilityService.markReady(this.footerVisibilityCycle);
         },
         error: () => {
-          this.sections = this.createInitialSections();
-          this.teams = [];
-          this.highlightedTeamId = null;
+          this.draftGroups.set([]);
           this.apiError = true;
           this.loading = false;
           this.changeDetectorRef.markForCheck();
           this.footerVisibilityService.markReady(this.footerVisibilityCycle);
         },
       });
-  }
-
-  onHighlightedTeamChange(event: MatSelectChange): void {
-    const selectedTeamId = typeof event.value === 'string' && event.value.length > 0
-      ? event.value
-      : null;
-
-    this.highlightedTeamId = selectedTeamId;
-    this.settingsService.setDraftStatisticsHighlightedTeamId(selectedTeamId);
-    this.sections = this.sections.map((section) => ({
-      ...section,
-      cards: section.cards.map((card) => {
-        const nextSkip = selectedTeamId === null
-          ? 0
-          : this.getTeamPageSkip(card.allRows, selectedTeamId);
-
-        return {
-          ...card,
-          skip: nextSkip,
-          rows: this.buildVisibleRows(card.allRows, nextSkip),
-        };
-      }),
-    }));
-    this.changeDetectorRef.markForCheck();
   }
 
   scrollToSection(anchorId: string): void {
@@ -353,11 +332,14 @@ export class DraftStatisticsComponent implements OnInit {
     };
   }
 
-  private buildSections(groups: EntryDraftTeamGroup[]): DraftStatisticsSection[] {
+  private buildSections(
+    groups: EntryDraftTeamGroup[],
+    highlightedTeamId: string | null,
+  ): DraftStatisticsSection[] {
     const cardsById = Object.fromEntries(
       draftStatisticDefinitions.map((definition) => [
         definition.id,
-        this.buildCard(groups, definition),
+        this.buildCard(groups, definition, highlightedTeamId),
       ]),
     ) as Record<DraftStatisticsCardId, DraftStatisticsCard>;
 
@@ -370,6 +352,7 @@ export class DraftStatisticsComponent implements OnInit {
   private buildCard(
     groups: EntryDraftTeamGroup[],
     definition: DraftStatisticDefinition,
+    highlightedTeamId: string | null,
   ): DraftStatisticsCard {
     const allRows = deriveTiedRanks(
       groups
@@ -378,9 +361,9 @@ export class DraftStatisticsComponent implements OnInit {
       .sort((left, right) => this.compareRows(left, right, definition.direction)),
       (left, right) => left.rawValue === right.rawValue,
     );
-    const initialSkip = this.highlightedTeamId === null
+    const initialSkip = highlightedTeamId === null
       ? 0
-      : this.getTeamPageSkip(allRows, this.highlightedTeamId);
+      : this.getTeamPageSkip(allRows, highlightedTeamId);
 
     return {
       id: definition.id,
@@ -388,19 +371,10 @@ export class DraftStatisticsComponent implements OnInit {
       descriptionKey: definition.descriptionKey,
       valueColumnLabelKey: definition.valueColumnLabelKey,
       allRows,
-      rows: this.buildVisibleRows(allRows, initialSkip),
+      rows: this.buildVisibleRows(allRows, initialSkip, highlightedTeamId),
       skip: initialSkip,
       total: allRows.length,
     };
-  }
-
-  private buildTeamOptions(groups: EntryDraftTeamGroup[]): DraftStatisticsTeamOption[] {
-    return groups
-      .map((group) => ({
-        id: group.team.id,
-        name: group.team.name,
-      }))
-      .sort((left, right) => left.name.localeCompare(right.name, 'fi'));
   }
 
   private buildSourceRow(
@@ -427,6 +401,7 @@ export class DraftStatisticsComponent implements OnInit {
   private buildVisibleRows(
     allRows: readonly DraftStatisticSourceRow[],
     skip: number,
+    highlightedTeamId: string | null,
   ): TableCardRow[] {
     return allRows
       .slice(skip, skip + PAGE_SIZE)
@@ -435,7 +410,7 @@ export class DraftStatisticsComponent implements OnInit {
         rank: this.buildRankLabel(row.displayRank, row.tieRank),
         primaryText: row.teamName,
         value: row.value,
-        emphasized: row.teamId === this.highlightedTeamId,
+        emphasized: row.teamId === highlightedTeamId,
       }));
   }
 
@@ -484,11 +459,23 @@ export class DraftStatisticsComponent implements OnInit {
         return {
           ...card,
           skip: nextSkip,
-          rows: this.buildVisibleRows(card.allRows, nextSkip),
+          rows: this.buildVisibleRows(card.allRows, nextSkip, this.highlightedTeamId),
         };
       }),
     }));
     this.changeDetectorRef.markForCheck();
+  }
+
+  private getEffectiveHighlightedTeamId(
+    groups: readonly EntryDraftTeamGroup[],
+    selectedTeamId: string,
+    disableDraftSelectedTeamHighlight: boolean,
+  ): string | null {
+    if (disableDraftSelectedTeamHighlight) {
+      return null;
+    }
+
+    return groups.some((group) => group.team.id === selectedTeamId) ? selectedTeamId : null;
   }
 
   private buildRankLabel(rank: number, tieRank: boolean): TableCardRow['rank'] {

--- a/src/app/services/settings.service.ts
+++ b/src/app/services/settings.service.ts
@@ -7,7 +7,7 @@ export type AppSettings = {
   startFromSeason: number | null;
   season: number | null;
   reportType: ReportType;
-  draftStatisticsHighlightedTeamId: string | null;
+  disableDraftSelectedTeamHighlight: boolean;
 };
 
 @Injectable({
@@ -45,8 +45,12 @@ export class SettingsService {
     return this.settingsSignal().reportType;
   }
 
-  get draftStatisticsHighlightedTeamId(): string | null {
-    return this.settingsSignal().draftStatisticsHighlightedTeamId;
+  readonly disableDraftSelectedTeamHighlightSignal = computed(
+    () => this.settingsSignal().disableDraftSelectedTeamHighlight,
+  );
+
+  get disableDraftSelectedTeamHighlight(): boolean {
+    return this.disableDraftSelectedTeamHighlightSignal();
   }
 
   setSelectedTeamId(teamId: string): void {
@@ -70,9 +74,9 @@ export class SettingsService {
     this.updateSettings({ reportType });
   }
 
-  setDraftStatisticsHighlightedTeamId(teamId: string | null): void {
-    if (teamId === this.settingsSignal().draftStatisticsHighlightedTeamId) return;
-    this.updateSettings({ draftStatisticsHighlightedTeamId: teamId });
+  setDisableDraftSelectedTeamHighlight(disabled: boolean): void {
+    if (disabled === this.settingsSignal().disableDraftSelectedTeamHighlight) return;
+    this.updateSettings({ disableDraftSelectedTeamHighlight: disabled });
   }
 
   private updateSettings(patch: Partial<AppSettings>): void {
@@ -103,18 +107,17 @@ export class SettingsService {
             : null;
 
         const reportType = this.parseReportType(parsed.reportType);
-        const draftStatisticsHighlightedTeamId =
-          typeof parsed.draftStatisticsHighlightedTeamId === 'string'
-            && parsed.draftStatisticsHighlightedTeamId.trim().length > 0
-            ? parsed.draftStatisticsHighlightedTeamId
-            : null;
+        const disableDraftSelectedTeamHighlight =
+          typeof parsed.disableDraftSelectedTeamHighlight === 'boolean'
+            ? parsed.disableDraftSelectedTeamHighlight
+            : false;
 
         return {
           selectedTeamId,
           startFromSeason,
           season,
           reportType,
-          draftStatisticsHighlightedTeamId,
+          disableDraftSelectedTeamHighlight,
         };
       }
     } catch {
@@ -126,7 +129,7 @@ export class SettingsService {
       startFromSeason: null,
       season: null,
       reportType: 'regular',
-      draftStatisticsHighlightedTeamId: null,
+      disableDraftSelectedTeamHighlight: false,
     };
     this.persist(defaults);
     return defaults;

--- a/src/app/shared/settings-drawer/draft-team-highlight-toggle/draft-team-highlight-toggle.component.html
+++ b/src/app/shared/settings-drawer/draft-team-highlight-toggle/draft-team-highlight-toggle.component.html
@@ -1,0 +1,8 @@
+<mat-slide-toggle
+  class="draft-team-highlight-toggle"
+  labelPosition="before"
+  [checked]="disabled()"
+  (change)="onToggleChange($event)"
+>
+  {{ 'draft.settings.disableSelectedTeamHighlight' | translate }}
+</mat-slide-toggle>

--- a/src/app/shared/settings-drawer/draft-team-highlight-toggle/draft-team-highlight-toggle.component.scss
+++ b/src/app/shared/settings-drawer/draft-team-highlight-toggle/draft-team-highlight-toggle.component.scss
@@ -1,0 +1,8 @@
+:host {
+  display: flex;
+  justify-content: center;
+}
+
+.draft-team-highlight-toggle {
+  max-width: 100%;
+}

--- a/src/app/shared/settings-drawer/draft-team-highlight-toggle/draft-team-highlight-toggle.component.ts
+++ b/src/app/shared/settings-drawer/draft-team-highlight-toggle/draft-team-highlight-toggle.component.ts
@@ -1,0 +1,25 @@
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import {
+  MatSlideToggleChange,
+  MatSlideToggleModule,
+} from '@angular/material/slide-toggle';
+import { TranslateModule } from '@ngx-translate/core';
+
+import { SettingsService } from '@services/settings.service';
+
+@Component({
+  selector: 'app-draft-team-highlight-toggle',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [MatSlideToggleModule, TranslateModule],
+  templateUrl: './draft-team-highlight-toggle.component.html',
+  styleUrl: './draft-team-highlight-toggle.component.scss',
+})
+export class DraftTeamHighlightToggleComponent {
+  private readonly settingsService = inject(SettingsService);
+
+  readonly disabled = this.settingsService.disableDraftSelectedTeamHighlightSignal;
+
+  onToggleChange(event: MatSlideToggleChange): void {
+    this.settingsService.setDisableDraftSelectedTeamHighlight(event.checked);
+  }
+}

--- a/src/app/shared/settings-drawer/settings-drawer.component.html
+++ b/src/app/shared/settings-drawer/settings-drawer.component.html
@@ -18,6 +18,12 @@
     <app-team-switcher />
   </div>
 
+  @if (showDraftTeamHighlightToggle()) {
+    <div class="settings-drawer-section settings-drawer-section--draft-settings">
+      <app-draft-team-highlight-toggle />
+    </div>
+  }
+
   @if (resolvedStatsContext(); as context) {
     <div class="settings-drawer-section settings-drawer-section--top-controls">
       <h3 class="settings-drawer-section-title">

--- a/src/app/shared/settings-drawer/settings-drawer.component.scss
+++ b/src/app/shared/settings-drawer/settings-drawer.component.scss
@@ -57,6 +57,7 @@
   padding: 0 16px;
   font-size: 0.85rem;
   color: var(--mat-sys-on-surface-variant);
+  text-align: center;
 }
 
 :host ::ng-deep app-settings-panel .control-panel-content {

--- a/src/app/shared/settings-drawer/settings-drawer.component.ts
+++ b/src/app/shared/settings-drawer/settings-drawer.component.ts
@@ -11,6 +11,7 @@ import { DrawerContextService } from '@services/drawer-context.service';
 import { SettingsDrawerMode } from '@shared/utils/settings-drawer.utils';
 import { StatsContext } from '@shared/types/context.types';
 import { SettingsPanelComponent } from '@shared/settings-panel/settings-panel.component';
+import { DraftTeamHighlightToggleComponent } from '@shared/settings-drawer/draft-team-highlight-toggle/draft-team-highlight-toggle.component';
 import { TeamSwitcherComponent } from '@shared/top-controls/team-switcher/team-switcher.component';
 import { TopControlsComponent } from '@shared/top-controls/top-controls.component';
 
@@ -22,6 +23,7 @@ import { TopControlsComponent } from '@shared/top-controls/top-controls.componen
     MatIconModule,
     MatTooltipModule,
     TranslateModule,
+    DraftTeamHighlightToggleComponent,
     TeamSwitcherComponent,
     TopControlsComponent,
     SettingsPanelComponent,
@@ -52,6 +54,8 @@ export class SettingsDrawerComponent {
 
     return this.statsContext() ?? 'player';
   });
+
+  readonly showDraftTeamHighlightToggle = computed(() => this.mode() === 'draft');
 
   readonly drawerMaxGames = computed(() => {
     const context = this.resolvedStatsContext();

--- a/src/app/shared/settings-panel/stats-mode-toggle/stats-mode-toggle.component.scss
+++ b/src/app/shared/settings-panel/stats-mode-toggle/stats-mode-toggle.component.scss
@@ -1,3 +1,0 @@
-:host ::ng-deep .mdc-form-field--align-end > label {
-  padding-right: 12px;
-}

--- a/src/app/shared/settings-panel/stats-mode-toggle/stats-mode-toggle.component.ts
+++ b/src/app/shared/settings-panel/stats-mode-toggle/stats-mode-toggle.component.ts
@@ -13,7 +13,6 @@ import { StatsContext } from '@shared/types/context.types';
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [MatSlideToggleModule, TranslateModule],
   templateUrl: './stats-mode-toggle.component.html',
-  styleUrl: './stats-mode-toggle.component.scss',
 })
 export class StatsModeToggleComponent {
   readonly context = input.required<StatsContext>();

--- a/src/app/shared/utils/settings-drawer.utils.ts
+++ b/src/app/shared/utils/settings-drawer.utils.ts
@@ -1,6 +1,6 @@
 import { StatsContext } from '@shared/types/context.types';
 
-export type SettingsDrawerMode = 'default' | 'stats';
+export type SettingsDrawerMode = 'default' | 'draft' | 'stats';
 
 export type SettingsDrawerRouteConfig = {
   mode: SettingsDrawerMode;
@@ -29,6 +29,10 @@ export function buildSettingsDrawerRouteConfig(url: string): SettingsDrawerRoute
       mode: 'stats',
       statsContext: 'player',
     };
+  }
+
+  if (normalizedUrl.startsWith('/draft')) {
+    return { mode: 'draft' };
   }
 
   return { mode: 'default' };

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -331,6 +331,17 @@ button[mat-icon-button]:focus-visible,
   color: inherit !important;
 }
 
+// Slide toggles: use shared spacing between the switch control and label text
+// instead of per-component label padding overrides.
+.mat-mdc-slide-toggle .mat-internal-form-field {
+  gap: 12px;
+}
+
+.mat-mdc-slide-toggle .mat-internal-form-field > label {
+  margin: 0;
+  padding: 0;
+}
+
 @media (prefers-color-scheme: dark) {
 
   // Slides toggles (points per game): ensure readable + modern dark styling.


### PR DESCRIPTION
PR notes

Summary
- move draft-specific team highlight behavior into the shared settings drawer
- remove the draft statistics toolbar and add a draft-only disable-highlight toggle
- make entry/opening draft views follow the shared selected team and scroll opened sections consistently
- standardize drawer sections, global slide-toggle spacing, and related drawer docs
- harden Playwright drawer interactions and switch touched E2E selectors to shared Finnish translation helpers

Testing
- npm run verify
- npm run e2e
