### PR TITLE
Fix: Adjust leaderboard finals mobile team labels

### DIFF
--- a/public/i18n/fi.json
+++ b/public/i18n/fi.json
@@ -294,8 +294,8 @@
         "playedGamesAria": "Finaalissa pelatut ottelut: yhteensä {{total}}, kenttäpelaajat {{skaters}}, maalivahdit {{goalies}}."
       },
       "rates": {
-        "actual": "Toteutunut osuus",
-        "deserved": "Laskennallinen osuus",
+        "actual": "Toteutunut",
+        "deserved": "Laskennallinen",
         "deltaTooltip": "Laskennallinen osuus yrittää kuvata sitä kuinka tiukka finaali on todellisuudessa ollut.\n\nEron ollessa positiivinen kertoo se siitä, että voittaja olisi ansainnut suuremmankin voiton.\n\nEron ollessa negatiivinen, ottelu oli tasaisempi miltä lopullinen tulos näyttää.\n\nLaskennallisen osuuden ollessa alle 50%, voitto on ansaittu osittain tuurilla."
       },
       "factors": {
@@ -448,10 +448,7 @@
       },
       {
         "type": "ul",
-        "items": [
-          "/ - kohdista hakukenttä",
-          "? - avaa tämä ohje"
-        ]
+        "items": ["/ - kohdista hakukenttä", "? - avaa tämä ohje"]
       },
       {
         "type": "h2",

--- a/src/app/leaderboards/finals/leaderboard-finals.component.html
+++ b/src/app/leaderboards/finals/leaderboard-finals.component.html
@@ -31,18 +31,34 @@
               <span class="leaderboard-finals-divider" aria-hidden="true">•</span>
 
               <div class="leaderboard-finals-matchup-core">
-                <span class="leaderboard-finals-team-name"
+                <span
+                  class="leaderboard-finals-team-name leaderboard-finals-team-name--full"
                   [class.leaderboard-finals-team-name--winner]="isWinner(entry, entry.homeTeam.teamId)">
                   {{ entry.homeTeam.teamName }}
+                </span>
+                <span
+                  class="leaderboard-finals-team-name leaderboard-finals-team-name--abbr"
+                  [class.leaderboard-finals-team-name--winner]="isWinner(entry, entry.homeTeam.teamId)"
+                  [attr.aria-label]="entry.homeTeam.teamName"
+                  [attr.title]="entry.homeTeam.teamName">
+                  {{ entry.homeTeam.teamAbbr }}
                 </span>
 
                 <span class="leaderboard-finals-score">
                   {{ formatScore(entry.homeTeam) }} - {{ formatScore(entry.awayTeam) }}
                 </span>
 
-                <span class="leaderboard-finals-team-name"
+                <span
+                  class="leaderboard-finals-team-name leaderboard-finals-team-name--full"
                   [class.leaderboard-finals-team-name--winner]="isWinner(entry, entry.awayTeam.teamId)">
                   {{ entry.awayTeam.teamName }}
+                </span>
+                <span
+                  class="leaderboard-finals-team-name leaderboard-finals-team-name--abbr"
+                  [class.leaderboard-finals-team-name--winner]="isWinner(entry, entry.awayTeam.teamId)"
+                  [attr.aria-label]="entry.awayTeam.teamName"
+                  [attr.title]="entry.awayTeam.teamName">
+                  {{ entry.awayTeam.teamAbbr }}
                 </span>
               </div>
 
@@ -215,7 +231,10 @@
                     <strong class="leaderboard-finals-factor-line">
                       <span class="leaderboard-finals-factor-side"
                         [class.leaderboard-finals-factor-side--winner]="factorLeads(entry, 'home', factorKey)">
-                        <span class="leaderboard-finals-factor-abbr">
+                        <span
+                          class="leaderboard-finals-factor-abbr"
+                          [attr.aria-label]="entry.homeTeam.teamName"
+                          [attr.title]="entry.homeTeam.teamName">
                           {{ entry.homeTeam.teamAbbr }}
                         </span>
                         <span class="leaderboard-finals-factor-value">
@@ -230,7 +249,10 @@
                         <span class="leaderboard-finals-factor-value">
                           {{ getFactorValue(entry, 'away', factorKey) }}
                         </span>
-                        <span class="leaderboard-finals-factor-abbr">
+                        <span
+                          class="leaderboard-finals-factor-abbr"
+                          [attr.aria-label]="entry.awayTeam.teamName"
+                          [attr.title]="entry.awayTeam.teamName">
                           {{ entry.awayTeam.teamAbbr }}
                         </span>
                       </span>

--- a/src/app/leaderboards/finals/leaderboard-finals.component.spec.ts
+++ b/src/app/leaderboards/finals/leaderboard-finals.component.spec.ts
@@ -1,5 +1,5 @@
 import { PLATFORM_ID } from '@angular/core';
-import { fireEvent, render, screen } from '@testing-library/angular';
+import { fireEvent, render, screen, within } from '@testing-library/angular';
 import { Observable, of, throwError } from 'rxjs';
 import { TranslateModule } from '@ngx-translate/core';
 import { MATERIAL_ANIMATIONS } from '@angular/material/core';
@@ -81,14 +81,28 @@ describe('LeaderboardFinalsComponent', () => {
     });
 
     const headers = screen.getAllByRole('button');
-    expect(headers[0]).toHaveTextContent('2025-26');
-    expect(headers[0]).toHaveTextContent('Carolina Hurricanes');
-    expect(headers[0]).toHaveAttribute('aria-expanded', 'false');
+    const newestHeader = headers[0];
+
+    expect(newestHeader).toHaveTextContent('2025-26');
+    expect(newestHeader).toHaveTextContent('Carolina Hurricanes');
+    expect(newestHeader).toHaveAttribute('aria-expanded', 'false');
     expect(screen.getByText('leaderboards.finals.selectedTeamBadge')).toBeInTheDocument();
+    expect(within(newestHeader).getByText('Carolina Hurricanes', { selector: '.leaderboard-finals-team-name--full' }))
+      .toBeInTheDocument();
+    expect(within(newestHeader).getByText('Edmonton Oilers', { selector: '.leaderboard-finals-team-name--full' }))
+      .toBeInTheDocument();
+    expect(within(newestHeader).getByText('CAR', { selector: '.leaderboard-finals-team-name--abbr' }))
+      .toHaveAttribute('aria-label', 'Carolina Hurricanes');
+    expect(within(newestHeader).getByText('CAR', { selector: '.leaderboard-finals-team-name--abbr' }))
+      .toHaveAttribute('title', 'Carolina Hurricanes');
+    expect(within(newestHeader).getByText('EDM', { selector: '.leaderboard-finals-team-name--abbr' }))
+      .toHaveAttribute('aria-label', 'Edmonton Oilers');
+    expect(within(newestHeader).getByText('EDM', { selector: '.leaderboard-finals-team-name--abbr' }))
+      .toHaveAttribute('title', 'Edmonton Oilers');
 
-    fireEvent.click(headers[0]);
+    fireEvent.click(newestHeader);
 
-    expect(headers[0]).toHaveAttribute('aria-expanded', 'true');
+    expect(newestHeader).toHaveAttribute('aria-expanded', 'true');
     expect((await screen.findAllByText('leaderboards.finals.summaryTitle')).length).toBeGreaterThan(0);
     expect(screen.getAllByText('leaderboards.finals.ratesTitle').length).toBeGreaterThan(0);
     expect(screen.getAllByText('leaderboards.finals.factorsTitle').length).toBeGreaterThan(0);
@@ -101,6 +115,10 @@ describe('LeaderboardFinalsComponent', () => {
     expect(screen.getAllByText('leaderboards.finals.goalieTotalsTitle').length).toBeGreaterThan(0);
     expect(screen.getAllByText('CAR').length).toBeGreaterThan(0);
     expect(screen.getAllByText('EDM').length).toBeGreaterThan(0);
+    expect(screen.getAllByTitle('Carolina Hurricanes')
+      .filter((element) => element.textContent?.trim() === 'CAR').length).toBeGreaterThan(1);
+    expect(screen.getAllByTitle('Edmonton Oilers')
+      .filter((element) => element.textContent?.trim() === 'EDM').length).toBeGreaterThan(1);
     expect(screen.getAllByText('57,0').length).toBeGreaterThan(0);
     expect(screen.getAllByText('43,0').length).toBeGreaterThan(0);
     expect(screen.getAllByText('tableColumnShort.goals').length).toBeGreaterThan(0);

--- a/src/styles/_leaderboard-finals.scss
+++ b/src/styles/_leaderboard-finals.scss
@@ -1,10 +1,14 @@
-@use './surface-patterns';
+@use "./surface-patterns";
 
 .leaderboard-finals {
   --finals-content-padding-inline: 1.25rem;
   --finals-section-gap: 0.75rem;
   --finals-card-padding: 0.95rem 1rem;
-  --finals-comparison-label-bg: color-mix(in srgb, var(--mat-sys-surface-container) 94%, transparent);
+  --finals-comparison-label-bg: color-mix(
+    in srgb,
+    var(--mat-sys-surface-container) 94%,
+    transparent
+  );
   --leaderboard-finals-delta-positive: light-dark(#1f6f2a, #8fe39a);
   --leaderboard-finals-delta-negative: var(--mat-sys-error);
 }
@@ -15,13 +19,21 @@
 }
 
 .leaderboard-finals-panel {
-  --mat-expansion-container-background-color: var(--mat-sys-surface-container-low);
+  --mat-expansion-container-background-color: var(
+    --mat-sys-surface-container-low
+  );
   --mat-expansion-header-text-color: var(--mat-sys-on-surface);
   --mat-expansion-header-indicator-color: var(--mat-sys-on-surface-variant);
-  --mat-expansion-header-hover-state-layer-color:
-    color-mix(in srgb, var(--mat-sys-primary) 6%, var(--mat-sys-surface-container-low));
-  --mat-expansion-header-focus-state-layer-color:
-    color-mix(in srgb, var(--mat-sys-primary) 10%, var(--mat-sys-surface-container-low));
+  --mat-expansion-header-hover-state-layer-color: color-mix(
+    in srgb,
+    var(--mat-sys-primary) 6%,
+    var(--mat-sys-surface-container-low)
+  );
+  --mat-expansion-header-focus-state-layer-color: color-mix(
+    in srgb,
+    var(--mat-sys-primary) 10%,
+    var(--mat-sys-surface-container-low)
+  );
   @include surface-patterns.outlined-panel-shell;
 }
 
@@ -137,7 +149,7 @@
 }
 
 .leaderboard-finals-rates-grid {
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
 }
 
 .leaderboard-finals-factors-grid {
@@ -284,12 +296,23 @@
 .leaderboard-finals .draft-focus-target:focus-visible {
   outline: none;
   border-radius: 0.9rem;
-  background: color-mix(in srgb, var(--mat-sys-primary) 5%, var(--mat-sys-surface-container-low));
-  box-shadow: inset 0 0 0 2px color-mix(in srgb, var(--mat-sys-primary) 70%, transparent);
+  background: color-mix(
+    in srgb,
+    var(--mat-sys-primary) 5%,
+    var(--mat-sys-surface-container-low)
+  );
+  box-shadow: inset 0 0 0 2px
+    color-mix(in srgb, var(--mat-sys-primary) 70%, transparent);
 }
 
-.leaderboard-finals .leaderboard-finals-comparison-tile.draft-focus-target:focus-visible .leaderboard-finals-comparison-label {
-  background: color-mix(in srgb, var(--mat-sys-primary) 10%, var(--mat-sys-surface-container));
+.leaderboard-finals
+  .leaderboard-finals-comparison-tile.draft-focus-target:focus-visible
+  .leaderboard-finals-comparison-label {
+  background: color-mix(
+    in srgb,
+    var(--mat-sys-primary) 10%,
+    var(--mat-sys-surface-container)
+  );
   color: var(--mat-sys-on-surface);
 }
 
@@ -359,7 +382,8 @@
   overflow: hidden;
 }
 
-.leaderboard-finals-comparison-grid .leaderboard-finals-comparison-tile:last-child {
+.leaderboard-finals-comparison-grid
+  .leaderboard-finals-comparison-tile:last-child {
   border-bottom: 0;
 }
 
@@ -403,7 +427,9 @@
 }
 
 .leaderboard-finals-status {
-  @include surface-patterns.status-surface(1rem var(--finals-content-padding-inline));
+  @include surface-patterns.status-surface(
+    1rem var(--finals-content-padding-inline)
+  );
 }
 
 .leaderboard-finals-status--error {
@@ -443,7 +469,11 @@
   .leaderboard-finals-subsection-title {
     padding: 0.75rem 0.75rem 0.55rem;
     border-bottom: 1px solid var(--mat-sys-outline-variant);
-    background: color-mix(in srgb, var(--mat-sys-surface-container) 85%, transparent);
+    background: color-mix(
+      in srgb,
+      var(--mat-sys-surface-container) 85%,
+      transparent
+    );
   }
 
   .leaderboard-finals-comparison-team-band {
@@ -457,7 +487,11 @@
     font-weight: 700;
     line-height: 1.2;
     text-align: left;
-    background: color-mix(in srgb, var(--mat-sys-surface-container-high) 92%, transparent);
+    background: color-mix(
+      in srgb,
+      var(--mat-sys-surface-container-high) 92%,
+      transparent
+    );
   }
 
   .leaderboard-finals-comparison-team-band--winner {
@@ -477,7 +511,10 @@
   }
 
   .leaderboard-finals-comparison-grid {
-    grid-template-columns: repeat(var(--finals-category-count, 1), minmax(0, 1fr));
+    grid-template-columns: repeat(
+      var(--finals-category-count, 1),
+      minmax(0, 1fr)
+    );
   }
 
   .leaderboard-finals-comparison-tile {
@@ -487,7 +524,8 @@
     border-right: 1px solid var(--mat-sys-outline-variant);
   }
 
-  .leaderboard-finals-comparison-grid .leaderboard-finals-comparison-tile:last-child {
+  .leaderboard-finals-comparison-grid
+    .leaderboard-finals-comparison-tile:last-child {
     border-right: 0;
   }
 

--- a/src/styles/_leaderboard-finals.scss
+++ b/src/styles/_leaderboard-finals.scss
@@ -81,6 +81,10 @@
   line-height: 1.35;
 }
 
+.leaderboard-finals-team-name--abbr {
+  display: none;
+}
+
 .leaderboard-finals-team-name--winner {
   color: var(--mat-sys-primary);
 }
@@ -584,7 +588,7 @@
   }
 
   .leaderboard-finals-team-name {
-    font-size: 0.75rem;
+    font-size: 0.88rem;
   }
 
   .leaderboard-finals-score {
@@ -603,6 +607,14 @@
 @media (max-width: 480px) {
   .leaderboard-finals {
     --finals-content-padding-inline: 1rem;
+  }
+
+  .leaderboard-finals-team-name--full {
+    display: none;
+  }
+
+  .leaderboard-finals-team-name--abbr {
+    display: inline;
   }
 
   .leaderboard-finals-content {


### PR DESCRIPTION
## Summary
- switch finals mobile header labels to team abbreviations at 480px and below
- increase finals mobile team label size to better match the score line on small screens
- add full team-name aria/title metadata for abbreviation labels in both the header and factors section

## Verification
- npm run verify
- checked finals page at 480px in both light and dark mode
