### PR TITLE
Fix: Keep draft navigation visible and simplify bottom area

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ The docs in this repo intentionally focus on project-specific architecture, work
 	- Team-by-team draft history and summary views
 	- Played-status markers show whether drafted players reached the drafting team or elsewhere in the league
 	- Draft statistics cards are grouped into sectioned rankings with jump navigation
+	- The full draft team listing now scrolls inside a bounded route-level window so the draft tabs stay reachable; when a selected team auto-opens on route entry, it aligns to the top of that list
 	- The shared team setting opens or highlights the selected team by default across draft views, and the shared settings drawer toggle can disable that behavior on both draft and leaderboard routes
 - ⚙️ **Shared Settings Drawer**: The same settings entry point is available across stats, career, draft, and leaderboard routes
 - 🗂️ **Global Navigation**: Bottom sheet menu for switching between views (hockey stats, player careers, leaderboards, info/help)

--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -70,8 +70,9 @@ Draft browse pages use long expansion panels, so header focus alone is not enoug
 Supported behavior on entry-draft and opening-draft pages:
 
 - Team headers remain the primary tab stops
-- Manually opening a panel scrolls its header to the top of the viewport, but does not move focus into the content by itself
-- The initial auto-opened selected team does not trigger that scroll jump on route entry
+- The full team accordion scrolls inside a bounded route-level region so the draft tab navigation stays reachable while browsing deep lists
+- The initial auto-opened selected team aligns its header to the top of the visible draft list on route entry
+- Manually opening a panel scrolls its header to the top of the visible draft list, but does not move focus into the content by itself
 - On an expanded team header:
   - `ArrowDown` moves focus into the expanded content
   - `Escape` collapses the currently expanded panel
@@ -83,6 +84,8 @@ Supported behavior on entry-draft and opening-draft pages:
 
 Notes:
 
+- Keyboard movement relies on focusing the next target and letting the nearest draft scroll region follow with `scrollIntoView()`
+- Team-header alignment now usually resolves inside the bounded accordion scroller instead of the whole page
 - Entry drafts use section- and season-level focus targets rather than tabbing through every summary value
 - Opening draft uses roving focus on pick rows so long pick lists stay keyboard-browsable without bloating the page tab order
 

--- a/docs/project-overview.md
+++ b/docs/project-overview.md
@@ -102,7 +102,9 @@ Accessibility is a core requirement: the UI is designed to remain usable via key
    - Batch 2 renders `/draft/opening-draft` as a Material accordion grouped by drafting team, with simple per-pick rows and a traded-owner suffix when the original pick came from another team
    - Batch 3 renders `/draft/entry-drafts` as a matching team-grouped accordion, with per-team summary cards, played-status totals plus played percentages, highest-pick highlights, and season-by-season pick lists that preserve null legacy player rows
    - Entry-draft pick rows add `🟢` / `🟡` played-status markers to show whether a drafted player reached the drafting team or played elsewhere in the league
