### PR TITLE
Feature: Add finals leaderboard view

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ The docs in this repo intentionally focus on project-specific architecture, work
 	- Expand team rows to see season-by-season breakdowns
 	- Ties, trophies, and transaction summaries are presented clearly in the standings
 	- The shared selected team receives keyboard focus by default unless selected-team highlighting is disabled from the settings drawer
+	- Finals view presents season-by-season championship matchups as expandable cards with category and totals breakdowns
 - 📚 **Career Listings**: Browse all-time player and goalie career tables plus career highlights
 	- Search and sort the main career tables
 	- Long lists stay responsive
@@ -186,7 +187,7 @@ E2E tests are organized into feature-based specs under `e2e/specs/`:
 - `smoke.spec.ts` — Core page rendering and navigation
 - `career.spec.ts` — Career players/goalies/highlights tabs, grouped highlight section navigation, paging, and route shell behavior
 - `draft.spec.ts` — Draft route redirect/tab behavior plus entry-draft and opening-draft accordion rendering
-- `leaderboards.spec.ts` — Leaderboards redirect, regular/playoff/transactions tabs, tie-rank vs incremental position logic, and expandable season details
+- `leaderboards.spec.ts` — Leaderboards redirect, regular/playoff/transactions/finals tabs, tie-rank vs incremental position logic, expandable season details, and finals matchup cards
 - `player-card.spec.ts` — Player card dialog (open/close, tabs, graphs, direct URLs)
 - `team-switching.spec.ts` — Team selector and filter reset behavior
 - `filters.spec.ts` — Report type, season, position, stats-per-game, and min games filters

--- a/docs/project-overview.md
+++ b/docs/project-overview.md
@@ -80,7 +80,8 @@ Accessibility is a core requirement: the UI is designed to remain usable via key
    - All-time regular season ranking table: position, wins, points, win percentage, regular season titles
    - All-time playoffs ranking table: position, championships, finals, conference finals, round results, appearances
    - All-time transactions ranking table: position, team, trades, claims, drops, rostered skaters, rostered goalies
-   - Tab navigation between Runkosarja, Playoffs, and Siirrot views (default route: Runkosarja)
+   - Finals view shows one championship matchup per season as an expandable browse card with winner context, actual-vs-deserved win-rate comparison, category results, and team totals
+   - Tab navigation between Runkosarja, Playoffs, Siirrot, and Finaalit views (default route: Runkosarja)
    - Column sorting via `mat-sort`; regular/playoff position ties stay blank after the first tied team, while transactions always show incremental positions
    - Expandable season breakdown rows per team (regular, playoffs, and transactions) by clicking a team row, with multiple expanded rows allowed
    - Season breakdown rows can show trophy markers for winner/championship seasons or emoji-prefixed transaction and roster counts per season
@@ -166,6 +167,7 @@ Accessibility is a core requirement: the UI is designed to remain usable via key
      - `/leaderboards/regular` - Regular season all-time ranking table
      - `/leaderboards/playoffs` - Playoffs all-time ranking table
      - `/leaderboards/transactions` - Transaction leaderboard with roster counts, trades, claims, and drops
+     - `/leaderboards/finals` - Season-by-season finals matchup cards with category and totals breakdowns
 
 ## Data Flow
 

--- a/docs/project-testing.md
+++ b/docs/project-testing.md
@@ -297,7 +297,7 @@ E2E tests are organized into feature-based spec files under `e2e/specs/`:
   - Server-paged highlight card behavior
   - Route-specific shell behavior (no stats controls/drawer)
 
-- **leaderboards.spec.ts** - Leaderboard routes and expandable team breakdowns
+- **leaderboards.spec.ts** - Leaderboard routes, expandable team breakdowns, and finals matchup cards
   - Redirect from `/leaderboards` to the default regular-season tab
   - Regular/playoff/transactions tab switching
   - Tie-rank handling for regular/playoffs and incremental ranks for transactions

--- a/public/i18n/fi.json
+++ b/public/i18n/fi.json
@@ -238,7 +238,8 @@
     "tabs": {
       "regular": "Runkosarja",
       "playoffs": "Playoffs",
-      "transactions": "Siirrot"
+      "transactions": "Siirrot",
+      "finals": "Finaalit"
     },
     "columns": {
       "position": "#",
@@ -273,6 +274,29 @@
       "playoffResult": "Tulos",
       "transactions": "Siirrot",
       "trophy": "🏆"
+    },
+    "finals": {
+      "noResults": "Finaalitietoja ei löytynyt.",
+      "selectedTeamBadge": "Valittu joukkue mukana",
+      "summaryTitle": "Yhteenveto",
+      "ratesTitle": "Voittomarginaali",
+      "categoriesTitle": "Kategoriayhteenveto",
+      "skaterTotalsTitle": "Kenttäpelaajat",
+      "goalieTotalsTitle": "Maalivahdit",
+      "summary": {
+        "winner": "Voittaja",
+        "loser": "Häviäjä",
+        "categoryRecord": "Kategoriat",
+        "recordTooltip": "Voitot-Häviöt-Tasapelit",
+        "recordAria": "{{value}}. Voitot-Häviöt-Tasapelit.",
+        "playedGames": "Finaalissa pelatut ottelut",
+        "playedGamesAria": "Finaalissa pelatut ottelut: yhteensä {{total}}, kenttäpelaajat {{skaters}}, maalivahdit {{goalies}}."
+      },
+      "rates": {
+        "actual": "Toteutunut osuus",
+        "deserved": "Laskennallinen osuus",
+        "deltaTooltip": "Laskennallinen osuus yrittää kuvata sitä kuinka tiukka finaali on todellisuudessa ollut.\n\nEron ollessa positiivinen kertoo se siitä, että voittaja olisi ansainnut suuremmankin voiton.\n\nEron ollessa negatiivinen, ottelu oli tasaisempi miltä lopullinen tulos näyttää.\n\nLaskennallisen osuuden ollessa alle 50%, voitto on ansaittu osittain tuurilla."
+      }
     },
     "noSeasonBreakdown": "Ei kausierittelyä saatavilla",
     "loading": "Ladataan taulukkoa...",

--- a/src/app/app.routes.server.ts
+++ b/src/app/app.routes.server.ts
@@ -62,6 +62,10 @@ export const serverRoutes: ServerRoute[] = [
     renderMode: RenderMode.Prerender,
   },
   {
+    path: 'leaderboards/finals',
+    renderMode: RenderMode.Prerender,
+  },
+  {
     path: 'player/:teamSlug/:playerSlug/:season',
     renderMode: RenderMode.Client,
   },

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -75,6 +75,18 @@ export const routes: Routes = [
             (m) => m.LeaderboardTransactionsComponent
           ),
       },
