### PR TITLE
Fix: Restore sticky section jump navigation and add draft loading progress bars

### DIFF
--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -5,8 +5,15 @@
   --settings-drawer-panel-width: min(380px, 92vw);
   position: relative;
   width: 100%;
+  overflow: visible;
   background: var(--mat-sys-surface);
   color: var(--mat-sys-on-surface);
+
+  // Let browse-route sticky UI follow the page scroll instead of getting trapped
+  // inside the non-scrolling Material drawer wrappers.
+  ::ng-deep .mat-drawer-content {
+    overflow: visible;
+  }
 
   ::ng-deep .mat-drawer-backdrop.mat-drawer-shown {
     position: fixed;

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -374,6 +374,29 @@ describe('AppComponent — desktop frontpage', { timeout: 60_000 }, () => {
     expect(screen.getByText(/lastModified\.label/)).toBeInTheDocument();
   });
 
+  it('keeps the shell overflow visible so browse-route sticky navigation can follow page scroll', async () => {
+    const { container, fixture } = await render(
+      AppComponent,
+      getBehaviorTestConfig({ isMobile: false }),
+    );
+    const router = TestBed.inject(Router);
+
+    await router.navigateByUrl('/career/highlights');
+    await waitForBehaviorAssertion(fixture, () => {
+      expect(
+        screen.getByRole('navigation', { name: 'career.highlights.jumpNavAriaLabel' }),
+      ).toBeInTheDocument();
+    });
+
+    const shell = container.querySelector('mat-sidenav-container');
+    const shellContent = container.querySelector('mat-sidenav-content');
+
+    expect(shell).not.toBeNull();
+    expect(shellContent).not.toBeNull();
+    expect(getComputedStyle(shell as Element).overflow).toBe('visible');
+    expect(getComputedStyle(shellContent as Element).overflow).toBe('visible');
+  });
+
   it.each([
     '/draft/statistics',
     '/leaderboards/regular',

--- a/src/app/draft/entry-drafts/entry-drafts.component.html
+++ b/src/app/draft/entry-drafts/entry-drafts.component.html
@@ -4,9 +4,10 @@
   </h3>
 
   @if (loading) {
-  <p class="draft-status" role="status" aria-live="polite" tabindex="-1" data-skip-focus="true">
-    {{ 'draft.loading' | translate }}
-  </p>
+  <div class="draft-status draft-status--loading" role="status" aria-live="polite" tabindex="-1" data-skip-focus="true">
+    <span>{{ 'draft.loading' | translate }}</span>
+    <mat-progress-bar class="loading-bar" mode="buffer" [value]="5" [bufferValue]="25" />
+  </div>
   } @else if (apiError) {
   <p class="draft-status draft-status--error" role="alert" tabindex="-1" data-skip-focus="true">
     {{ 'draft.apiUnavailable' | translate }}

--- a/src/app/draft/entry-drafts/entry-drafts.component.spec.ts
+++ b/src/app/draft/entry-drafts/entry-drafts.component.spec.ts
@@ -462,6 +462,7 @@ describe('EntryDraftsComponent', () => {
     });
 
     expect(screen.getByText('draft.loading')).toBeInTheDocument();
+    expect(screen.getByRole('progressbar')).toBeInTheDocument();
     expect(footerVisibilityService.markReady).not.toHaveBeenCalled();
 
     response$.next(entryDraftGroupsFixture);
@@ -477,6 +478,7 @@ describe('EntryDraftsComponent', () => {
         entryDraftGroupsFixture[1],
       ]);
       expect(screen.getByText('Anaheim Ducks')).toBeInTheDocument();
+      expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
     });
     expect(footerVisibilityService.markReady).toHaveBeenCalledWith(7);
   });
@@ -537,6 +539,7 @@ describe('EntryDraftsComponent', () => {
     });
 
     expect(screen.getByText('draft.loading')).toBeInTheDocument();
+    expect(screen.getByRole('progressbar')).toBeInTheDocument();
     expect(screen.queryByText('draft.apiUnavailable')).not.toBeInTheDocument();
     expect(fixture.componentInstance.loading).toBe(true);
     expect(fixture.componentInstance.apiError).toBe(false);