-   - Manually opened draft panels auto-align their sticky header to the top of the viewport, while `ArrowDown` still explicitly enters the panel body; once inside, `ArrowUp` / `ArrowDown` / `Home` / `End` / `PageUp` / `PageDown` browse within it and `Escape` collapses the panel while returning focus to the team header
+   - The full draft accordion list sits inside a bounded route-level scroll window so the draft tabs stay reachable while browsing teams
+   - When the shared selected team auto-opens on route entry, that team header aligns to the top of the visible draft list; manually opened draft panels use the same header alignment, while `ArrowDown` still explicitly enters the panel body
+   - Once inside expanded content, `ArrowUp` / `ArrowDown` / `Home` / `End` / `PageUp` / `PageDown` browse within it and `Escape` collapses the panel while returning focus to the team header
    - `/draft/statistics` reuses the shared card-table UI to rank teams across entry-draft summary metrics, including separate played-percentage rankings, with local 10-row paging
    - By default, all three draft views follow the shared selected-team setting: entry/opening draft expand that team automatically and draft statistics emphasizes it plus jumps each card to the matching page
    - Draft routes share the same selected-team highlight toggle used on leaderboards; disabling it removes the default selected-team emphasis/auto-open behavior without affecting the actual shared team selection

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -108,17 +108,6 @@ describe('AppComponent — desktop frontpage', { timeout: 60_000 }, () => {
     // -- Search input --
     expect(screen.getByLabelText('table.playerSearch')).toBeInTheDocument();
 
-    // -- Footer --
-    expect(await screen.findByRole(
-      'navigation',
-      { name: 'footer.links.ariaLabel' },
-      { timeout: 5000 }
-    )).toBeInTheDocument();
-    expect(screen.getByText('footer.links.linkedin.label')).toBeInTheDocument();
-    expect(screen.getByText('footer.links.ui.label')).toBeInTheDocument();
-    expect(screen.getByText('footer.links.api.label')).toBeInTheDocument();
-    expect(screen.getByText('footer.copyright')).toBeInTheDocument();
-
     // -- Accessibility flow (merged on purpose for speed):
     // Verify the skip link moves focus directly to the first data row after initial content has loaded.
     // Keeping this in the same render avoids a second expensive full-app render while preserving user-path behavior.

--- a/src/app/base/footer/footer.component.html
+++ b/src/app/base/footer/footer.component.html
@@ -1,23 +1,3 @@
 <div class="footer">
   <mat-divider></mat-divider>
-
-  <nav class="footer-links" [attr.aria-label]="'footer.links.ariaLabel' | translate">
-    @for (link of links; track link.key) {
-      <a
-        class="footer-link"
-        [href]="('footer.links.' + link.key + '.href') | translate"
-        target="_blank"
-        rel="noopener noreferrer"
-      >
-        <fa-icon
-          class="footer-icon"
-          [icon]="link.icon"
-          aria-hidden="true"
-        ></fa-icon>
-        <span>{{ ('footer.links.' + link.key + '.label') | translate }}</span>
-      </a>
-    }
-  </nav>
-
-  <p class="center">{{ 'footer.copyright' | translate }}</p>
 </div>

--- a/src/app/base/footer/footer.component.scss
+++ b/src/app/base/footer/footer.component.scss
@@ -1,6 +1,6 @@
 .footer {
   max-width: 1280px;
-  margin: 36px auto;
+  margin: 0 auto;
   padding-bottom: 12px;
 }
 

--- a/src/app/draft/draft-keyboard-navigation.utils.ts
+++ b/src/app/draft/draft-keyboard-navigation.utils.ts
@@ -1,5 +1,6 @@
 export const DRAFT_FOCUS_TARGET_SELECTOR = '.draft-focus-target';
 export const DRAFT_FOCUS_PAGE_STEP = 5;
+export const DRAFT_LIST_SCROLL_CONTAINER_SELECTOR = '.draft-accordion-scroll-window';
 
 export function getDraftPanelHeader(panel: ParentNode): HTMLElement | null {
   return panel.querySelector<HTMLElement>('.mat-expansion-panel-header');
@@ -24,13 +25,29 @@ export function focusDraftElement(element: HTMLElement | null | undefined): bool
   return true;
 }
 
-export function scrollDraftElementToTop(element: HTMLElement | null | undefined): boolean {
+export function scrollDraftElementToTop(
+  element: HTMLElement | null | undefined,
+  behavior: ScrollBehavior = 'smooth',
+): boolean {
   if (!element) {
     return false;
   }
 
+  const scrollContainer = element.closest<HTMLElement>(DRAFT_LIST_SCROLL_CONTAINER_SELECTOR);
+  if (scrollContainer && typeof scrollContainer.scrollTo === 'function') {
+    const containerRect = scrollContainer.getBoundingClientRect();
+    const elementRect = element.getBoundingClientRect();
+    const nextTop = scrollContainer.scrollTop + (elementRect.top - containerRect.top);
+
+    scrollContainer.scrollTo({
+      top: Math.max(nextTop, 0),
+      behavior,
+    });
+    return true;
+  }
+
   if (typeof element.scrollIntoView === 'function') {
-    element.scrollIntoView({ block: 'start', inline: 'nearest', behavior: 'smooth' });
+    element.scrollIntoView({ block: 'start', inline: 'nearest', behavior });
   }
 
   return true;
@@ -45,10 +62,40 @@ export function getExpandedDraftHeaderForEscape(currentHeader: HTMLElement): HTM
   return accordion?.querySelector('.mat-expansion-panel-header[aria-expanded="true"]') as HTMLElement | null;
 }
 
-export function scheduleDraftHeaderAlignment(header: HTMLElement): void {
+export function getDraftPanelHeaderByTeamId(panelRoot: ParentNode, teamId: string): HTMLElement | null {
+  const escapedTeamId = teamId.replaceAll('"', '\\"');
+  return panelRoot.querySelector<HTMLElement>(
+    `[data-team-id="${escapedTeamId}"] .mat-expansion-panel-header`,
+  );
+}
+
+export function scheduleDraftHeaderAlignment(
+  header: HTMLElement,
+  behavior: ScrollBehavior = 'smooth',
+): void {
   const alignHeader = () => {
     if (header.getAttribute('aria-expanded') === 'true') {
-      scrollDraftElementToTop(header);
+      scrollDraftElementToTop(header, behavior);
+    }
+  };
+
+  window.setTimeout(alignHeader, 0);
+  window.setTimeout(alignHeader, 250);
+}
+
+export function scheduleDraftTeamHeaderAlignment(
+  panelRoot: ParentNode | null | undefined,
+  teamId: string,
+  behavior: ScrollBehavior = 'auto',
+): void {
+  if (!panelRoot || !teamId) {
+    return;
+  }
+
+  const alignHeader = () => {
+    const header = getDraftPanelHeaderByTeamId(panelRoot, teamId);
+    if (header?.getAttribute('aria-expanded') === 'true') {
+      scrollDraftElementToTop(header, behavior);
     }
   };
 

--- a/src/app/draft/entry-drafts/entry-drafts.component.html
+++ b/src/app/draft/entry-drafts/entry-drafts.component.html
@@ -16,28 +16,29 @@
     {{ 'draft.noResults' | translate }}
   </p>
   } @else {
-  <mat-accordion class="draft-accordion" displayMode="flat">
-    @for (group of groups; track group.team.id) {
-    <mat-expansion-panel
-      class="draft-panel"
-      #panel
-      [attr.data-team-id]="group.team.id"
-      [expanded]="expandedTeamId === group.team.id"
-      (expandedChange)="onPanelExpandedChange(group.team.id, $event)"
-    >
-      <mat-expansion-panel-header class="draft-panel-header" draftPanelHeaderNavigation>
-        <mat-panel-title class="draft-panel-title">
-          {{ group.team.name }}
-        </mat-panel-title>
-      </mat-expansion-panel-header>
+  <div class="draft-accordion-scroll-window">
+    <mat-accordion class="draft-accordion" displayMode="flat">
+      @for (group of groups; track group.team.id) {
+      <mat-expansion-panel
+        class="draft-panel"
+        #panel
+        [attr.data-team-id]="group.team.id"
+        [expanded]="expandedTeamId === group.team.id"
+        (expandedChange)="onPanelExpandedChange(group.team.id, $event)"
+      >
+        <mat-expansion-panel-header class="draft-panel-header" draftPanelHeaderNavigation>
+          <mat-panel-title class="draft-panel-title">
+            {{ group.team.name }}
+          </mat-panel-title>
+        </mat-expansion-panel-header>
 
-      <div class="entry-draft-panel-content" [attr.aria-hidden]="panel.expanded ? null : 'true'"
-        [attr.inert]="panel.expanded ? null : ''">
-        <section class="entry-summary draft-focus-target" aria-labelledby="entry-summary-heading-{{ group.team.id }}"
-          tabindex="-1" draftPanelFocusTarget>
-          <h4 class="entry-section-title" id="entry-summary-heading-{{ group.team.id }}">
-            {{ 'draft.entryDrafts.summaryHeading' | translate }}
-          </h4>
+        <div class="entry-draft-panel-content" [attr.aria-hidden]="panel.expanded ? null : 'true'"
+          [attr.inert]="panel.expanded ? null : ''">
+          <section class="entry-summary draft-focus-target" aria-labelledby="entry-summary-heading-{{ group.team.id }}"
+            tabindex="-1" draftPanelFocusTarget>
+            <h4 class="entry-section-title" id="entry-summary-heading-{{ group.team.id }}">
+              {{ 'draft.entryDrafts.summaryHeading' | translate }}
+            </h4>
 
           <div class="entry-summary-grid">
             <article class="entry-summary-card entry-summary-card--wide">
@@ -171,67 +172,68 @@
             </p>
             }
           </section>
-        </section>
+          </section>
 
-        <section class="entry-seasons draft-focus-target" aria-labelledby="entry-seasons-heading-{{ group.team.id }}"
-          tabindex="-1" draftPanelFocusTarget>
-          <h4 class="entry-section-title" id="entry-seasons-heading-{{ group.team.id }}">
-            {{ 'draft.entryDrafts.seasonsHeading' | translate }}
-          </h4>
+          <section class="entry-seasons draft-focus-target" aria-labelledby="entry-seasons-heading-{{ group.team.id }}"
+            tabindex="-1" draftPanelFocusTarget>
+            <h4 class="entry-section-title" id="entry-seasons-heading-{{ group.team.id }}">
+              {{ 'draft.entryDrafts.seasonsHeading' | translate }}
+            </h4>
 
-          @if (group.seasons.length === 0) {
-          <p class="entry-season-empty">{{ 'draft.noResults' | translate }}</p>
-          } @else {
-          <div class="entry-season-list">
-            @for (season of group.seasons; track season.season) {
-            <section class="entry-season draft-focus-target"
-              aria-labelledby="entry-season-title-{{ group.team.id }}-{{ season.season }}" tabindex="-1"
-              draftPanelFocusTarget>
-              <h5 class="entry-season-title" id="entry-season-title-{{ group.team.id }}-{{ season.season }}">
-                {{ season.season }}
-              </h5>
+            @if (group.seasons.length === 0) {
+            <p class="entry-season-empty">{{ 'draft.noResults' | translate }}</p>
+            } @else {
+            <div class="entry-season-list">
+              @for (season of group.seasons; track season.season) {
+              <section class="entry-season draft-focus-target"
+                aria-labelledby="entry-season-title-{{ group.team.id }}-{{ season.season }}" tabindex="-1"
+                draftPanelFocusTarget>
+                <h5 class="entry-season-title" id="entry-season-title-{{ group.team.id }}-{{ season.season }}">
+                  {{ season.season }}
+                </h5>
 
-              <mat-list class="draft-pick-list" role="list">
-                @for (pick of season.picks; track pick.pickNumber; let pickIndex = $index) {
-                <div class="draft-pick-item" role="listitem">
-                  <div class="draft-pick-row">
-                    <span class="draft-pick-tag">
-                      {{ 'draft.entryDrafts.selectionLabel' | translate }} {{ pickIndex + 1 }}
-                    </span>
-                    <span class="draft-pick-tag">
-                      {{ 'draft.entryDrafts.roundLabel' | translate }} {{ pick.round }}
-                    </span>
-                    <span class="draft-pick-tag">
-                      {{ 'draft.entryDrafts.turnLabel' | translate }} {{ pick.pickNumber }}
-                    </span>
-                    <span class="draft-pick-player" [class.draft-pick-player--missing]="pick.draftedPlayer === null">
-                      <span>{{ pick.draftedPlayer ?? ('draft.entryDrafts.unknownPlayerLabel' | translate) }}</span>
-                      @if (getPickStatus(pick); as pickStatus) {
-                      <span class="draft-pick-status-badge" [matTooltip]="pickStatus.tooltipKey | translate"
-                        aria-hidden="true">
-                        {{ pickStatus.emoji }}
+                <mat-list class="draft-pick-list" role="list">
+                  @for (pick of season.picks; track pick.pickNumber; let pickIndex = $index) {
+                  <div class="draft-pick-item" role="listitem">
+                    <div class="draft-pick-row">
+                      <span class="draft-pick-tag">
+                        {{ 'draft.entryDrafts.selectionLabel' | translate }} {{ pickIndex + 1 }}
                       </span>
-                      <span class="sr-only">{{ pickStatus.tooltipKey | translate }}</span>
+                      <span class="draft-pick-tag">
+                        {{ 'draft.entryDrafts.roundLabel' | translate }} {{ pick.round }}
+                      </span>
+                      <span class="draft-pick-tag">
+                        {{ 'draft.entryDrafts.turnLabel' | translate }} {{ pick.pickNumber }}
+                      </span>
+                      <span class="draft-pick-player" [class.draft-pick-player--missing]="pick.draftedPlayer === null">
+                        <span>{{ pick.draftedPlayer ?? ('draft.entryDrafts.unknownPlayerLabel' | translate) }}</span>
+                        @if (getPickStatus(pick); as pickStatus) {
+                        <span class="draft-pick-status-badge" [matTooltip]="pickStatus.tooltipKey | translate"
+                          aria-hidden="true">
+                          {{ pickStatus.emoji }}
+                        </span>
+                        <span class="sr-only">{{ pickStatus.tooltipKey | translate }}</span>
+                        }
+                      </span>
+                      @if (isTradedPick(group.team, pick)) {
+                      <span class="draft-pick-origin">
+                        {{ 'draft.entryDrafts.originalOwnerLabel' | translate }}
+                        <span class="draft-pick-origin-team">{{ pick.originalOwner.name }}</span>
+                      </span>
                       }
-                    </span>
-                    @if (isTradedPick(group.team, pick)) {
-                    <span class="draft-pick-origin">
-                      {{ 'draft.entryDrafts.originalOwnerLabel' | translate }}
-                      <span class="draft-pick-origin-team">{{ pick.originalOwner.name }}</span>
-                    </span>
-                    }
+                    </div>
                   </div>
-                </div>
-                }
-              </mat-list>
-            </section>
+                  }
+                </mat-list>
+              </section>
+              }
+            </div>
             }
-          </div>
-          }
-        </section>
-      </div>
-    </mat-expansion-panel>
-    }
-  </mat-accordion>
+          </section>
+        </div>
+      </mat-expansion-panel>
+      }
+    </mat-accordion>
+  </div>
   }
 </section>

--- a/src/app/draft/entry-drafts/entry-drafts.component.spec.ts
+++ b/src/app/draft/entry-drafts/entry-drafts.component.spec.ts
@@ -133,27 +133,27 @@ describe('EntryDraftsComponent', () => {
     };
   }
 
-  function stubScrollIntoView() {
-    const original = HTMLElement.prototype.scrollIntoView;
-    const scrollIntoView = vi.fn();
+  function stubScrollTo() {
+    const original = HTMLElement.prototype.scrollTo;
+    const scrollTo = vi.fn();
 
-    Object.defineProperty(HTMLElement.prototype, 'scrollIntoView', {
+    Object.defineProperty(HTMLElement.prototype, 'scrollTo', {
       configurable: true,
-      value: scrollIntoView,
+      value: scrollTo,
     });
 
     return {
-      scrollIntoView,
+      scrollTo,
       restore: () => {
         if (original) {
-          Object.defineProperty(HTMLElement.prototype, 'scrollIntoView', {
+          Object.defineProperty(HTMLElement.prototype, 'scrollTo', {
             configurable: true,
             value: original,
           });
           return;
         }
 
-        delete (HTMLElement.prototype as Partial<typeof HTMLElement.prototype>).scrollIntoView;
+        delete (HTMLElement.prototype as Partial<typeof HTMLElement.prototype>).scrollTo;
       },
     };
   }
@@ -201,7 +201,7 @@ describe('EntryDraftsComponent', () => {
     expect(screen.getByRole('button', { name: 'Boston Bruins' })).toHaveAttribute('aria-expanded', 'false');
   });
 
-  it('does not scroll the auto-opened shared selected team header on initial render', async () => {
+  it('scrolls the auto-opened shared selected team header to the top of the draft list on initial render', async () => {
     localStorage.setItem('fantrax.settings', JSON.stringify({
       selectedTeamId: '12',
       startFromSeason: null,
@@ -210,14 +210,17 @@ describe('EntryDraftsComponent', () => {
       disableSelectedTeamHighlight: false,
     }));
 
-    const { scrollIntoView, restore } = stubScrollIntoView();
+    const { scrollTo, restore } = stubScrollTo();
 
     try {
       const { fixture } = await renderComponent();
       const header = await screen.findByRole('button', { name: 'Anaheim Ducks' });
 
       await waitForBehaviorAssertion(fixture, () => {
-        expect(scrollIntoView).not.toHaveBeenCalled();
+        expect(scrollTo).toHaveBeenCalledWith({
+          behavior: 'auto',
+          top: expect.any(Number),
+        });
         expect(header).toHaveAttribute('aria-expanded', 'true');
         expect(header).not.toHaveFocus();
       });
@@ -409,7 +412,7 @@ describe('EntryDraftsComponent', () => {
   });
 
   it('scrolls an expanded team header to the top without moving focus into content', async () => {
-    const { scrollIntoView, restore } = stubScrollIntoView();
+    const { scrollTo, restore } = stubScrollTo();
 
     try {
       const { fixture } = await renderComponent();
@@ -418,10 +421,9 @@ describe('EntryDraftsComponent', () => {
       fireEvent.click(header);
 
       await waitForBehaviorAssertion(fixture, () => {
-        expect(scrollIntoView).toHaveBeenCalledWith({
+        expect(scrollTo).toHaveBeenCalledWith({
           behavior: 'smooth',
-          block: 'start',
-          inline: 'nearest',
+          top: expect.any(Number),
         });
         expect(header).toHaveAttribute('aria-expanded', 'true');
       });

--- a/src/app/draft/entry-drafts/entry-drafts.component.ts
+++ b/src/app/draft/entry-drafts/entry-drafts.component.ts
@@ -4,6 +4,7 @@ import {
   ChangeDetectorRef,
   Component,
   DestroyRef,
+  ElementRef,
   OnInit,
   PLATFORM_ID,
   effect,
@@ -23,6 +24,7 @@ import {
   DraftPanelFocusTargetDirective,
   DraftPanelHeaderNavigationDirective,
 } from '../draft-panel-navigation.directive';
+import { scheduleDraftTeamHeaderAlignment } from '../draft-keyboard-navigation.utils';
 
 type DraftPickStatus = {
   readonly emoji: '🟢' | '🟡';
@@ -51,6 +53,7 @@ export class EntryDraftsComponent implements OnInit {
   private readonly apiService = inject(ApiService);
   private readonly changeDetectorRef = inject(ChangeDetectorRef);
   private readonly destroyRef = inject(DestroyRef);
+  private readonly elementRef = inject(ElementRef<HTMLElement>);
   private readonly footerVisibilityService = inject(FooterVisibilityService);
   private readonly platformId = inject(PLATFORM_ID);
   private readonly settingsService = inject(SettingsService);
@@ -64,6 +67,7 @@ export class EntryDraftsComponent implements OnInit {
   apiError = false;
   expandedTeamId: string | null = null;
   private footerVisibilityCycle = 0;
+  private lastAutoAlignedTeamId: string | null = null;
 
   constructor() {
     effect(() => {
@@ -73,6 +77,18 @@ export class EntryDraftsComponent implements OnInit {
         this.disableSelectedTeamHighlight(),
       );
       this.expandedTeamId = nextExpandedTeamId;
+
+      if (!isPlatformBrowser(this.platformId)) {
+        this.changeDetectorRef.markForCheck();
+        return;
+      }
+
+      if (!nextExpandedTeamId) {
+        this.lastAutoAlignedTeamId = null;
+      } else if (nextExpandedTeamId !== this.lastAutoAlignedTeamId) {
+        scheduleDraftTeamHeaderAlignment(this.elementRef.nativeElement, nextExpandedTeamId, 'auto');
+        this.lastAutoAlignedTeamId = nextExpandedTeamId;
+      }
 
       this.changeDetectorRef.markForCheck();
     });

--- a/src/app/draft/opening-draft/opening-draft.component.html
+++ b/src/app/draft/opening-draft/opening-draft.component.html
@@ -16,50 +16,52 @@
       {{ 'draft.noResults' | translate }}
     </p>
   } @else {
-    <mat-accordion class="draft-accordion" displayMode="flat">
-      @for (group of groups; track group.team.id) {
-        <mat-expansion-panel
-          class="draft-panel"
-          #panel
-          [attr.data-team-id]="group.team.id"
-          [expanded]="expandedTeamId === group.team.id"
-          (expandedChange)="onPanelExpandedChange(group.team.id, $event)"
-        >
-          <mat-expansion-panel-header class="draft-panel-header" draftPanelHeaderNavigation>
-            <mat-panel-title class="draft-panel-title">
-              {{ group.team.name }}
-            </mat-panel-title>
-          </mat-expansion-panel-header>
+    <div class="draft-accordion-scroll-window">
+      <mat-accordion class="draft-accordion" displayMode="flat">
+        @for (group of groups; track group.team.id) {
+          <mat-expansion-panel
+            class="draft-panel"
+            #panel
+            [attr.data-team-id]="group.team.id"
+            [expanded]="expandedTeamId === group.team.id"
+            (expandedChange)="onPanelExpandedChange(group.team.id, $event)"
+          >
+            <mat-expansion-panel-header class="draft-panel-header" draftPanelHeaderNavigation>
+              <mat-panel-title class="draft-panel-title">
+                {{ group.team.name }}
+              </mat-panel-title>
+            </mat-expansion-panel-header>
 
-          <div class="opening-draft-panel-content" [attr.aria-hidden]="panel.expanded ? null : 'true'"
-            [attr.inert]="panel.expanded ? null : ''">
-            <mat-list class="draft-pick-list" role="list">
-              @for (pick of group.picks; track pick.pickNumber; let pickIndex = $index) {
-                <div class="draft-pick-item draft-focus-target" role="listitem" tabindex="-1" draftPanelFocusTarget>
-                  <div class="draft-pick-row">
-                    <span class="draft-pick-tag">
-                      {{ 'draft.openingDraft.selectionLabel' | translate }} {{ pickIndex + 1 }}
-                    </span>
-                    <span class="draft-pick-tag">
-                      {{ 'draft.openingDraft.roundLabel' | translate }} {{ pick.round }}
-                    </span>
-                    <span class="draft-pick-tag">
-                      {{ 'draft.openingDraft.turnLabel' | translate }} {{ pick.pickNumber }}
-                    </span>
-                    <span class="draft-pick-player">{{ pick.draftedPlayer }}</span>
-                    @if (isTradedPick(group.team, pick)) {
-                      <span class="draft-pick-origin">
-                        {{ 'draft.openingDraft.originalOwnerLabel' | translate }}
-                        <span class="draft-pick-origin-team">{{ pick.originalOwner.name }}</span>
+            <div class="opening-draft-panel-content" [attr.aria-hidden]="panel.expanded ? null : 'true'"
+              [attr.inert]="panel.expanded ? null : ''">
+              <mat-list class="draft-pick-list" role="list">
+                @for (pick of group.picks; track pick.pickNumber; let pickIndex = $index) {
+                  <div class="draft-pick-item draft-focus-target" role="listitem" tabindex="-1" draftPanelFocusTarget>
+                    <div class="draft-pick-row">
+                      <span class="draft-pick-tag">
+                        {{ 'draft.openingDraft.selectionLabel' | translate }} {{ pickIndex + 1 }}
                       </span>
-                    }
+                      <span class="draft-pick-tag">
+                        {{ 'draft.openingDraft.roundLabel' | translate }} {{ pick.round }}
+                      </span>
+                      <span class="draft-pick-tag">
+                        {{ 'draft.openingDraft.turnLabel' | translate }} {{ pick.pickNumber }}
+                      </span>
+                      <span class="draft-pick-player">{{ pick.draftedPlayer }}</span>
+                      @if (isTradedPick(group.team, pick)) {
+                        <span class="draft-pick-origin">
+                          {{ 'draft.openingDraft.originalOwnerLabel' | translate }}
+                          <span class="draft-pick-origin-team">{{ pick.originalOwner.name }}</span>
+                        </span>
+                      }
+                    </div>
                   </div>
-                </div>
-              }
-            </mat-list>
-          </div>
-        </mat-expansion-panel>
-      }
-    </mat-accordion>
+                }
+              </mat-list>
+            </div>
+          </mat-expansion-panel>
+        }
+      </mat-accordion>
+    </div>
   }
 </section>

--- a/src/app/draft/opening-draft/opening-draft.component.spec.ts
+++ b/src/app/draft/opening-draft/opening-draft.component.spec.ts
@@ -34,27 +34,27 @@ describe('OpeningDraftComponent', () => {
     };
   }
 
-  function stubScrollIntoView() {
-    const original = HTMLElement.prototype.scrollIntoView;
-    const scrollIntoView = vi.fn();
+  function stubScrollTo() {
+    const original = HTMLElement.prototype.scrollTo;
+    const scrollTo = vi.fn();
 
-    Object.defineProperty(HTMLElement.prototype, 'scrollIntoView', {
+    Object.defineProperty(HTMLElement.prototype, 'scrollTo', {
       configurable: true,
-      value: scrollIntoView,
+      value: scrollTo,
     });
 
     return {
-      scrollIntoView,
+      scrollTo,
       restore: () => {
         if (original) {
-          Object.defineProperty(HTMLElement.prototype, 'scrollIntoView', {
+          Object.defineProperty(HTMLElement.prototype, 'scrollTo', {
             configurable: true,
             value: original,
           });
           return;
         }
 
-        delete (HTMLElement.prototype as Partial<typeof HTMLElement.prototype>).scrollIntoView;
+        delete (HTMLElement.prototype as Partial<typeof HTMLElement.prototype>).scrollTo;
       },
     };
   }
@@ -102,7 +102,7 @@ describe('OpeningDraftComponent', () => {
     expect(screen.getByRole('button', { name: 'Dallas Stars' })).toHaveAttribute('aria-expanded', 'false');
   });
 
-  it('does not scroll the auto-opened shared selected team header on initial render', async () => {
+  it('scrolls the auto-opened shared selected team header to the top of the draft list on initial render', async () => {
     localStorage.setItem('fantrax.settings', JSON.stringify({
       selectedTeamId: '1',
       startFromSeason: null,
@@ -111,14 +111,17 @@ describe('OpeningDraftComponent', () => {
       disableSelectedTeamHighlight: false,
     }));
 
-    const { scrollIntoView, restore } = stubScrollIntoView();
+    const { scrollTo, restore } = stubScrollTo();
 
     try {
       const { fixture } = await renderComponent();
       const header = await screen.findByRole('button', { name: 'Colorado Avalanche' });
 
       await waitForBehaviorAssertion(fixture, () => {
-        expect(scrollIntoView).not.toHaveBeenCalled();
+        expect(scrollTo).toHaveBeenCalledWith({
+          behavior: 'auto',
+          top: expect.any(Number),
+        });
         expect(header).toHaveAttribute('aria-expanded', 'true');
         expect(header).not.toHaveFocus();
       });
@@ -247,7 +250,7 @@ describe('OpeningDraftComponent', () => {
   it('scrolls an expanded opening-draft header to the top without moving focus into picks', async () => {
     seedCollapsedDrawerState();
 
-    const { scrollIntoView, restore } = stubScrollIntoView();
+    const { scrollTo, restore } = stubScrollTo();
 
     try {
       const { fixture } = await renderComponent();
@@ -256,10 +259,9 @@ describe('OpeningDraftComponent', () => {
       fireEvent.click(header);
 
       await waitForBehaviorAssertion(fixture, () => {
-        expect(scrollIntoView).toHaveBeenCalledWith({
+        expect(scrollTo).toHaveBeenCalledWith({
           behavior: 'smooth',
-          block: 'start',
-          inline: 'nearest',
+          top: expect.any(Number),
         });
         expect(header).toHaveAttribute('aria-expanded', 'true');
       });

--- a/src/app/draft/opening-draft/opening-draft.component.ts
+++ b/src/app/draft/opening-draft/opening-draft.component.ts
@@ -4,6 +4,7 @@ import {
   ChangeDetectorRef,
   Component,
   DestroyRef,
+  ElementRef,
   OnInit,
   PLATFORM_ID,
   effect,
@@ -22,6 +23,7 @@ import {
   DraftPanelFocusTargetDirective,
   DraftPanelHeaderNavigationDirective,
 } from '../draft-panel-navigation.directive';
+import { scheduleDraftTeamHeaderAlignment } from '../draft-keyboard-navigation.utils';
 
 @Component({
   selector: 'app-opening-draft',
@@ -34,6 +36,7 @@ export class OpeningDraftComponent implements OnInit {
   private readonly apiService = inject(ApiService);
   private readonly changeDetectorRef = inject(ChangeDetectorRef);
   private readonly destroyRef = inject(DestroyRef);
+  private readonly elementRef = inject(ElementRef<HTMLElement>);
   private readonly footerVisibilityService = inject(FooterVisibilityService);
   private readonly platformId = inject(PLATFORM_ID);
   private readonly settingsService = inject(SettingsService);
@@ -47,6 +50,7 @@ export class OpeningDraftComponent implements OnInit {
   apiError = false;
   expandedTeamId: string | null = null;
   private footerVisibilityCycle = 0;
+  private lastAutoAlignedTeamId: string | null = null;
 
   constructor() {
     effect(() => {
@@ -56,6 +60,18 @@ export class OpeningDraftComponent implements OnInit {
         this.disableSelectedTeamHighlight(),
       );
       this.expandedTeamId = nextExpandedTeamId;
+
+      if (!isPlatformBrowser(this.platformId)) {
+        this.changeDetectorRef.markForCheck();
+        return;
+      }
+
+      if (!nextExpandedTeamId) {
+        this.lastAutoAlignedTeamId = null;
+      } else if (nextExpandedTeamId !== this.lastAutoAlignedTeamId) {
+        scheduleDraftTeamHeaderAlignment(this.elementRef.nativeElement, nextExpandedTeamId, 'auto');
+        this.lastAutoAlignedTeamId = nextExpandedTeamId;
+      }
 
       this.changeDetectorRef.markForCheck();
     });

--- a/src/app/shared/help-dialog/help-dialog.component.html
+++ b/src/app/shared/help-dialog/help-dialog.component.html
@@ -45,5 +45,6 @@
   <button mat-button type="button" (click)="close()">
     {{ 'helpDialog.close' | translate }}
   </button>
+  <p class="copyright">{{ 'footer.copyright' | translate }}</p>
 </div>
 }

--- a/src/app/shared/help-dialog/help-dialog.component.scss
+++ b/src/app/shared/help-dialog/help-dialog.component.scss
@@ -80,3 +80,8 @@
   width: 16px;
   height: 16px;
 }
+
+.copyright {
+  margin-top: 0;
+  margin-bottom: 0;
+}

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -2,13 +2,14 @@
 @use '@fontsource/roboto/400' as *;
 @use '@fontsource/roboto/500' as *;
 @use './styles/draft-shared';
+
 @font-face {
   font-family: "Material Icons";
   font-style: normal;
   font-weight: 400;
   font-display: swap;
   src: url("/fonts/material-icons.woff2") format("woff2"),
-       url("/fonts/material-icons.woff") format("woff");
+    url("/fonts/material-icons.woff") format("woff");
 }
 
 .material-icons {
@@ -343,7 +344,7 @@ button[mat-icon-button]:focus-visible,
   gap: 12px;
 }
 
-.mat-mdc-slide-toggle .mat-internal-form-field > label {
+.mat-mdc-slide-toggle .mat-internal-form-field>label {
   margin: 0;
   padding: 0;
 }
@@ -460,7 +461,7 @@ mat-checkbox .mdc-label {
 }
 
 .content {
-  margin: 12px auto;
+  margin: 0 auto;
   max-width: var(--app-content-max-width);
 }
 
@@ -734,7 +735,7 @@ app-stats-table {
     overflow-x: auto;
     overflow-y: auto;
     width: 100%;
-    max-height: calc(100vh - 200px);
+    max-height: calc(100vh - 120px);
   }
 
   .mat-mdc-table {
@@ -813,6 +814,7 @@ app-stats-table {
 }
 
 app-virtual-table {
+
   .mat-mdc-form-field,
   .search-field {
     width: 100%;
@@ -889,7 +891,7 @@ app-virtual-table {
   }
 
   .virtual-viewport {
-    height: calc(100vh - 252px);
+    height: calc(100vh - 200px);
     width: 100%;
     background: var(--mat-sys-surface);
     scrollbar-gutter: stable;

--- a/src/styles/_draft-shared.scss
+++ b/src/styles/_draft-shared.scss
@@ -3,7 +3,7 @@
   --draft-pick-row-gap: 0.65rem;
   --draft-pick-list-padding: 0;
   --draft-expanded-pick-list-padding-top: 0;
-  padding-top: 1rem;
+  --draft-accordion-scroll-max-height: calc(var(--app-height) - 170px);
   --draft-sticky-top: env(safe-area-inset-top, 0px);
 }
 
@@ -13,27 +13,32 @@
   border: 1px solid var(--mat-sys-outline-variant);
   border-radius: 1rem;
   background:
-    linear-gradient(
-      180deg,
+    linear-gradient(180deg,
       color-mix(in srgb, var(--mat-sys-surface-container) 88%, transparent) 0%,
-      var(--mat-sys-surface) 100%
-    );
+      var(--mat-sys-surface) 100%);
   color: var(--mat-sys-on-surface);
   line-height: 1.6;
 }
 
 :where(.entry-drafts, .opening-draft) .draft-status--error {
   background:
-    linear-gradient(
-      180deg,
+    linear-gradient(180deg,
       color-mix(in srgb, var(--mat-sys-error-container) 46%, transparent) 0%,
-      var(--mat-sys-surface) 100%
-    );
+      var(--mat-sys-surface) 100%);
 }
 
 :where(.entry-drafts, .opening-draft) .draft-accordion {
   display: grid;
   gap: 0.1rem;
+}
+
+:where(.entry-drafts, .opening-draft) .draft-accordion-scroll-window {
+  max-height: var(--draft-accordion-scroll-max-height);
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  scrollbar-gutter: stable;
+  padding-bottom: calc(8px + var(--safe-bottom));
+  -webkit-overflow-scrolling: touch;
 }
 
 :where(.entry-drafts, .opening-draft) .draft-panel {
@@ -169,6 +174,7 @@
 @media (max-width: 640px) {
   :where(.entry-drafts, .opening-draft) {
     --draft-content-padding-inline: 1rem;
+    --draft-accordion-scroll-max-height: calc(var(--app-height) - 140px);
   }
 
   :where(.entry-drafts, .opening-draft) .draft-panel-title {


### PR DESCRIPTION
## Summary
- keep draft team navigation visible across screen sizes by using a bounded outer team-list scroll area
- align the auto-opened selected team to the top of the visible draft list on route entry
- simplify the bottom area by trimming the footer, moving copyright into the info/help surface, and polishing the lower layout

## Testing
- npm run verify