### PR TITLE
Fix: Align finals delta colors and goalie stat formatting

### DIFF
--- a/src/app/leaderboards/finals/leaderboard-finals.component.html
+++ b/src/app/leaderboards/finals/leaderboard-finals.component.html
@@ -188,7 +188,10 @@
                   </span>
                   <strong class="leaderboard-finals-rate-value">
                     {{ formatPercent(entry.rates.deservedToWinRate) }}
-                    <span class="leaderboard-finals-rate-delta-inline">
+                    <span
+                      class="leaderboard-finals-rate-delta-inline"
+                      [class.leaderboard-finals-rate-delta-inline--positive]="getRateDeltaTone(entry) === 'positive'"
+                      [class.leaderboard-finals-rate-delta-inline--negative]="getRateDeltaTone(entry) === 'negative'">
                       ({{ formatRateDeltaCompact(entry) }})
                     </span>
                   </strong>

--- a/src/app/leaderboards/finals/leaderboard-finals.component.scss
+++ b/src/app/leaderboards/finals/leaderboard-finals.component.scss
@@ -1,5 +1,7 @@
 .leaderboard-finals {
   --finals-content-padding-inline: 1.25rem;
+  --leaderboard-finals-delta-positive: light-dark(#1f6f2a, #8fe39a);
+  --leaderboard-finals-delta-negative: var(--mat-sys-error);
 }
 
 .leaderboard-finals-accordion {
@@ -314,6 +316,14 @@
   font-size: 0.95rem;
   font-weight: 600;
   white-space: nowrap;
+}
+
+.leaderboard-finals-rate-delta-inline--positive {
+  color: var(--leaderboard-finals-delta-positive);
+}
+
+.leaderboard-finals-rate-delta-inline--negative {
+  color: var(--leaderboard-finals-delta-negative);
 }
 
 @media (max-width: 720px) {

--- a/src/app/leaderboards/finals/leaderboard-finals.component.spec.ts
+++ b/src/app/leaderboards/finals/leaderboard-finals.component.spec.ts
@@ -97,7 +97,9 @@ describe('LeaderboardFinalsComponent', () => {
     expect(screen.getAllByText('leaderboards.finals.goalieTotalsTitle').length).toBeGreaterThan(0);
     expect(screen.getAllByText('tableColumn.goals').length).toBeGreaterThan(0);
     expect(screen.getAllByText('tableColumn.saves').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('2.18').length).toBeGreaterThan(0);
     expect(screen.getAllByText(/\(\+6,0\)/).length).toBeGreaterThan(0);
+    expect(screen.getAllByText('(+6,0)')[0]).toHaveClass('leaderboard-finals-rate-delta-inline--positive');
   });
 
   it('shows the API error state and marks the footer ready when the finals request fails', async () => {
@@ -167,13 +169,23 @@ describe('LeaderboardFinalsComponent', () => {
         deservedToWinRate: 60,
       },
     };
+    const neutralDeltaEntry: FinalsLeaderboardEntry = {
+      ...entry,
+      rates: {
+        winRate: 62,
+        deservedToWinRate: 62,
+      },
+    };
 
     expect(component.hasSelectedFinalist(entry)).toBe(false);
     expect(component.formatPercent(0.673)).toBe('67,3 %');
     expect(component.formatRateDelta(entry)).toBe('+6,0 %-yks.');
     expect(component.formatRateDeltaCompact(negativeDeltaEntry)).toBe('-7,3');
-    expect(component.getCategoryValue(savePercentCategory, 'home')).toBe('0,925');
-    expect(component.getCategoryValue(gaaCategory, 'home')).toBe('2,18');
+    expect(component.getRateDeltaTone(entry)).toBe('positive');
+    expect(component.getRateDeltaTone(negativeDeltaEntry)).toBe('negative');
+    expect(component.getRateDeltaTone(neutralDeltaEntry)).toBe('neutral');
+    expect(component.getCategoryValue(savePercentCategory, 'home')).toBe('0.925');
+    expect(component.getCategoryValue(gaaCategory, 'home')).toBe('2.18');
     expect(component.getCategoryValue(nullCategory, 'away')).toBe('—');
   });
 });

--- a/src/app/leaderboards/finals/leaderboard-finals.component.ts
+++ b/src/app/leaderboards/finals/leaderboard-finals.component.ts
@@ -24,6 +24,7 @@ import {
 } from '@services/api.service';
 import { FooterVisibilityService } from '@services/footer-visibility.service';
 import { SettingsService } from '@services/settings.service';