+      {
+        path: 'finals',
+        data: {
+          seo: {
+            tabKey: 'leaderboards.tabs.finals',
+          } satisfies RouteSeoData,
+        },
+        loadComponent: () =>
+          import('./leaderboards/finals/leaderboard-finals.component').then(
+            (m) => m.LeaderboardFinalsComponent
+          ),
+      },
     ],
   },
   {

--- a/src/app/leaderboards/finals/leaderboard-finals.component.html
+++ b/src/app/leaderboards/finals/leaderboard-finals.component.html
@@ -1,0 +1,268 @@
+<section class="leaderboard-finals" id="leaderboard-table" aria-labelledby="leaderboard-finals-heading">
+  <h3 id="leaderboard-finals-heading" class="sr-only" tabindex="-1" data-skip-focus="true">
+    {{ 'leaderboards.tabs.finals' | translate }}
+  </h3>
+
+  @if (loading) {
+    <div class="leaderboard-finals-status leaderboard-finals-status--loading" role="status" aria-live="polite"
+      tabindex="-1" data-skip-focus="true">
+      <span>{{ 'leaderboards.loading' | translate }}</span>
+      <mat-progress-bar class="loading-bar" mode="buffer" [value]="5" [bufferValue]="25" />
+    </div>
+  } @else if (apiError) {
+    <p class="leaderboard-finals-status leaderboard-finals-status--error" role="alert" tabindex="-1"
+      data-skip-focus="true">
+      {{ 'leaderboards.apiUnavailable' | translate }}
+    </p>
+  } @else if (finals().length === 0) {
+    <p class="leaderboard-finals-status" role="status" tabindex="-1" data-skip-focus="true">
+      {{ 'leaderboards.finals.noResults' | translate }}
+    </p>
+  } @else {
+    <mat-accordion class="leaderboard-finals-accordion" displayMode="flat" multi>
+      @for (entry of finals(); track entry.season) {
+        <mat-expansion-panel class="draft-panel leaderboard-finals-panel" #panel>
+          <mat-expansion-panel-header class="draft-panel-header leaderboard-finals-header" draftPanelHeaderNavigation>
+            <div class="leaderboard-finals-matchup-line">
+              <span class="leaderboard-finals-season">
+                {{ entry.season }}-{{ (entry.season + 1).toString().slice(-2) }}
+              </span>
+
+              <span class="leaderboard-finals-divider" aria-hidden="true">•</span>
+
+              <div class="leaderboard-finals-matchup-core">
+                <span class="leaderboard-finals-team-name"
+                  [class.leaderboard-finals-team-name--winner]="isWinner(entry, entry.homeTeam.teamId)">
+                  {{ entry.homeTeam.teamName }}
+                </span>
+
+                <span class="leaderboard-finals-score">
+                  {{ formatScore(entry.homeTeam) }} - {{ formatScore(entry.awayTeam) }}
+                </span>
+
+                <span class="leaderboard-finals-team-name"
+                  [class.leaderboard-finals-team-name--winner]="isWinner(entry, entry.awayTeam.teamId)">
+                  {{ entry.awayTeam.teamName }}
+                </span>
+              </div>
+
+              @if (hasSelectedFinalist(entry)) {
+                <span class="leaderboard-finals-selected-badge">
+                  {{ 'leaderboards.finals.selectedTeamBadge' | translate }}
+                </span>
+              }
+            </div>
+          </mat-expansion-panel-header>
+
+          <div class="leaderboard-finals-content" [attr.aria-hidden]="panel.expanded ? null : 'true'"
+            [attr.inert]="panel.expanded ? null : ''">
+            <section class="leaderboard-finals-section">
+              <h4 class="leaderboard-finals-section-title">
+                {{ 'leaderboards.finals.summaryTitle' | translate }}
+              </h4>
+
+              <div class="leaderboard-finals-summary-grid">
+                <article class="leaderboard-finals-summary-card draft-focus-target" tabindex="-1" draftPanelFocusTarget>
+                  <span class="leaderboard-finals-summary-label">
+                    {{ 'leaderboards.finals.summary.winner' | translate }}
+                  </span>
+                  <span class="leaderboard-finals-summary-value">
+                    <span class="leaderboard-finals-summary-trophy" aria-hidden="true">🏆</span>
+                    {{ getWinnerTeam(entry).teamName }}
+                  </span>
+
+                  <div class="leaderboard-finals-summary-meta">
+                    <span class="leaderboard-finals-summary-meta-label leaderboard-finals-summary-meta-label--with-icon">
+                      <span>{{ 'leaderboards.finals.summary.categoryRecord' | translate }}</span>
+                      <button type="button" class="leaderboard-finals-inline-help"
+                        [matTooltip]="'leaderboards.finals.summary.recordTooltip' | translate"
+                        [attr.aria-label]="'leaderboards.finals.summary.recordTooltip' | translate">
+                        <mat-icon fontIcon="info" />
+                      </button>
+                    </span>
+                    <span class="leaderboard-finals-summary-meta-value"
+                      [attr.aria-label]="'leaderboards.finals.summary.recordAria' | translate : { value: formatCategoryRecord(getWinnerTeam(entry)) }">
+                      {{ formatCategoryRecord(getWinnerTeam(entry)) }}
+                    </span>
+                  </div>
+
+                  <div class="leaderboard-finals-summary-meta">
+                    <span class="leaderboard-finals-summary-meta-label">
+                      {{ 'leaderboards.finals.summary.playedGames' | translate }}
+                    </span>
+                    <span class="leaderboard-finals-summary-games"
+                      [attr.aria-label]="'leaderboards.finals.summary.playedGamesAria' | translate : { total: getWinnerTeam(entry).playedGames.total, skaters: getWinnerTeam(entry).playedGames.skaters, goalies: getWinnerTeam(entry).playedGames.goalies }"
+                      [attr.title]="'leaderboards.finals.summary.playedGamesAria' | translate : { total: getWinnerTeam(entry).playedGames.total, skaters: getWinnerTeam(entry).playedGames.skaters, goalies: getWinnerTeam(entry).playedGames.goalies }">
+                      <span class="leaderboard-finals-summary-game-part">
+                        <span aria-hidden="true">👥</span>
+                        <span>{{ getWinnerTeam(entry).playedGames.total }}</span>
+                      </span>
+                      <span class="leaderboard-finals-divider" aria-hidden="true">•</span>
+                      <span class="leaderboard-finals-summary-game-part">
+                        <span aria-hidden="true">🏒</span>
+                        <span>{{ getWinnerTeam(entry).playedGames.skaters }}</span>
+                      </span>
+                      <span class="leaderboard-finals-divider" aria-hidden="true">•</span>
+                      <span class="leaderboard-finals-summary-game-part">
+                        <span aria-hidden="true">🥅</span>
+                        <span>{{ getWinnerTeam(entry).playedGames.goalies }}</span>
+                      </span>
+                    </span>
+                  </div>
+                </article>
+
+                <article class="leaderboard-finals-summary-card draft-focus-target" tabindex="-1" draftPanelFocusTarget>
+                  <span class="leaderboard-finals-summary-label">
+                    {{ 'leaderboards.finals.summary.loser' | translate }}
+                  </span>
+                  <span class="leaderboard-finals-summary-value">
+                    {{ getLoserTeam(entry).teamName }}
+                  </span>
+
+                  <div class="leaderboard-finals-summary-meta">
+                    <span class="leaderboard-finals-summary-meta-label leaderboard-finals-summary-meta-label--with-icon">
+                      <span>{{ 'leaderboards.finals.summary.categoryRecord' | translate }}</span>
+                      <button type="button" class="leaderboard-finals-inline-help"
+                        [matTooltip]="'leaderboards.finals.summary.recordTooltip' | translate"
+                        [attr.aria-label]="'leaderboards.finals.summary.recordTooltip' | translate">
+                        <mat-icon fontIcon="info" />
+                      </button>
+                    </span>
+                    <span class="leaderboard-finals-summary-meta-value"
+                      [attr.aria-label]="'leaderboards.finals.summary.recordAria' | translate : { value: formatCategoryRecord(getLoserTeam(entry)) }">
+                      {{ formatCategoryRecord(getLoserTeam(entry)) }}
+                    </span>
+                  </div>
+
+                  <div class="leaderboard-finals-summary-meta">
+                    <span class="leaderboard-finals-summary-meta-label">
+                      {{ 'leaderboards.finals.summary.playedGames' | translate }}
+                    </span>
+                    <span class="leaderboard-finals-summary-games"
+                      [attr.aria-label]="'leaderboards.finals.summary.playedGamesAria' | translate : { total: getLoserTeam(entry).playedGames.total, skaters: getLoserTeam(entry).playedGames.skaters, goalies: getLoserTeam(entry).playedGames.goalies }"
+                      [attr.title]="'leaderboards.finals.summary.playedGamesAria' | translate : { total: getLoserTeam(entry).playedGames.total, skaters: getLoserTeam(entry).playedGames.skaters, goalies: getLoserTeam(entry).playedGames.goalies }">
+                      <span class="leaderboard-finals-summary-game-part">
+                        <span aria-hidden="true">👥</span>
+                        <span>{{ getLoserTeam(entry).playedGames.total }}</span>
+                      </span>
+                      <span class="leaderboard-finals-divider" aria-hidden="true">•</span>
+                      <span class="leaderboard-finals-summary-game-part">
+                        <span aria-hidden="true">🏒</span>
+                        <span>{{ getLoserTeam(entry).playedGames.skaters }}</span>
+                      </span>
+                      <span class="leaderboard-finals-divider" aria-hidden="true">•</span>
+                      <span class="leaderboard-finals-summary-game-part">
+                        <span aria-hidden="true">🥅</span>
+                        <span>{{ getLoserTeam(entry).playedGames.goalies }}</span>
+                      </span>
+                    </span>
+                  </div>
+                </article>
+              </div>
+            </section>
+
+            <section class="leaderboard-finals-section">
+              <h4 class="leaderboard-finals-section-title">
+                {{ 'leaderboards.finals.ratesTitle' | translate }}
+              </h4>
+
+              <div class="leaderboard-finals-rates-grid">
+                <article class="leaderboard-finals-rate-card draft-focus-target" tabindex="-1" draftPanelFocusTarget>
+                  <span class="leaderboard-finals-summary-label">
+                    {{ 'leaderboards.finals.rates.actual' | translate }}
+                  </span>
+                  <strong class="leaderboard-finals-rate-value">
+                    {{ formatPercent(entry.rates.winRate) }}
+                  </strong>
+                </article>
+
+                <article class="leaderboard-finals-rate-card draft-focus-target" tabindex="-1" draftPanelFocusTarget>
+                  <span class="leaderboard-finals-summary-label leaderboard-finals-summary-label--with-icon">
+                    <span>{{ 'leaderboards.finals.rates.deserved' | translate }}</span>
+                    <button type="button" class="leaderboard-finals-inline-help"
+                      [matTooltip]="'leaderboards.finals.rates.deltaTooltip' | translate"
+                      matTooltipClass="table-card-tooltip"
+                      [attr.aria-label]="'leaderboards.finals.rates.deltaTooltip' | translate">
+                      <mat-icon fontIcon="info" />
+                    </button>
+                  </span>
+                  <strong class="leaderboard-finals-rate-value">
+                    {{ formatPercent(entry.rates.deservedToWinRate) }}
+                    <span class="leaderboard-finals-rate-delta-inline">
+                      ({{ formatRateDeltaCompact(entry) }})
+                    </span>
+                  </strong>
+                </article>
+              </div>
+            </section>
+
+            <section class="leaderboard-finals-section">
+              <h4 class="leaderboard-finals-section-title">
+                {{ 'leaderboards.finals.categoriesTitle' | translate }}
+              </h4>
+
+              <div class="leaderboard-finals-comparison-card">
+                <div class="leaderboard-finals-comparison-header" aria-hidden="true">
+                  <span class="leaderboard-finals-comparison-heading leaderboard-finals-comparison-heading--home">
+                    {{ entry.homeTeam.teamName }}
+                  </span>
+                  <span class="leaderboard-finals-comparison-heading leaderboard-finals-comparison-heading--away">
+                    {{ entry.awayTeam.teamName }}
+                  </span>
+                </div>
+
+                <div class="leaderboard-finals-comparison-group">
+                  <h5 class="leaderboard-finals-subsection-title">
+                    {{ 'leaderboards.finals.skaterTotalsTitle' | translate }}
+                  </h5>
+
+                  @for (category of getSkaterCategories(entry); track category.statKey) {
+                    <div class="leaderboard-finals-comparison-row draft-focus-target" tabindex="-1" draftPanelFocusTarget>
+                      <span
+                        class="leaderboard-finals-comparison-value leaderboard-finals-comparison-value--home"
+                        [class.leaderboard-finals-comparison-value--winner]="categoryWonBy(category, entry.homeTeam.teamId)">
+                        {{ getCategoryValue(category, 'home') }}
+                      </span>
+                      <span class="leaderboard-finals-comparison-label">
+                        {{ ('tableColumn.' + category.statKey) | translate }}
+                      </span>
+                      <span
+                        class="leaderboard-finals-comparison-value leaderboard-finals-comparison-value--away"
+                        [class.leaderboard-finals-comparison-value--winner]="categoryWonBy(category, entry.awayTeam.teamId)">
+                        {{ getCategoryValue(category, 'away') }}
+                      </span>
+                    </div>
+                  }
+                </div>
+
+                <div class="leaderboard-finals-comparison-group">
+                  <h5 class="leaderboard-finals-subsection-title">
+                    {{ 'leaderboards.finals.goalieTotalsTitle' | translate }}
+                  </h5>
+
+                  @for (category of getGoalieCategories(entry); track category.statKey) {
+                    <div class="leaderboard-finals-comparison-row draft-focus-target" tabindex="-1" draftPanelFocusTarget>
+                      <span
+                        class="leaderboard-finals-comparison-value leaderboard-finals-comparison-value--home"
+                        [class.leaderboard-finals-comparison-value--winner]="categoryWonBy(category, entry.homeTeam.teamId)">
+                        {{ getCategoryValue(category, 'home') }}
+                      </span>
+                      <span class="leaderboard-finals-comparison-label">
+                        {{ ('tableColumn.' + category.statKey) | translate }}
+                      </span>
+                      <span
+                        class="leaderboard-finals-comparison-value leaderboard-finals-comparison-value--away"
+                        [class.leaderboard-finals-comparison-value--winner]="categoryWonBy(category, entry.awayTeam.teamId)">
+                        {{ getCategoryValue(category, 'away') }}
+                      </span>
+                    </div>
+                  }
+                </div>
+              </div>
+            </section>
+          </div>
+        </mat-expansion-panel>
+      }
+    </mat-accordion>
+  }
+</section>

--- a/src/app/leaderboards/finals/leaderboard-finals.component.scss
+++ b/src/app/leaderboards/finals/leaderboard-finals.component.scss
@@ -1,0 +1,413 @@
+.leaderboard-finals {
+  --finals-content-padding-inline: 1.25rem;
+}
+
+.leaderboard-finals-accordion {
+  display: grid;
+  gap: 0.1rem;
+}
+
+.leaderboard-finals-panel {
+  --mat-expansion-container-background-color: var(--mat-sys-surface-container-low);
+  --mat-expansion-header-text-color: var(--mat-sys-on-surface);
+  --mat-expansion-header-indicator-color: var(--mat-sys-on-surface-variant);
+  --mat-expansion-header-hover-state-layer-color:
+    color-mix(in srgb, var(--mat-sys-primary) 6%, var(--mat-sys-surface-container-low));
+  --mat-expansion-header-focus-state-layer-color:
+    color-mix(in srgb, var(--mat-sys-primary) 10%, var(--mat-sys-surface-container-low));
+  border: 1px solid var(--mat-sys-outline-variant);
+  border-radius: 1rem;
+  background: var(--mat-expansion-container-background-color);
+  box-shadow: var(--mat-sys-level1);
+  overflow: hidden;
+}
+
+.leaderboard-finals-header {
+  padding-inline: var(--finals-content-padding-inline);
+  height: auto;
+  min-height: 56px;
+  padding-block: 0.3rem;
+}
+
+.leaderboard-finals-matchup-line {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+  align-items: center;
+  width: 100%;
+  padding-inline-end: 0.85rem;
+  color: var(--mat-sys-on-surface);
+}
+
+.leaderboard-finals-season {
+  color: var(--mat-sys-on-surface-variant);
+  font-size: 0.82rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.leaderboard-finals-divider {
+  color: var(--mat-sys-on-surface-variant);
+}
+
+.leaderboard-finals-matchup-core {
+  display: flex;
+  flex: 1 1 auto;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+  align-items: center;
+  min-width: 0;
+}
+
+.leaderboard-finals-team-name {
+  font-size: 1rem;
+  font-weight: 600;
+  line-height: 1.35;
+}
+
+.leaderboard-finals-team-name--winner {
+  color: var(--mat-sys-primary);
+}
+
+.leaderboard-finals-score {
+  font-size: 1.02rem;
+  font-weight: 800;
+  white-space: nowrap;
+}
+
+.leaderboard-finals-selected-badge {
+  display: inline-flex;
+  align-items: center;
+  margin-inline-start: auto;
+  margin-inline-end: 0.85rem;
+  padding: 0.16rem 0.55rem;
+  border-radius: 999px;
+  background: var(--mat-sys-surface-container-high);
+  color: var(--mat-sys-on-surface-variant);
+  font-size: 0.76rem;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.leaderboard-finals-content {
+  display: grid;
+  gap: 1rem;
+  padding: 0 1.25rem 1.1rem;
+}
+
+.leaderboard-finals-panel.mat-expanded .leaderboard-finals-content {
+  padding-top: 0.9rem;
+}
+
+.leaderboard-finals-section {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.leaderboard-finals-section-title {
+  margin: 0;
+  color: var(--mat-sys-on-surface);
+  font-size: 0.98rem;
+  font-weight: 700;
+}
+
+.leaderboard-finals-subsection-title {
+  margin: 0 0 0.15rem;
+  color: var(--mat-sys-on-surface-variant);
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-align: center;
+  text-transform: uppercase;
+}
+
+.leaderboard-finals-summary-grid,
+.leaderboard-finals-rates-grid {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.leaderboard-finals-summary-grid {
+  grid-template-columns: repeat(auto-fit, minmax(175px, 1fr));
+}
+
+.leaderboard-finals-rates-grid {
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.leaderboard-finals-summary-card,
+.leaderboard-finals-rate-card {
+  border: 1px solid var(--mat-sys-outline-variant);
+  border-radius: 1rem;
+  padding: 0.95rem 1rem;
+  background: var(--mat-sys-surface-container-lowest);
+}
+
+.leaderboard-finals-summary-card,
+.leaderboard-finals-rate-card {
+  display: grid;
+  gap: 0.3rem;
+}
+
+.leaderboard-finals-summary-label {
+  color: var(--mat-sys-on-surface-variant);
+  font-size: 0.74rem;
+  font-weight: 600;
+  line-height: 1.35;
+}
+
+.leaderboard-finals-summary-label--with-icon {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  width: fit-content;
+}
+
+.leaderboard-finals-summary-value,
+.leaderboard-finals-rate-value {
+  color: var(--mat-sys-on-surface);
+  font-size: 1rem;
+  font-weight: 700;
+  line-height: 1.2;
+}
+
+.leaderboard-finals-summary-trophy {
+  margin-inline-end: 0.35rem;
+}
+
+.leaderboard-finals-summary-meta {
+  display: grid;
+  gap: 0.3rem;
+}
+
+.leaderboard-finals-summary-meta-label {
+  color: var(--mat-sys-on-surface-variant);
+  font-size: 0.74rem;
+  font-weight: 600;
+  line-height: 1.35;
+}
+
+.leaderboard-finals-summary-meta-label--with-icon {
+  display: flex;
+  gap: 0.3rem;
+  align-items: center;
+}
+
+.leaderboard-finals-summary-meta-value {
+  color: var(--mat-sys-on-surface);
+  font-size: 0.96rem;
+  font-weight: 700;
+}
+
+.leaderboard-finals-summary-games {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.3rem 0.45rem;
+  align-items: center;
+  color: var(--mat-sys-on-surface);
+  font-size: 0.92rem;
+  font-weight: 600;
+}
+
+.leaderboard-finals-summary-game-part {
+  display: inline-flex;
+  gap: 0.3rem;
+  align-items: center;
+}
+
+.leaderboard-finals-comparison-card {
+  border: 1px solid var(--mat-sys-outline-variant);
+  border-radius: 1rem;
+  background: var(--mat-sys-surface-container-lowest);
+  overflow: hidden;
+}
+
+.leaderboard-finals-comparison-header {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.8rem 1rem 0.7rem;
+  border-bottom: 1px solid var(--mat-sys-outline-variant);
+  background: var(--mat-sys-surface-container);
+}
+
+.leaderboard-finals-comparison-heading {
+  color: var(--mat-sys-on-surface-variant);
+  font-size: 0.78rem;
+  font-weight: 700;
+}
+
+.leaderboard-finals-comparison-heading--home {
+  text-align: left;
+}
+
+.leaderboard-finals-comparison-heading--away {
+  text-align: right;
+}
+
+.leaderboard-finals-comparison-group {
+  padding: 0.95rem 1rem;
+}
+
+.leaderboard-finals-comparison-group+.leaderboard-finals-comparison-group {
+  border-top: 1px solid var(--mat-sys-outline-variant);
+}
+
+.leaderboard-finals-comparison-row {
+  position: relative;
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: stretch;
+  border-bottom: 1px solid var(--mat-sys-outline-variant);
+  border-radius: 0.9rem;
+  font-size: var(--mat-sys-body-medium-size, 14px);
+  overflow: hidden;
+}
+
+.leaderboard-finals-comparison-row:last-child {
+  border-bottom: 0;
+}
+
+.leaderboard-finals-comparison-value,
+.leaderboard-finals-comparison-label {
+  display: flex;
+  align-items: center;
+  min-height: 48px;
+}
+
+.leaderboard-finals-comparison-value {
+  color: var(--mat-sys-on-surface);
+  font-weight: 600;
+}
+
+.leaderboard-finals-comparison-value--home {
+  justify-content: flex-end;
+  padding-right: 24px;
+}
+
+.leaderboard-finals-comparison-label {
+  justify-content: center;
+  min-width: 160px;
+  padding: 0 10px;
+  background: color-mix(in srgb, var(--mat-sys-surface-container) 92%, transparent);
+  color: var(--mat-sys-on-surface-variant);
+  font-size: 0.82rem;
+  font-weight: 700;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.leaderboard-finals-comparison-value--away {
+  justify-content: flex-start;
+  padding-left: 24px;
+}
+
+.leaderboard-finals-comparison-value--winner {
+  color: var(--mat-sys-primary);
+  font-weight: 800;
+}
+
+.leaderboard-finals-rate-delta-inline {
+  color: var(--mat-sys-on-surface-variant);
+  font-size: 0.95rem;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+@media (max-width: 720px) {
+  .leaderboard-finals-matchup-line {
+    gap: 0;
+    padding-block: 0.2rem;
+  }
+
+  .leaderboard-finals-divider {
+    display: none;
+  }
+
+  .leaderboard-finals-matchup-core {
+    flex-basis: 100%;
+    gap: 0.2rem;
+  }
+
+  .leaderboard-finals-selected-badge {
+    display: none;
+  }
+
+  .leaderboard-finals-team-name {
+    font-size: 0.75rem;
+  }
+
+  .leaderboard-finals-score {
+    font-size: 0.88rem;
+  }
+
+  .leaderboard-finals-header {
+    padding-block: 0.45rem;
+  }
+
+  .leaderboard-finals-comparison-header {
+    display: none;
+  }
+
+  .leaderboard-finals-comparison-label {
+    min-width: 0;
+    white-space: normal;
+  }
+}
+
+@media (max-width: 640px) {
+  .leaderboard-finals {
+    --finals-content-padding-inline: 1rem;
+  }
+
+  .leaderboard-finals-content {
+    padding-inline: 1rem;
+  }
+
+  .leaderboard-finals-summary-card,
+  .leaderboard-finals-rate-card,
+  .leaderboard-finals-comparison-card {
+    padding-inline: 0.9rem;
+  }
+
+  .leaderboard-finals-comparison-group {
+    padding-inline: 0;
+  }
+
+  .leaderboard-finals-comparison-row {
+    grid-template-columns: 1fr 1fr;
+    grid-template-areas:
+      'label label'
+      'home away';
+    gap: 0.2rem 0.75rem;
+    padding: 0.75rem 0;
+  }
+
+  .leaderboard-finals-comparison-value,
+  .leaderboard-finals-comparison-label {
+    min-height: 0;
+  }
+
+  .leaderboard-finals-comparison-label {
+    grid-area: label;
+    justify-content: center;
+    margin-bottom: 0.2rem;
+    border-radius: 0.8rem;
+    padding-block: 0.45rem;
+  }
+
+  .leaderboard-finals-comparison-value--home {
+    grid-area: home;
+    justify-content: flex-start;
+    padding-right: 0;
+  }
+
+  .leaderboard-finals-comparison-value--away {
+    grid-area: away;
+    justify-content: flex-end;
+    padding-left: 0;
+  }
+
+}

--- a/src/app/leaderboards/finals/leaderboard-finals.component.scss
+++ b/src/app/leaderboards/finals/leaderboard-finals.component.scss
@@ -322,17 +322,28 @@
     padding-block: 0.2rem;
   }
 
+  .leaderboard-finals-season {
+    order: 1;
+  }
+
   .leaderboard-finals-divider {
     display: none;
   }
 
   .leaderboard-finals-matchup-core {
+    order: 3;
     flex-basis: 100%;
     gap: 0.2rem;
   }
 
   .leaderboard-finals-selected-badge {
-    display: none;
+    order: 2;
+    display: inline-flex;
+    margin-inline-start: 0.35rem;
+    margin-inline-end: 0;
+    padding: 0.1rem 0.42rem;
+    font-size: 0.64rem;
+    line-height: 1.2;
   }
 
   .leaderboard-finals-team-name {

--- a/src/app/leaderboards/finals/leaderboard-finals.component.spec.ts
+++ b/src/app/leaderboards/finals/leaderboard-finals.component.spec.ts
@@ -1,0 +1,290 @@
+import { PLATFORM_ID } from '@angular/core';
+import { fireEvent, render, screen } from '@testing-library/angular';
+import { Observable, of, throwError } from 'rxjs';
+import { TranslateModule } from '@ngx-translate/core';
+import { MATERIAL_ANIMATIONS } from '@angular/material/core';
+
+import { LeaderboardFinalsComponent } from './leaderboard-finals.component';
+import { ApiService, FinalsLeaderboardCategory, FinalsLeaderboardEntry } from '@services/api.service';
+import { FooterVisibilityService } from '@services/footer-visibility.service';
+
+describe('LeaderboardFinalsComponent', () => {
+  async function setup(options: {
+    entries?: FinalsLeaderboardEntry[];
+    finals$?: Observable<FinalsLeaderboardEntry[]>;
+    platformId?: object | string;
+    disableSelectedTeamHighlight?: boolean;
+  } = {}) {
+    const getLeaderboardFinals = vi.fn(() => options.finals$ ?? of(options.entries ?? []));
+    const markReady = vi.fn();
+
+    localStorage.setItem('fantrax.settings', JSON.stringify({
+      selectedTeamId: '1',
+      startFromSeason: null,
+      season: null,
+      reportType: 'regular',
+      disableSelectedTeamHighlight: options.disableSelectedTeamHighlight ?? false,
+    }));
+
+    const result = await render(LeaderboardFinalsComponent, {
+      imports: [TranslateModule.forRoot()],
+      providers: [
+        {
+          provide: MATERIAL_ANIMATIONS,
+          useValue: { animationsDisabled: true },
+        },
+        {
+          provide: PLATFORM_ID,
+          useValue: options.platformId ?? 'browser',
+        },
+        {
+          provide: ApiService,
+          useValue: {
+            getLeaderboardFinals,
+          },
+        },
+        {
+          provide: FooterVisibilityService,
+          useValue: {
+            currentCycle: () => 0,
+            markReady,
+          },
+        },
+      ],
+    });
+
+    return { ...result, getLeaderboardFinals, markReady };
+  }
+
+  it('renders newest finals first, starts collapsed, and reveals the summary and breakdown on expand', async () => {
+    await setup({
+      entries: [
+        createFinalsEntry({
+          season: 2023,
+          winnerTeamId: '2',
+          winnerTeamName: 'Dallas Stars',
+          homeTeamId: '2',
+          homeTeamName: 'Dallas Stars',
+          awayTeamId: '7',
+          awayTeamName: 'Colorado Avalanche',
+        }),
+        createFinalsEntry({
+          season: 2025,
+          winnerTeamId: '1',
+          winnerTeamName: 'Carolina Hurricanes',
+          homeTeamId: '1',
+          homeTeamName: 'Carolina Hurricanes',
+          awayTeamId: '9',
+          awayTeamName: 'Edmonton Oilers',
+        }),
+      ],
+    });
+
+    const headers = screen.getAllByRole('button');
+    expect(headers[0]).toHaveTextContent('2025-26');
+    expect(headers[0]).toHaveTextContent('Carolina Hurricanes');
+    expect(headers[0]).toHaveAttribute('aria-expanded', 'false');
+    expect(screen.getByText('leaderboards.finals.selectedTeamBadge')).toBeInTheDocument();
+
+    fireEvent.click(headers[0]);
+
+    expect(headers[0]).toHaveAttribute('aria-expanded', 'true');
+    expect((await screen.findAllByText('leaderboards.finals.summaryTitle')).length).toBeGreaterThan(0);
+    expect(screen.getAllByText('leaderboards.finals.ratesTitle').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('leaderboards.finals.summary.loser').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('leaderboards.finals.summary.playedGames').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('leaderboards.finals.skaterTotalsTitle').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('leaderboards.finals.goalieTotalsTitle').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('tableColumn.goals').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('tableColumn.saves').length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/\(\+6,0\)/).length).toBeGreaterThan(0);
+  });
+
+  it('shows the API error state and marks the footer ready when the finals request fails', async () => {
+    const { markReady } = await setup({
+      finals$: throwError(() => new Error('boom')),
+    });
+
+    expect(await screen.findByText('leaderboards.apiUnavailable')).toBeInTheDocument();
+    expect(markReady).toHaveBeenCalledWith(0);
+  });
+
+  it('marks the footer ready on the server without calling the finals endpoint', async () => {
+    const { getLeaderboardFinals, markReady } = await setup({
+      entries: [createFinalsEntry({
+        season: 2025,
+        winnerTeamId: '1',
+        winnerTeamName: 'A',
+        homeTeamId: '1',
+        homeTeamName: 'A',
+        awayTeamId: '2',
+        awayTeamName: 'B',
+      })],
+      platformId: 'server',
+    });
+
+    expect(getLeaderboardFinals).not.toHaveBeenCalled();
+    expect(markReady).toHaveBeenCalledWith(0);
+  });
+
+  it('covers finals formatting helpers for deltas, null values, goalie decimals, and disabled highlights', async () => {
+    const entry = createFinalsEntry({
+      season: 2025,
+      winnerTeamId: '1',
+      winnerTeamName: 'Carolina Hurricanes',
+      homeTeamId: '1',
+      homeTeamName: 'Carolina Hurricanes',
+      awayTeamId: '9',
+      awayTeamName: 'Edmonton Oilers',
+    });
+    const { fixture } = await setup({
+      entries: [entry],
+      disableSelectedTeamHighlight: true,
+    });
+    const component = fixture.componentInstance;
+    const savePercentCategory: FinalsLeaderboardCategory = {
+      statKey: 'savePercent',
+      awayValue: 0.914,
+      homeValue: 0.925,
+      winnerTeamId: '1',
+    };
+    const gaaCategory: FinalsLeaderboardCategory = {
+      statKey: 'gaa',
+      awayValue: 2.61,
+      homeValue: 2.18,
+      winnerTeamId: '1',
+    };
+    const nullCategory: FinalsLeaderboardCategory = {
+      statKey: 'wins',
+      awayValue: null,
+      homeValue: 5,
+      winnerTeamId: '1',
+    };
+    const negativeDeltaEntry: FinalsLeaderboardEntry = {
+      ...entry,
+      rates: {
+        winRate: 67.3,
+        deservedToWinRate: 60,
+      },
+    };
+
+    expect(component.hasSelectedFinalist(entry)).toBe(false);
+    expect(component.formatPercent(0.673)).toBe('67,3 %');
+    expect(component.formatRateDelta(entry)).toBe('+6,0 %-yks.');
+    expect(component.formatRateDeltaCompact(negativeDeltaEntry)).toBe('-7,3');
+    expect(component.getCategoryValue(savePercentCategory, 'home')).toBe('0,925');
+    expect(component.getCategoryValue(gaaCategory, 'home')).toBe('2,18');
+    expect(component.getCategoryValue(nullCategory, 'away')).toBe('—');
+  });
+});
+
+function createFinalsEntry(options: {
+  season: number;
+  winnerTeamId: string;
+  winnerTeamName: string;
+  homeTeamId: string;
+  homeTeamName: string;
+  awayTeamId: string;
+  awayTeamName: string;
+}): FinalsLeaderboardEntry {
+  return {
+    season: options.season,
+    wonOnHomeTiebreak: false,
+    winnerTeamId: options.winnerTeamId,
+    winnerTeamName: options.winnerTeamName,
+    homeTeam: {
+      teamId: options.homeTeamId,
+      teamName: options.homeTeamName,
+      score: {
+        matchPoints: 8,
+        categoriesWon: 8,
+        categoriesLost: 5,
+        categoriesTied: 2,
+      },
+      playedGames: {
+        total: 28,
+        skaters: 20,
+        goalies: 8,
+      },
+      totals: {
+        goals: 24,
+        assists: 41,
+        points: 65,
+        plusMinus: 14,
+        penalties: 18,
+        shots: 161,
+        ppp: 12,
+        shp: 1,
+        hits: 53,
+        blocks: 47,
+        wins: 3,
+        saves: 121,
+        shutouts: 1,
+        gaa: 2.18,
+        savePercent: 0.925,
+      },
+    },
+    awayTeam: {
+      teamId: options.awayTeamId,
+      teamName: options.awayTeamName,
+      score: {
+        matchPoints: 7,
+        categoriesWon: 5,
+        categoriesLost: 8,
+        categoriesTied: 2,
+      },
+      playedGames: {
+        total: 26,
+        skaters: 18,
+        goalies: 8,
+      },
+      totals: {
+        goals: 22,
+        assists: 36,
+        points: 58,
+        plusMinus: 8,
+        penalties: 20,
+        shots: 148,
+        ppp: 9,
+        shp: 0,
+        hits: 48,
+        blocks: 42,
+        wins: 2,
+        saves: 118,
+        shutouts: 0,
+        gaa: 2.61,
+        savePercent: 0.914,
+      },
+    },
+    categories: [
+      {
+        statKey: 'goals',
+        awayValue: 22,
+        homeValue: 24,
+        winnerTeamId: options.homeTeamId,
+      },
+      {
+        statKey: 'points',
+        awayValue: 58,
+        homeValue: 65,
+        winnerTeamId: options.homeTeamId,
+      },
+      {
+        statKey: 'saves',
+        awayValue: 118,
+        homeValue: 121,
+        winnerTeamId: options.homeTeamId,
+      },
+      {
+        statKey: 'gaa',
+        awayValue: 2.61,
+        homeValue: 2.18,
+        winnerTeamId: options.homeTeamId,
+      },
+    ],
+    rates: {
+      winRate: 0.5,
+      deservedToWinRate: 0.56,
+    },
+  };
+}

--- a/src/app/leaderboards/finals/leaderboard-finals.component.ts
+++ b/src/app/leaderboards/finals/leaderboard-finals.component.ts
@@ -1,0 +1,209 @@
+import { isPlatformBrowser } from '@angular/common';
+import {
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  DestroyRef,
+  OnInit,
+  PLATFORM_ID,
+  computed,
+  inject,
+} from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { MatExpansionModule } from '@angular/material/expansion';
+import { MatIconModule } from '@angular/material/icon';
+import { MatProgressBarModule } from '@angular/material/progress-bar';
+import { MatTooltipModule } from '@angular/material/tooltip';
+import { TranslateModule } from '@ngx-translate/core';
+
+import {
+  ApiService,
+  FinalsLeaderboardCategory,
+  FinalsLeaderboardEntry,
+  FinalsLeaderboardTeam,
+} from '@services/api.service';
+import { FooterVisibilityService } from '@services/footer-visibility.service';
+import { SettingsService } from '@services/settings.service';
+import {
+  DraftPanelFocusTargetDirective,
+  DraftPanelHeaderNavigationDirective,
+} from '../../draft/draft-panel-navigation.directive';
+
+const SKATER_CATEGORY_KEYS: FinalsLeaderboardCategory['statKey'][] = [
+  'goals',
+  'assists',
+  'points',
+  'plusMinus',
+  'penalties',
+  'shots',
+  'ppp',
+  'shp',
+  'hits',
+  'blocks',
+];
+
+const GOALIE_CATEGORY_KEYS: FinalsLeaderboardCategory['statKey'][] = [
+  'wins',
+  'saves',
+  'shutouts',
+  'gaa',
+  'savePercent',
+];
+
+@Component({
+  selector: 'app-leaderboard-finals',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [
+    MatExpansionModule,
+    MatIconModule,
+    MatProgressBarModule,
+    MatTooltipModule,
+    TranslateModule,
+    DraftPanelFocusTargetDirective,
+    DraftPanelHeaderNavigationDirective,
+  ],
+  templateUrl: './leaderboard-finals.component.html',
+  styleUrl: './leaderboard-finals.component.scss',
+})
+export class LeaderboardFinalsComponent implements OnInit {
+  private readonly apiService = inject(ApiService);
+  private readonly changeDetectorRef = inject(ChangeDetectorRef);
+  private readonly destroyRef = inject(DestroyRef);
+  private readonly footerVisibilityService = inject(FooterVisibilityService);
+  private readonly platformId = inject(PLATFORM_ID);
+  private readonly settingsService = inject(SettingsService);
+
+  private footerVisibilityCycle = 0;
+
+  readonly selectedTeamId = this.settingsService.selectedTeamIdSignal;
+  readonly disableSelectedTeamHighlight = this.settingsService.disableSelectedTeamHighlightSignal;
+  readonly finals = computed(() => (
+    [...this.entries].sort((a, b) => b.season - a.season)
+  ));
+
+  entries: FinalsLeaderboardEntry[] = [];
+  loading = true;
+  apiError = false;
+
+  ngOnInit(): void {
+    this.footerVisibilityCycle = this.footerVisibilityService.currentCycle();
+    this.loading = true;
+    this.apiError = false;
+
+    if (!isPlatformBrowser(this.platformId)) {
+      this.footerVisibilityService.markReady(this.footerVisibilityCycle);
+      return;
+    }
+
+    this.apiService.getLeaderboardFinals()
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (entries) => {
+          this.entries = entries;
+          this.loading = false;
+          this.changeDetectorRef.markForCheck();
+          this.footerVisibilityService.markReady(this.footerVisibilityCycle);
+        },
+        error: () => {
+          this.entries = [];
+          this.loading = false;
+          this.apiError = true;
+          this.changeDetectorRef.markForCheck();
+          this.footerVisibilityService.markReady(this.footerVisibilityCycle);
+        },
+      });
+  }
+
+  isWinner(entry: FinalsLeaderboardEntry, teamId: string): boolean {
+    return entry.winnerTeamId === teamId;
+  }
+
+  hasSelectedFinalist(entry: FinalsLeaderboardEntry): boolean {
+    return !this.disableSelectedTeamHighlight()
+      && (entry.homeTeam.teamId === this.selectedTeamId() || entry.awayTeam.teamId === this.selectedTeamId());
+  }
+
+  formatPercent(value: number): string {
+    return `${this.normalizeRateValue(value).toFixed(1).replace('.', ',')} %`;
+  }
+
+  formatRateDelta(entry: FinalsLeaderboardEntry): string {
+    const delta =
+      this.normalizeRateValue(entry.rates.deservedToWinRate)
+      - this.normalizeRateValue(entry.rates.winRate);
+    const sign = delta > 0 ? '+' : '';
+    return `${sign}${delta.toFixed(1).replace('.', ',')} %-yks.`;
+  }
+
+  formatRateDeltaCompact(entry: FinalsLeaderboardEntry): string {
+    const delta =
+      this.normalizeRateValue(entry.rates.deservedToWinRate)
+      - this.normalizeRateValue(entry.rates.winRate);
+    const sign = delta > 0 ? '+' : '';
+    return `${sign}${delta.toFixed(1).replace('.', ',')}`;
+  }
+
+  formatScore(team: FinalsLeaderboardTeam): string {
+    return this.formatNumber(team.score.matchPoints, 1);
+  }
+
+  formatCategoryRecord(team: FinalsLeaderboardTeam): string {
+    return [
+      team.score.categoriesWon,
+      team.score.categoriesLost,
+      team.score.categoriesTied,
+    ].join('-');
+  }
+
+  getWinnerTeam(entry: FinalsLeaderboardEntry): FinalsLeaderboardTeam {
+    return entry.homeTeam.teamId === entry.winnerTeamId ? entry.homeTeam : entry.awayTeam;
+  }
+
+  getLoserTeam(entry: FinalsLeaderboardEntry): FinalsLeaderboardTeam {
+    return entry.homeTeam.teamId === entry.winnerTeamId ? entry.awayTeam : entry.homeTeam;
+  }
+
+  getSkaterCategories(entry: FinalsLeaderboardEntry): FinalsLeaderboardCategory[] {
+    return entry.categories.filter((category) => SKATER_CATEGORY_KEYS.includes(category.statKey));
+  }
+
+  getGoalieCategories(entry: FinalsLeaderboardEntry): FinalsLeaderboardCategory[] {
+    return entry.categories.filter((category) => GOALIE_CATEGORY_KEYS.includes(category.statKey));
+  }
+
+  getCategoryValue(category: FinalsLeaderboardCategory, side: 'away' | 'home'): string {
+    const value = side === 'away' ? category.awayValue : category.homeValue;
+    return this.formatFinalsValue(category.statKey, value);
+  }
+
+  categoryWonBy(category: FinalsLeaderboardCategory, teamId: string): boolean {
+    return category.winnerTeamId === teamId;
+  }
+
+  private formatFinalsValue(statKey: FinalsLeaderboardCategory['statKey'], value: number | null): string {
+    if (value === null || value === undefined) {
+      return '—';
+    }
+
+    if (statKey === 'savePercent') {
+      return this.formatNumber(value, 3);
+    }
+
+    if (statKey === 'gaa') {
+      return this.formatNumber(value, 2);
+    }
+
+    return this.formatNumber(value, Number.isInteger(value) ? 0 : 1);
+  }
+
+  private formatNumber(value: number, maximumFractionDigits: number): string {
+    return new Intl.NumberFormat('fi-FI', {
+      minimumFractionDigits: 0,
+      maximumFractionDigits,
+    }).format(value);
+  }
+
+  private normalizeRateValue(value: number): number {
+    return Math.abs(value) > 1 ? value : value * 100;
+  }
+}

--- a/src/app/leaderboards/leaderboards.component.spec.ts
+++ b/src/app/leaderboards/leaderboards.component.spec.ts
@@ -31,6 +31,12 @@ describe('LeaderboardsComponent', () => {
 
     component.ngOnInit();
 
+    expect(component.tabs.map((tab) => tab.path)).toEqual([
+      '/leaderboards/regular',
+      '/leaderboards/playoffs',
+      '/leaderboards/transactions',
+      '/leaderboards/finals',
+    ]);
     expect(component.activeLink).toBe('/leaderboards/regular');
 
     router.url = '/leaderboards/transactions?bar=1';

--- a/src/app/leaderboards/leaderboards.component.ts
+++ b/src/app/leaderboards/leaderboards.component.ts
@@ -21,6 +21,7 @@ export class LeaderboardsComponent implements OnInit {
     { label: 'leaderboards.tabs.regular', path: '/leaderboards/regular' },
     { label: 'leaderboards.tabs.playoffs', path: '/leaderboards/playoffs' },
     { label: 'leaderboards.tabs.transactions', path: '/leaderboards/transactions' },
+    { label: 'leaderboards.tabs.finals', path: '/leaderboards/finals' },
   ];
 
   ngOnInit(): void {

--- a/src/app/services/api.service.ts
+++ b/src/app/services/api.service.ts
@@ -16,6 +16,11 @@ export type Team                    = components['schemas']['Team'];
 export type RegularLeaderboardEntry = components['schemas']['RegularLeaderboardEntry'];
 export type PlayoffLeaderboardEntry = components['schemas']['PlayoffLeaderboardEntry'];
 export type TransactionLeaderboardEntry = components['schemas']['TransactionLeaderboardEntry'];
+export type FinalsLeaderboardEntry = components['schemas']['FinalsLeaderboardEntry'];
+export type FinalsLeaderboardTeam = components['schemas']['FinalsLeaderboardTeam'];
+export type FinalsLeaderboardCategory = components['schemas']['FinalsLeaderboardCategory'];
+export type FinalsLeaderboardRates = components['schemas']['FinalsLeaderboardRates'];
+export type FinalsStatKey = components['schemas']['FinalsStatKey'];
 export type CareerPlayerListItem    = components['schemas']['CareerPlayerListItem'];
 export type CareerGoalieListItem    = components['schemas']['CareerGoalieListItem'];
 export type CareerPlayer            = components['schemas']['CareerPlayer'];
@@ -165,6 +170,14 @@ export class ApiService {
     return this.handleRequest<TransactionLeaderboardEntry[]>(
       "leaderboard/transactions",
       "leaderboard-transactions",
+    );
+  }
+
+  // Fetching finals leaderboard data
+  getLeaderboardFinals(): Observable<FinalsLeaderboardEntry[]> {
+    return this.handleRequest<FinalsLeaderboardEntry[]>(
+      'leaderboard/finals',
+      'leaderboard-finals',
     );
   }
 

--- a/src/app/services/api.types.generated.ts
+++ b/src/app/services/api.types.generated.ts
@@ -1332,6 +1332,54 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/leaderboard/finals": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Finals matchup leaderboard
+         * @description Returns one finals matchup summary per imported season, including away/home team details,
+         *     category results, and a `rates` object with both the actual win share and a modeled
+         *     deserved-to-win percentage.
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Finals matchup summaries. */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["FinalsLeaderboardEntry"][];
+                    };
+                };
+                /** @description Missing or invalid API key. */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -1952,6 +2000,65 @@ export interface components {
             players: number;
             /** @description Count of distinct goalie Fantrax entity IDs the team rostered that season. */
             goalies: number;
+        };
+        FinalsLeaderboardEntry: {
+            season: number;
+            wonOnHomeTiebreak: boolean;
+            winnerTeamId: string;
+            winnerTeamName: string;
+            awayTeam: components["schemas"]["FinalsLeaderboardTeam"];
+            homeTeam: components["schemas"]["FinalsLeaderboardTeam"];
+            categories: components["schemas"]["FinalsLeaderboardCategory"][];
+            rates: components["schemas"]["FinalsLeaderboardRates"];
+        };
+        FinalsLeaderboardTeam: {
+            teamId: string;
+            teamName: string;
+            score: components["schemas"]["FinalsLeaderboardScore"];
+            playedGames: components["schemas"]["FinalsLeaderboardPlayedGames"];
+            totals: components["schemas"]["FinalsLeaderboardTeamTotals"];
+        };
+        FinalsLeaderboardScore: {
+            matchPoints: number;
+            categoriesWon: number;
+            categoriesLost: number;
+            categoriesTied: number;
+        };
+        FinalsLeaderboardPlayedGames: {
+            total: number;
+            skaters: number;
+            goalies: number;
+        };
+        FinalsLeaderboardTeamTotals: {
+            goals: number;
+            assists: number;
+            points: number;
+            plusMinus: number;
+            penalties: number;
+            shots: number;
+            ppp: number;
+            shp: number;
+            hits: number;
+            blocks: number;
+            wins: number;
+            saves: number;
+            shutouts: number;
+            gaa: number | null;
+            savePercent: number | null;
+        };
+        /** @enum {string} */
+        FinalsStatKey: "goals" | "assists" | "points" | "plusMinus" | "penalties" | "shots" | "ppp" | "shp" | "hits" | "blocks" | "wins" | "saves" | "shutouts" | "gaa" | "savePercent";
+        FinalsLeaderboardCategory: {
+            statKey: components["schemas"]["FinalsStatKey"];
+            awayValue: number | null;
+            homeValue: number | null;
+            winnerTeamId: string | null;
+        };
+        FinalsLeaderboardRates: {
+            /** @description The actual finals scoreboard share for the champion, equivalent to raw match-points share. */
+            winRate: number;
+            /** @description A weighted, games-adjusted finals strength model that downweights plusMinus, SHP, and shutouts. */
+            deservedToWinRate: number;
         };
     };
     responses: never;

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -620,6 +620,68 @@ mat-checkbox .mdc-label {
   color: var(--mat-sys-on-surface);
 }
 
+.leaderboard-finals .leaderboard-finals-inline-help {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: var(--mat-sys-on-surface-variant);
+  cursor: pointer;
+}
+
+.leaderboard-finals .leaderboard-finals-inline-help mat-icon {
+  width: 20px;
+  height: 20px;
+  font-size: 20px;
+  line-height: 20px;
+}
+
+.leaderboard-finals .draft-focus-target:focus-visible {
+  outline: none;
+  border-radius: 0.9rem;
+  background: color-mix(in srgb, var(--mat-sys-primary) 5%, var(--mat-sys-surface-container-low));
+  box-shadow: inset 0 0 0 2px color-mix(in srgb, var(--mat-sys-primary) 70%, transparent);
+}
+
+.leaderboard-finals .leaderboard-finals-comparison-row.draft-focus-target:focus-visible .leaderboard-finals-comparison-label {
+  background: color-mix(in srgb, var(--mat-sys-primary) 10%, var(--mat-sys-surface-container));
+  color: var(--mat-sys-on-surface);
+}
+
+.leaderboard-finals .leaderboard-finals-status {
+  margin: 0;
+  padding: 1rem var(--finals-content-padding-inline);
+  border: 1px solid var(--mat-sys-outline-variant);
+  border-radius: 1rem;
+  background:
+    linear-gradient(180deg,
+      color-mix(in srgb, var(--mat-sys-surface-container) 88%, transparent) 0%,
+      var(--mat-sys-surface) 100%);
+  color: var(--mat-sys-on-surface);
+  line-height: 1.6;
+}
+
+.leaderboard-finals .leaderboard-finals-status--error {
+  background:
+    linear-gradient(180deg,
+      color-mix(in srgb, var(--mat-sys-error-container) 46%, transparent) 0%,
+      var(--mat-sys-surface) 100%);
+  color: var(--mat-sys-error);
+}
+
+.leaderboard-finals .leaderboard-finals-status--loading {
+  display: grid;
+  gap: 0.75rem;
+  border: 0;
+  border-radius: 0;
+}
+
+.leaderboard-finals .loading-bar {
+  width: 100%;
+}
+
 // Shared stats-table and virtual-table shell styles. Keeping the DOM-targeting rules
 // here avoids repeating the same Material overrides in multiple component stylesheets.
 app-stats-table,

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -190,6 +190,7 @@ body {
 
 // Tabs: avoid black-on-black by explicitly mapping to system tokens.
 .mat-mdc-tab-header {
+  --mat-tab-pagination-icon-color: var(--mat-sys-on-surface-variant);
   background-color: var(--mat-sys-surface-container);
   border-bottom: 1px solid var(--mat-sys-outline-variant);
 }
@@ -202,6 +203,24 @@ body {
 .mat-mdc-tab.mdc-tab--active .mdc-tab__text-label,
 .mat-mdc-tab-header .mdc-tab--active .mdc-tab__text-label {
   color: var(--mat-sys-on-surface) !important;
+}
+
+.mat-mdc-tab-header-pagination {
+  color: var(--mat-sys-on-surface-variant);
+  opacity: 1;
+}
+
+.mat-mdc-tab-header-pagination-chevron {
+  border-color: var(--mat-tab-pagination-icon-color);
+  opacity: 1;
+}
+
+.mat-mdc-tab-header-pagination-disabled {
+  opacity: 0.38;
+}
+
+.mat-mdc-tab-header-pagination-disabled .mat-mdc-tab-header-pagination-chevron {
+  opacity: 0.38;
 }
 
 // Focus rings: some MDC focus indicators are too subtle in dark mode.


### PR DESCRIPTION
## Summary
- add a new `Finaalit` leaderboard tab and route backed by the new `/leaderboard/finals` API
- build a dedicated finals accordion view with season cards, winner/loser summary, win-rate vs calculated-rate section, and category breakdowns
- support keyboard-accessible expansion flow, selected-team indication, dark/mobile-friendly layouts, and multiline tooltip text
- regenerate API types and wire the finals endpoint into `ApiService`
- update docs and tests for the new finals leaderboard flow

## Verification
- `npm run verify`