--- a/src/app/draft/entry-drafts/entry-drafts.component.ts
+++ b/src/app/draft/entry-drafts/entry-drafts.component.ts
@@ -14,6 +14,7 @@ import {
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { MatExpansionModule } from '@angular/material/expansion';
 import { MatListModule } from '@angular/material/list';
+import { MatProgressBarModule } from '@angular/material/progress-bar';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { TranslateModule } from '@ngx-translate/core';
 
@@ -41,6 +42,7 @@ type DraftPickStatus = {
     PercentPipe,
     MatExpansionModule,
     MatListModule,
+    MatProgressBarModule,
     MatTooltipModule,
     TranslateModule,
     DraftPanelHeaderNavigationDirective,

--- a/src/app/draft/opening-draft/opening-draft.component.html
+++ b/src/app/draft/opening-draft/opening-draft.component.html
@@ -4,9 +4,10 @@
   </h3>
 
   @if (loading) {
-    <p class="draft-status" role="status" aria-live="polite" tabindex="-1" data-skip-focus="true">
-      {{ 'draft.loading' | translate }}
-    </p>
+    <div class="draft-status draft-status--loading" role="status" aria-live="polite" tabindex="-1" data-skip-focus="true">
+      <span>{{ 'draft.loading' | translate }}</span>
+      <mat-progress-bar class="loading-bar" mode="buffer" [value]="5" [bufferValue]="25" />
+    </div>
   } @else if (apiError) {
     <p class="draft-status draft-status--error" role="alert" tabindex="-1" data-skip-focus="true">
       {{ 'draft.apiUnavailable' | translate }}

--- a/src/app/draft/opening-draft/opening-draft.component.spec.ts
+++ b/src/app/draft/opening-draft/opening-draft.component.spec.ts
@@ -302,6 +302,7 @@ describe('OpeningDraftComponent', () => {
     });
 
     expect(screen.getByText('draft.loading')).toBeInTheDocument();
+    expect(screen.getByRole('progressbar')).toBeInTheDocument();
     expect(footerVisibilityService.markReady).not.toHaveBeenCalled();
 
     response$.next(openingDraftsFixture);
@@ -311,6 +312,7 @@ describe('OpeningDraftComponent', () => {
       expect(fixture.componentInstance.loading).toBe(false);
       expect(fixture.componentInstance.groups).toEqual(openingDraftsFixture);
       expect(screen.getByText('Colorado Avalanche')).toBeInTheDocument();
+      expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
     });
     expect(footerVisibilityService.markReady).toHaveBeenCalledWith(7);
   });
@@ -373,6 +375,7 @@ describe('OpeningDraftComponent', () => {
     });
 
     expect(screen.getByText('draft.loading')).toBeInTheDocument();
+    expect(screen.getByRole('progressbar')).toBeInTheDocument();
     expect(screen.queryByText('draft.apiUnavailable')).not.toBeInTheDocument();
     expect(fixture.componentInstance.loading).toBe(true);
     expect(fixture.componentInstance.apiError).toBe(false);

--- a/src/app/draft/opening-draft/opening-draft.component.ts
+++ b/src/app/draft/opening-draft/opening-draft.component.ts
@@ -14,6 +14,7 @@ import {
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { MatExpansionModule } from '@angular/material/expansion';
 import { MatListModule } from '@angular/material/list';
+import { MatProgressBarModule } from '@angular/material/progress-bar';
 import { TranslateModule } from '@ngx-translate/core';
 
 import { ApiService, DraftTeamRef, OpeningDraftPick, OpeningDraftTeamGroup } from '@services/api.service';
@@ -28,7 +29,14 @@ import { scheduleDraftTeamHeaderAlignment } from '../draft-keyboard-navigation.u
 @Component({
   selector: 'app-opening-draft',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [MatExpansionModule, MatListModule, TranslateModule, DraftPanelHeaderNavigationDirective, DraftPanelFocusTargetDirective],
+  imports: [
+    MatExpansionModule,
+    MatListModule,
+    MatProgressBarModule,
+    TranslateModule,
+    DraftPanelHeaderNavigationDirective,
+    DraftPanelFocusTargetDirective,
+  ],
   templateUrl: './opening-draft.component.html',
   styleUrl: './opening-draft.component.scss',
 })

--- a/src/styles/_draft-shared.scss
+++ b/src/styles/_draft-shared.scss
@@ -27,6 +27,17 @@
       var(--mat-sys-surface) 100%);
 }
 
+:where(.entry-drafts, .opening-draft) .draft-status--loading {
+  display: grid;
+  gap: 0.75rem;
+  border: 0;
+  border-radius: 0;
+}
+
+:where(.entry-drafts, .opening-draft) .loading-bar {
+  width: 100%;
+}
+
 :where(.entry-drafts, .opening-draft) .draft-accordion {
   display: grid;
   gap: 0.1rem;


### PR DESCRIPTION
## Summary
- restore sticky `section-jump-nav` behavior on browse routes by fixing the shared settings-drawer shell overflow
- add `mat-progress-bar` loading states to entry draft and opening draft pages for consistency with the rest of the app
- keep draft statistics unchanged while aligning shared draft loading styling
- add regression coverage for both the sticky shell behavior and the draft loading progress bars

## Testing
- npm run verify

## Notes
- `section-jump-nav` now stays pinned again on browse routes like `/career/highlights` and `/draft/statistics`
- entry draft and opening draft now show a Material progress bar during loading
- existing build budget warnings remain, but verification passes