+import { formatStatDisplayValue } from '@shared/utils/stat-value-format.utils';
 import {
   DraftPanelFocusTargetDirective,
   DraftPanelHeaderNavigationDirective,
@@ -128,19 +129,29 @@ export class LeaderboardFinalsComponent implements OnInit {
   }
 
   formatRateDelta(entry: FinalsLeaderboardEntry): string {
-    const delta =
-      this.normalizeRateValue(entry.rates.deservedToWinRate)
-      - this.normalizeRateValue(entry.rates.winRate);
+    const delta = this.getRateDeltaValue(entry);
     const sign = delta > 0 ? '+' : '';
     return `${sign}${delta.toFixed(1).replace('.', ',')} %-yks.`;
   }
 
   formatRateDeltaCompact(entry: FinalsLeaderboardEntry): string {
-    const delta =
-      this.normalizeRateValue(entry.rates.deservedToWinRate)
-      - this.normalizeRateValue(entry.rates.winRate);
+    const delta = this.getRateDeltaValue(entry);
     const sign = delta > 0 ? '+' : '';
     return `${sign}${delta.toFixed(1).replace('.', ',')}`;
+  }
+
+  getRateDeltaTone(entry: FinalsLeaderboardEntry): 'negative' | 'neutral' | 'positive' {
+    const delta = this.getRateDeltaValue(entry);
+
+    if (delta > 0) {
+      return 'positive';
+    }
+
+    if (delta < 0) {
+      return 'negative';
+    }
+
+    return 'neutral';
   }
 
   formatScore(team: FinalsLeaderboardTeam): string {
@@ -185,12 +196,8 @@ export class LeaderboardFinalsComponent implements OnInit {
       return '—';
     }
 
-    if (statKey === 'savePercent') {
-      return this.formatNumber(value, 3);
-    }
-
-    if (statKey === 'gaa') {
-      return this.formatNumber(value, 2);
+    if (statKey === 'savePercent' || statKey === 'gaa') {
+      return formatStatDisplayValue(statKey, value);
     }
 
     return this.formatNumber(value, Number.isInteger(value) ? 0 : 1);
@@ -205,5 +212,10 @@ export class LeaderboardFinalsComponent implements OnInit {
 
   private normalizeRateValue(value: number): number {
     return Math.abs(value) > 1 ? value : value * 100;
+  }
+
+  private getRateDeltaValue(entry: FinalsLeaderboardEntry): number {
+    return this.normalizeRateValue(entry.rates.deservedToWinRate)
+      - this.normalizeRateValue(entry.rates.winRate);
   }
 }

--- a/src/app/shared/stats-table/stats-table.component.html
+++ b/src/app/shared/stats-table/stats-table.component.html
@@ -94,7 +94,7 @@
             [ngClass]="getCellClass(column)">
             {{ formatCell
                 ? formatCell(column.field, getCellValue(element, column.field))
-                : (getCellValue(element, column.field) ?? "-") }}
+                : formatDefaultCellValue(column.field, getCellValue(element, column.field)) }}
           </td>
         </ng-container>
       }

--- a/src/app/shared/stats-table/stats-table.component.spec.ts
+++ b/src/app/shared/stats-table/stats-table.component.spec.ts
@@ -357,8 +357,8 @@ describe('StatsTableComponent — user behavior', () => {
         name: 'Goalie Alpha',
         games: 50,
         scoreAdjustedByGames: 4.5,
-        gaa: '2.10',
-        savePercent: '0.921',
+        gaa: 2.1,
+        savePercent: 0.921,
       },
     ] as unknown as TableRow[];
     view.fixture.componentInstance.columns = [

--- a/src/app/shared/stats-table/stats-table.component.ts
+++ b/src/app/shared/stats-table/stats-table.component.ts
@@ -26,6 +26,7 @@ import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatIconModule } from '@angular/material/icon';
 import { MatDialog } from '@angular/material/dialog';
 import { Column, ColumnIcon } from '@shared/column.types';
+import { formatStatDisplayValue } from '@shared/utils/stat-value-format.utils';
 import {
   Player,
   Goalie,
@@ -457,6 +458,10 @@ export class StatsTableComponent implements AfterViewInit, OnDestroy {
 
   getCellValue(row: TableRow, field: string): number | string | undefined {
     return (row as Record<string, unknown>)[field] as number | string | undefined;
+  }
+
+  formatDefaultCellValue(column: string, value: number | string | undefined): string {
+    return formatStatDisplayValue(column, value);
   }
 
   isExpandControlColumn(column: Column): boolean {

--- a/src/app/shared/stats-table/virtual-table.component.ts
+++ b/src/app/shared/stats-table/virtual-table.component.ts
@@ -21,6 +21,7 @@ import { MatIconModule } from '@angular/material/icon';
 import { TranslateModule } from '@ngx-translate/core';
 
 import { Column, ColumnIcon } from '@shared/column.types';
+import { formatStatDisplayValue } from '@shared/utils/stat-value-format.utils';
 import { TableRow } from './stats-table.component';
 
 const ROW_NUMBER_COLUMN = '__rowNumber';
@@ -184,7 +185,7 @@ export class VirtualTableComponent implements AfterViewInit {
 
   formatValue(row: TableRow, field: string): string {
     const value = this.getCellValue(row, field);
-    return this.formatCell ? this.formatCell(row, field, value) : String(value ?? '-');
+    return this.formatCell ? this.formatCell(row, field, value) : formatStatDisplayValue(field, value);
   }
 
   filterItems(event: Event): void {

--- a/src/app/shared/utils/stat-value-format.utils.ts
+++ b/src/app/shared/utils/stat-value-format.utils.ts
@@ -1,0 +1,23 @@
+const FIXED_DECIMAL_STAT_DIGITS: Record<string, number> = {
+  gaa: 2,
+  savePercent: 3,
+};
+
+export function formatStatDisplayValue(
+  field: string,
+  value: number | string | undefined,
+): string {
+  if (value === undefined) {
+    return '-';
+  }
+
+  const fractionDigits = FIXED_DECIMAL_STAT_DIGITS[field];
+  if (fractionDigits === undefined) {
+    return String(value);
+  }
+
+  const numericValue = typeof value === 'number' ? value : Number(value);
+  return Number.isFinite(numericValue)
+    ? numericValue.toFixed(fractionDigits)
+    : String(value);
+}


### PR DESCRIPTION
Summary
- Color the finals deserved-win delta green for positive values and red for negative values, while keeping zero neutral
- Align finals GAA and save percentage formatting with the rest of the app
- Reuse one shared stat display formatter for goalie decimal formatting in shared table fallbacks

Testing
- npm run verify

Notes
- Verify passed after updating the finals spec assertions to avoid assuming duplicate rendered values are unique
- Build still reports existing budget warnings, including leaderboard-finals.component.scss exceeding the component-style warning threshold
