### PR TITLE
Docs: Add project-local workflow skills

### DIFF
--- a/.agents/skills/accessibility-first-ui/SKILL.md
+++ b/.agents/skills/accessibility-first-ui/SKILL.md
@@ -1,0 +1,140 @@
+---
+name: accessibility-first-ui
+description: Use when building or changing user interfaces that should be accessible by default rather than audited later. Helps design and implement semantic, keyboard-friendly, screen-reader-friendly, and touch-friendly web or mobile UI, choose accessible names and structure, handle focus and status messaging correctly, and verify accessibility through real behavior tests.
+---
+
+# Accessibility First UI
+
+## Overview
+
+Use this skill when UI work should be accessible from the first implementation, not patched afterward.
+
+The goal is to build interfaces that remain understandable and usable for:
+
+- keyboard users
+- screen-reader users
+- touch users
+- users with low vision or zoomed layouts
+- users moving through forms, dialogs, tables, drawers, tabs, and navigation flows
+
+This skill applies to web UI and mobile UI. Platform details differ, but the core rule is the same: accessibility is part of the behavior, not decoration around it.
+
+## Core Rules
+
+- Start from semantic structure, not visual appearance alone.
+- Give every interactive control a clear accessible name.
+- Ensure text, controls, focus indicators, and meaningful graphics have sufficient contrast.
+- Make focus order and navigation intentional.
+- Ensure status, error, and loading changes are communicated.
+- Use real interaction patterns for dialogs, drawers, menus, tabs, and forms.
+- Prefer accessible queries in tests because they reflect real usage.
+- Fix inaccessible patterns in the implementation instead of testing around them.
+- Keep accessibility work proportional and practical, but never optional for core flows.
+
+## Token Discipline
+
+- Keep explanations short unless the accessibility tradeoff is non-obvious.
+- Report only:
+  - the main accessibility behavior protected
+  - key semantics or focus decisions
+  - any remaining known gap
+- Expand only when a pattern is subtle or a platform-specific compromise is required.
+
+## Workflow
+
+### 1. Identify the interaction model
+
+Before implementing, identify what the UI actually is:
+
+- navigation target
+- button or action trigger
+- form control
+- dialog or drawer
+- menu or tablist
+- data table or list
+- alert, status, or validation surface
+
+Read [references/ui-checklist.md](./references/ui-checklist.md) when the component type or platform behavior needs a concrete checklist.
+
+### 2. Build semantic structure first
+
+Choose the right underlying structure:
+
+- headings that reflect content hierarchy
+- buttons for actions
+- links for navigation
+- labeled inputs for forms
+- appropriate roles only when native semantics are not enough
+
+Do not start from anonymous clickable containers and patch semantics later.
+
+### 3. Define accessible names and instructions
+
+Make sure users can understand the UI without visual guessing:
+
+- controls have clear labels
+- icon-only controls have usable accessible names
+- grouped controls have contextual labeling where needed
+- validation or helper text is associated with the relevant control
+
+### 4. Design focus and navigation flow
+
+For interactive flows, ensure users can move predictably:
+
+- keyboard order follows meaning
+- dialogs and drawers move focus intentionally on open and close
+- route changes and major content swaps do not leave focus lost
+- mobile touch targets remain usable without precision tapping
+
+### 5. Communicate state changes
+
+Make loading, success, error, and empty states understandable:
+
+- loading is visible and not confused with emptiness
+- errors are announced or clearly associated with the affected area
+- validation feedback is specific
+- toggled or expanded state is clear
+
+### 6. Check contrast deliberately
+
+Do not assume a visually nice palette is accessible.
+
+- normal text should meet at least `4.5:1` contrast against its background
+- large text may use `3:1`
+- user interface components, focus indicators, and meaningful non-text graphics should meet at least `3:1` against adjacent colors
+- do not rely on color alone to communicate state, meaning, or validation
+- verify contrast in the actual states users see: default, hover, focus, disabled styling that is still relevant, error, success, selected, and dark-mode or themed variants
+
+Use [references/ui-checklist.md](./references/ui-checklist.md) for a concrete contrast checklist during implementation or review.
+
+### 7. Verify through real behavior
+
+Use tests and checks that reflect actual interaction:
+
+- accessible queries in component or screen tests
+- keyboard and focus checks for relevant web flows
+- route or screen behavior tests for navigation semantics
+- browser or device verification when layout or visual clipping may affect usability
+
+Do not treat accessibility as a checklist detached from behavior.
+
+## Anti-Patterns
+
+- clickable `div` patterns when a button or link is correct
+- icon-only actions with no accessible name
+- low-contrast text, controls, focus rings, or chart elements that look refined but are hard to perceive
+- focus disappearing after dialog, drawer, or route changes
+- relying on placeholder text as the only label
+- using color as the only indicator for error, success, selection, or required state
+- testing through CSS selectors instead of accessible roles and names
+- adding ARIA roles that fight native semantics
+
+## Expected Behavior When This Skill Is Used
+
+When applying this skill to a task:
+
+1. Identify the real interaction model.
+2. Choose semantic structure before styling details.
+3. Define labels, names, contrast, and state communication clearly.
+4. Make focus and navigation behavior intentional.
+5. Verify accessibility through real interaction tests or checks.

--- a/.agents/skills/accessibility-first-ui/agents/openai.yaml
+++ b/.agents/skills/accessibility-first-ui/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Accessibility First UI"
+  short_description: "Build accessible UI behavior from the start"
+  default_prompt: "Use $accessibility-first-ui to build or review this UI with accessibility built in from the start."

--- a/.agents/skills/accessibility-first-ui/references/ui-checklist.md
+++ b/.agents/skills/accessibility-first-ui/references/ui-checklist.md
@@ -1,0 +1,84 @@
+# UI Checklist
+
+Use this checklist when building or reviewing accessible UI.
+
+## Shared Questions
+
+- Can users understand what each control does without seeing the visual styling?
+- Can they reach and use the control through the platform's normal interaction model?
+- Is state communicated when content loads, fails, expands, collapses, opens, or closes?
+- Do text, controls, focus indicators, and meaningful graphics have enough contrast in the actual theme and state being shown?
+- Does the testing approach use roles, labels, names, or other accessible affordances?
+
+## Contrast Checklist
+
+- normal text should meet at least `4.5:1` contrast against its background
+- large text can use `3:1`
+- UI component boundaries, focus indicators, and meaningful non-text graphics should meet at least `3:1`
+- check contrast in all meaningful states, not only the default state
+- do not rely on color alone for errors, selection, requiredness, success, or warnings
+- check both light and dark themes when the product supports them
+- check text placed over gradients, images, tinted surfaces, or translucent overlays carefully
+- prefer design tokens or shared color roles that preserve contrast consistently instead of one-off local color choices
+
+## Web UI
+
+### Buttons, Links, And Icon Actions
+
+- use buttons for actions
+- use links for navigation
+- give icon-only controls explicit accessible names
+- keep text, icons, outlines, and focus rings distinguishable from the surrounding surface
+- ensure visible focus is not lost or suppressed
+
+### Forms
+
+- associate labels with inputs
+- keep helper text and validation messages connected to the control
+- avoid placeholder-only labeling
+- make invalid state and requiredness clear
+
+### Dialogs, Drawers, Menus
+
+- move focus intentionally on open
+- keep interaction contained appropriately while open
+- return focus predictably on close when the user flow expects it
+- ensure trigger state is still understandable after closing
+- verify overlays, scrims, and layered surfaces do not reduce text or control contrast below usable levels
+
+### Tables, Lists, Tabs
+
+- use real structure where possible
+- make sorting, selection, and active-tab state understandable
+- keep keyboard movement predictable
+- avoid hiding key context when content updates dynamically
+- make selected, sorted, active, and focused states distinguishable without depending on color alone
+
+## Mobile UI
+
+### Touch Targets And Labels
+
+- controls should be clearly labeled for assistive technologies
+- small visual affordances should still be comfortably tappable
+- stacked controls should remain distinguishable in reading order
+- ensure text and icons remain legible in bright conditions and on tinted mobile surfaces
+
+### Navigation And Screen Changes
+
+- route targets and back actions should be understandable
+- major screen changes should not leave the user without context
+- loading, empty, and error states should read as distinct outcomes
+
+### Forms And Feedback
+
+- text inputs need clear labels or equivalent accessible descriptions
+- validation should be specific and associated with the field
+- transient success or error feedback should still be understandable
+
+## Testing Checklist
+
+- use accessible queries first
+- include keyboard or focus checks when the web flow depends on them
+- verify dialogs, drawers, and navigation through actual interaction
+- inspect or test contrast-sensitive states when colors, themes, or overlays changed
+- do not mark a UI as accessible just because it visually looks clean

--- a/.agents/skills/api-contract-sync/SKILL.md
+++ b/.agents/skills/api-contract-sync/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: api-contract-sync
+description: Use when backend and frontend or mobile clients share an API contract that must stay in sync. Helps treat the contract as a source of truth, update schemas or OpenAPI before consumer code drifts, regenerate typed clients safely, coordinate breaking and additive changes, and verify that runtime responses, generated types, and consuming code still agree.
+---
+
+# API Contract Sync
+
+## Overview
+
+Use this skill when API changes affect more than one codebase or layer.
+
+The goal is to keep:
+
+- the contract source of truth
+- generated types or clients
+- backend behavior
+- frontend or mobile consumers
+
+in sync at the same time.
+
+This skill is especially useful for TypeScript stacks that use OpenAPI, JSON Schema, Zod-derived schemas, generated types, or shared DTO packages.
+
+## Core Rules
+
+- Identify the contract source of truth first.
+- Change the source of truth before changing consumers that depend on it.
+- Do not hand-edit generated artifacts.
+- Prefer additive contract changes when possible.
+- Treat breaking changes as deliberate decisions, not incidental refactors.
+- Update all affected consumers in the same task when practical.
+- Verify runtime behavior, not just generated TypeScript.
+- Remove stale fields, params, and client assumptions once the new contract is in place.
+
+## Token Discipline
+
+- Keep reporting short by default.
+- Report only:
+  - source of truth changed
+  - consumers updated
+  - generation or validation performed
+  - remaining compatibility risk
+- Expand only when the contract change is breaking, cross-repo, or operationally risky.
+
+## Workflow
+
+### 1. Find the source of truth
+
+Determine which artifact defines the contract:
+
+- OpenAPI document
+- schema definitions
+- shared DTO package
+- route-level contract builders
+
+If the repo has both generated files and handwritten types, prefer the upstream source and treat generated output as disposable.
+
+### 2. Map the consumers
+
+Identify all consumers that depend on the contract:
+
+- web frontend
+- mobile app
+- other backend services
+- tests, fixtures, mocks, or fake servers
+- generated types or SDKs
+
+Read [references/contract-change-checklist.md](./references/contract-change-checklist.md) when the change is cross-repo or potentially breaking.
+
+### 3. Change the contract at the source
+
+Update the source-of-truth contract first.
+
+Typical changes:
+
+- add or remove fields
+- change nullability or optionality
+- change enum values
+- add or remove query or path params
+- split or rename endpoints
+- tighten validation rules
+
+Prefer the smallest contract change that solves the actual product need.
+
+### 4. Regenerate and reconcile consumers
+
+After the source changes:
+
+- regenerate typed clients or types
+- update consuming code
+- fix mocks, fixtures, and tests that model the contract
+- remove outdated assumptions and compatibility shims that are no longer needed
+
+Do not keep drift alive by patching consumer-side handwritten types to imitate the new contract temporarily.
+
+### 5. Verify both compile-time and runtime agreement
+
+Check both:
+
+- compile-time agreement: generated types, app builds, typecheck
+- runtime agreement: real route responses, integration tests, behavior tests, or schema validation
+
+Type generation passing is not enough if the actual response shape is still wrong.
+
+### 6. Handle breaking changes explicitly
+
+When a change is breaking:
+
+- name it clearly
+- update all in-repo consumers in the same batch when possible
+- document migration assumptions briefly if external consumers may exist
+- avoid silent partial compatibility unless the project truly needs a migration window
+
+### 7. Close drift immediately
+
+Before finishing:
+
+- remove dead fields and deprecated consumer logic that no longer matches the contract
+- update fixtures and mocks to the real shape
+- make sure future generation checks will catch drift again
+
+## Anti-Patterns
+
+- Editing generated files directly
+- Changing frontend types without updating the backend contract
+- Shipping a contract change without updating fixtures or mocks
+- Treating typecheck success as proof of runtime correctness
+- Keeping compatibility branches "just in case" without a real migration plan
+- Letting additive and breaking changes blend together without calling out the risk
+
+## Expected Behavior When This Skill Is Used
+
+When applying this skill to a task:
+
+1. Identify the contract source of truth.
+2. Change the contract there first.
+3. Regenerate or refresh dependent artifacts.
+4. Update all affected consumers.
+5. Verify both runtime and type-level agreement.
+6. Report any remaining compatibility risk briefly.

--- a/.agents/skills/api-contract-sync/agents/openai.yaml
+++ b/.agents/skills/api-contract-sync/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "API Contract Sync"
+  short_description: "Keep backend and client API contracts in sync"
+  default_prompt: "Use $api-contract-sync to update this API contract and keep all consumers aligned."

--- a/.agents/skills/api-contract-sync/references/contract-change-checklist.md
+++ b/.agents/skills/api-contract-sync/references/contract-change-checklist.md
@@ -1,0 +1,55 @@
+# Contract Change Checklist
+
+Use this checklist when an API contract change touches more than one layer or repository.
+
+## Change Types
+
+### Usually additive
+
+- adding an optional field
+- adding a new endpoint
+- adding a new optional query param
+- adding a new enum value only when every consumer is already resilient to unknown values
+
+Even additive changes still require fixture, mock, and generated-type updates where relevant.
+
+### Potentially breaking
+
+- removing a field
+- renaming a field
+- changing a field type
+- changing nullability or requiredness
+- changing enum semantics
+- changing route paths or query param names
+- changing pagination, filtering, sorting, or auth expectations
+
+Treat these as explicit compatibility decisions.
+
+## Consumer Checklist
+
+- backend implementation updated
+- source-of-truth contract updated
+- generated types or SDK regenerated
+- web frontend updated
+- mobile app updated
+- tests updated
+- mocks or fake servers updated
+- fixtures updated
+- docs or examples updated if they are user-facing or operationally important
+
+## Verification Checklist
+
+- typecheck passes in changed repos
+- build or verify passes where appropriate
+- integration or route tests prove the live response shape
+- behavior tests still pass in consumers
+- no stale consumer-side handwritten type overrides remain
+
+## Drift Warnings
+
+Pause if any of these appear:
+
+- generated files changed unexpectedly far beyond the intended contract edit
+- frontend or mobile starts casting around the contract instead of updating usage properly
+- fixtures pass but runtime responses no longer match them
+- the change seems additive in TypeScript but changes real user-visible behavior

--- a/.agents/skills/browser-ui-verification/SKILL.md
+++ b/.agents/skills/browser-ui-verification/SKILL.md
@@ -1,0 +1,188 @@
+---
+name: browser-ui-verification
+description: "Use when building or changing web UI that needs real-browser validation before handoff: inspect rendered routes, interaction states, responsive layout, and theme-sensitive light/dark mode with agent-browser or equivalent browser automation. Helps decide when browser inspection is warranted, start or reuse local dev servers, verify dark mode explicitly, keep Playwright/E2E for automated coverage, and report visual/browser evidence without over-testing non-visual changes. Web only."
+---
+
+# Browser UI Verification
+
+## Overview
+
+Use this skill when web UI work needs to be checked in a real browser before review, handoff, or commit.
+
+The goal is to make rendered browser behavior the final truth for UI changes that regular component tests cannot fully prove:
+
+- layout, spacing, clipping, overflow, and stacking
+- light and dark theme rendering
+- responsive desktop and mobile states
+- focus, hover, active, selected, loading, empty, and error states
+- dialogs, drawers, menus, tabs, tables, sticky elements, and overlays
+- screenshots or snapshots that reveal what the user actually sees
+
+This skill is web-only. Do not apply it to native mobile UI work unless the project explicitly routes mobile validation through a browser-based web app.
+
+## Core Rules
+
+- Use the repository's explicitly preferred browser automation path first when one exists.
+- If no project convention has selected or installed a browser inspection tool yet, prefer installing or using `agent-browser` as the default manual UI and theme inspection path.
+- Keep Playwright, Cypress, or other E2E suites for automated regression coverage; do not replace them with ad hoc browser inspection.
+- Run browser inspection when the task has real rendering, theme, interaction, layout, or responsive risk.
+- Skip browser inspection for backend-only work, docs-only work, generated artifacts, pure test refactors, or non-visual data wiring that cannot meaningfully affect rendered UI.
+- If a product supports dark mode, check dark mode explicitly for theme-sensitive UI changes.
+- Check the changed route and the affected user state, not just the app shell or home page.
+- Prefer realistic local data, fixtures, or app states that expose the changed UI.
+- Use explicit browser media settings for theme checks; do not rely on the machine's current OS preference.
+- Keep the browser session tidy: close sessions when done and do not leave long-lived inspection state for unrelated tasks.
+- Report what was actually inspected: route, viewport, color scheme, interaction state, and any remaining gap.
+
+## Token Discipline
+
+- Choose the smallest honest browser matrix that can prove the changed UI.
+- Prefer targeted routes, states, and snapshots over full-app tours.
+- Do not dump every browser snapshot, screenshot, or DOM detail into the response.
+- Summarize only the route, viewport, color scheme, state, result, and unresolved gap.
+- Stop once the changed browser behavior is honestly verified; escalate only when the browser reveals a real issue or unverified risk.
+
+## Agent Browser Bias
+
+When a project has not chosen a different manual browser inspection tool, use `agent-browser` as the default. A practical inspection flow is:
+
+```bash
+agent-browser open http://localhost:4200
+agent-browser wait --load networkidle
+agent-browser snapshot -i -c
+agent-browser close
+```
+
+For dark-mode checks, use explicit browser media settings such as:
+
+```bash
+agent-browser --color-scheme dark open http://localhost:4200
+```
+
+or switch an existing session if the tool supports it:
+
+```bash
+agent-browser set media dark
+```
+
+Useful commands during UI verification, only when they answer the current UI question:
+
+- `agent-browser snapshot -i -c -s "#main"` for scoped, compact interactive refs that reduce output.
+- `agent-browser set viewport 390 844` or `agent-browser set device "iPhone 14"` for responsive checks.
+- `agent-browser screenshot --annotate` when visual layout, unlabeled icon controls, canvas, or image state needs inspection.
+- `agent-browser screenshot --full` when footer, sticky, or long-page behavior matters.
+- `agent-browser find role button click --name "Submit"`, `find label`, or `find text` when semantic locators are clearer than CSS selectors.
+- `agent-browser hover`, `focus`, `press`, `check`, `uncheck`, `select`, `scroll`, and `scrollintoview` for real interaction states.
+- `agent-browser get styles <sel>`, `get box <sel>`, and `is visible <sel>` for targeted layout, color, and visibility checks.
+- `agent-browser console`, `errors`, and `network requests --type xhr,fetch` for debugging unexpected UI behavior.
+- `agent-browser diff snapshot --selector "#main" --compact` or `agent-browser diff screenshot --baseline before.png --selector "#main"` for focused before/after comparison.
+
+Use `agent-browser batch --bail` for setup steps that do not require intermediate output, but keep snapshot and interaction steps separate when refs or visible state need to be interpreted. If command details are uncertain, run `agent-browser --help` or `agent-browser skills get core` instead of guessing.
+
+Use equivalent browser tooling only when `agent-browser` is unavailable or project conventions explicitly prefer another tool, but preserve the same behavior: open the real page, wait until it is ready, inspect the relevant state, interact when needed, and close the session.
+
+Read [references/browser-verification-checklist.md](./references/browser-verification-checklist.md) when the changed UI spans multiple routes, themes, or responsive states.
+
+## Workflow
+
+### 1. Decide whether browser verification is warranted
+
+Good times to use browser verification:
+
+- after changing shared CSS, design tokens, theme files, component-library overrides, or layout primitives
+- after changing a route, shell, nav, drawer, modal, menu, table, chart, graph, sticky element, or virtualized list
+- after changing responsive behavior, mobile breakpoints, scroll behavior, focus styling, hover styling, or overlays
+- after changing loading, empty, error, disabled, selected, expanded, active, or tooltip states
+- after changing copy that may wrap, truncate, overflow, or affect important layout
+- when the product supports dark mode and the change could affect colors, surfaces, shadows, borders, charts, icons, or contrast
+
+Usually skip browser verification for:
+
+- backend-only or API-only changes
+- docs, comments, generated files, lockfile-only updates, or static metadata
+- pure data wiring where existing rendered tests already prove the visible outcome
+- routine test-only refactors that do not change rendered behavior
+
+### 2. Identify the minimum browser matrix
+
+Choose only the states that can reveal the changed behavior:
+
+- route or component surface
+- desktop and/or mobile viewport
+- light and/or dark color scheme
+- relevant data state: populated, empty, loading, error, long text, or many rows
+- relevant interaction state: focused, hovered, open, expanded, selected, disabled, or scrolled
+
+Keep the matrix small, but do not skip the state where the bug is most likely to show.
+
+### 3. Confirm local runtime assumptions
+
+Before opening a browser, confirm what the UI needs:
+
+- dev server command and port
+- backend or mock server expectations
+- environment variables or fixture mode
+- whether a server is already running
+- whether dark mode follows browser media settings or an in-app toggle
+
+Use an existing server when appropriate. If the expected port is already occupied by the user's session, coordinate instead of silently changing the workflow.
+
+### 4. Inspect the real rendered state
+
+Open the target page and wait for the app to be ready. Then inspect the changed UI in context.
+
+Check for:
+
+- visible content matches the intended state
+- text does not clip, overlap, overflow, or become unreadable
+- spacing, alignment, stacking, sticky elements, and scroll containers behave correctly
+- controls remain usable and visibly focused
+- overlays, dialogs, drawers, menus, and tooltips layer above the right content
+- loading, empty, and error states are distinct
+- charts, icons, images, and media render rather than appearing blank or stale
+
+Use snapshots or screenshots when they help confirm what is on screen. Prefer interaction through real controls over inspecting markup alone.
+
+### 5. Verify theme-sensitive UI explicitly
+
+When dark mode or theme-sensitive styling is in scope:
+
+- inspect the affected route in light mode
+- inspect the same affected route in dark mode
+- check surfaces, text, borders, focus rings, icons, shadows, charts, disabled states, and overlays
+- hard refresh or restart the dev server if browser or dev-server caching appears to keep stale CSS
+
+Do not assume dark mode works because light mode works.
+
+### 6. Escalate to automated coverage only when needed
+
+If browser inspection finds a repeatable behavioral regression, decide whether it deserves automated coverage:
+
+- Testing Library for local component or page behavior
+- E2E for route, shell, browser, or full-flow behavior
+- visual regression tooling only when the project already supports it or the risk justifies introducing it
+
+Do not add screenshots or E2E tests for every visual tweak. Use browser inspection to catch visual reality; use automated tests to protect durable behavior.
+
+## Anti-Patterns
+
+- Marking UI work done after tests pass without checking the rendered browser when styling or layout changed
+- Checking only the default route when the changed UI lives elsewhere
+- Checking only light mode in a dark-mode-capable app
+- Treating Playwright E2E and manual browser inspection as interchangeable
+- Leaving agent-browser or browser sessions open after the task
+- Starting a second server on a surprise port without telling the user
+- Using browser inspection for non-visual changes just to add ritual command output
+- Trusting screenshots before the app has reached a stable loaded state
+
+## Expected Behavior When This Skill Is Used
+
+When applying this skill to a task:
+
+1. Decide whether the change has real web rendering risk.
+2. Identify the smallest honest browser matrix for route, viewport, theme, and state.
+3. Confirm local server, backend, fixture, and theme assumptions.
+4. Inspect the changed UI in a real browser with interaction where needed.
+5. Check dark mode explicitly when theme-sensitive UI is in scope.
+6. Escalate to automated tests only for durable behavior that should be protected.
+7. Report exactly what was browser-verified and what was not, keeping the report concise.

--- a/.agents/skills/browser-ui-verification/agents/openai.yaml
+++ b/.agents/skills/browser-ui-verification/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Browser UI Verification"
+  short_description: "Verify web UI work in a real browser"
+  default_prompt: "Use $browser-ui-verification to validate this web UI change in the browser, including dark mode when relevant."

--- a/.agents/skills/browser-ui-verification/references/browser-verification-checklist.md
+++ b/.agents/skills/browser-ui-verification/references/browser-verification-checklist.md
@@ -1,0 +1,161 @@
+# Browser Verification Checklist
+
+Use this checklist when a web UI change needs real-browser inspection before handoff.
+
+## Trigger Checklist
+
+Browser verification is usually warranted when the change touches:
+
+- shared styles, themes, tokens, or component-library overrides
+- route shells, navigation, drawers, dialogs, menus, tabs, tables, charts, cards, or overlays
+- responsive breakpoints, scroll containers, sticky elements, virtualized lists, or viewport-specific layout
+- focus, hover, active, selected, expanded, disabled, loading, empty, or error states
+- text that may wrap, truncate, overflow, or alter layout
+- images, icons, charts, canvas, media, or generated visual output
+- dark mode, color-scheme, surfaces, borders, shadows, contrast, or theme-specific assets
+
+Browser verification is usually unnecessary for:
+
+- backend-only changes
+- docs-only changes
+- test-only refactors with no rendered behavior change
+- generated files or dependency metadata
+- pure data wiring already proved by meaningful rendered behavior tests
+
+## Minimum Matrix
+
+Choose the smallest matrix that can catch the likely problem.
+
+### Route or surface
+
+- exact route where the changed UI appears
+- route shell if shared layout changed
+- one representative consuming screen for shared components
+- a deep-linked route when routing or direct-load behavior changed
+
+### Viewport
+
+- desktop when the changed UI primarily affects wide layouts
+- mobile when breakpoints, drawers, bottom sheets, sticky nav, or wrapping can change
+- both when shared layout, navigation, tables, or responsive controls changed
+
+### Theme
+
+- light mode when colors, spacing, or default visual state changed
+- dark mode when the product supports it and surfaces, text, borders, shadows, charts, or overlays could be affected
+- both when shared styles or component-library tokens changed
+
+### Data and state
+
+- populated state for normal usage
+- empty state when valid and user-visible
+- loading state when visible long enough to matter
+- error state when the feature handles it intentionally
+- long text, many rows, missing images, or edge values when layout can break
+- open, focused, hovered, selected, expanded, disabled, scrolled, or sticky state when the changed UI has one
+
+## Agent Browser Flow
+
+Use the repo's preferred browser automation. If no project convention has selected or installed a browser inspection tool yet, prefer `agent-browser` as the default manual browser path:
+
+```bash
+agent-browser open http://localhost:4200
+agent-browser wait --load networkidle
+agent-browser snapshot -i -c
+agent-browser close
+```
+
+For dark mode:
+
+```bash
+agent-browser --color-scheme dark open http://localhost:4200
+```
+
+or, when supported for an existing session:
+
+```bash
+agent-browser set media dark
+```
+
+Keep Playwright for automated E2E and performance coverage. Use browser inspection for ad hoc rendered UI validation.
+
+## Useful Agent Browser Commands
+
+Use these only when they fit the changed UI surface:
+
+| Need                                 | Command pattern                                                                                                                       |
+| ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------- |
+| Small interactive snapshot           | `agent-browser snapshot -i -c -s "#main"`                                                                                             |
+| Desktop or mobile viewport           | `agent-browser set viewport 1440 900` / `agent-browser set viewport 390 844`                                                          |
+| Device emulation                     | `agent-browser set device "iPhone 14"`                                                                                                |
+| Light, dark, or reduced-motion media | `agent-browser set media dark` / `agent-browser set media light reduced-motion`                                                       |
+| Annotated visual refs                | `agent-browser screenshot --annotate`                                                                                                 |
+| Long-page inspection                 | `agent-browser screenshot --full`                                                                                                     |
+| Semantic interaction                 | `agent-browser find role button click --name "Submit"`                                                                                |
+| Interaction states                   | `agent-browser hover <sel>`, `focus <sel>`, `press Tab`, `check <sel>`, `select <sel> <value>`                                      |
+| Scroll or sticky state               | `agent-browser scroll down 500` / `agent-browser scrollintoview <sel>`                                                                |
+| Targeted layout/style facts          | `agent-browser get box <sel>` / `agent-browser get styles <sel>`                                                                      |
+| Visibility and control state         | `agent-browser is visible <sel>` / `is enabled <sel>` / `is checked <sel>`                                                            |
+| Route and readiness                  | `agent-browser wait --url "**/dashboard"` / `wait --text "Ready"` / `wait "#spinner" --state hidden`                                 |
+| Browser-side failures                | `agent-browser console` / `agent-browser errors`                                                                                      |
+| API activity behind UI               | `agent-browser network requests --type xhr,fetch`                                                                                     |
+| Focused before/after comparison      | `agent-browser diff snapshot --selector "#main" --compact` / `agent-browser diff screenshot --baseline before.png --selector "#main"` |
+
+Use `agent-browser batch --bail` for setup steps where no intermediate output is needed. Keep steps separate when a snapshot, screenshot, or command result must guide the next action. Use `agent-browser --help` or `agent-browser skills get core` for the current installed command reference.
+
+## Token And Cost Discipline
+
+- Inspect the smallest route, viewport, theme, and state set that can prove the change.
+- Prefer targeted snapshots or screenshots only when they answer the current UI question.
+- Avoid full-app tours and repeated light/dark checks after the affected state is already verified.
+- Do not paste large DOM snapshots or screenshot descriptions into the final report.
+- Report the browser evidence briefly: route, viewport, color scheme, state, result, and gap.
+
+## What To Inspect
+
+### Layout and rendering
+
+- no overlapping or clipped text
+- no unwanted horizontal scroll
+- stable spacing and alignment
+- sticky elements remain anchored correctly
+- virtualized or long lists render enough visible content
+- images, icons, charts, and canvas content are visible and not stale
+- scroll containers and page height behave as intended
+
+### Controls and interactions
+
+- controls are reachable and visibly focused
+- hover, active, selected, expanded, and disabled states remain legible
+- dialogs, drawers, menus, tooltips, and overlays layer correctly
+- buttons, links, tabs, menus, and form controls respond through real interaction
+- route changes and deep links land on a coherent visible state
+
+### Theme and dark mode
+
+- text remains readable on all affected surfaces
+- borders, dividers, icons, and focus rings remain visible
+- elevated surfaces and shadows still separate layers
+- scrims and overlays do not obscure content too aggressively
+- charts and semantic colors remain distinguishable
+- disabled, selected, error, warning, and success states remain understandable without relying on color alone
+
+## Runtime Hygiene
+
+- Reuse the expected local server when it is already running.
+- Coordinate with the user before stopping their server or changing ports.
+- Confirm backend, mock, fixture, or environment assumptions before debugging browser output.
+- Wait for the page to be stable before judging screenshots or snapshots.
+- Hard refresh or restart the dev server if stale CSS or cached assets are suspected.
+- Close browser sessions after inspection.
+
+## Reporting Pattern
+
+Keep the final report concrete:
+
+- route or surface inspected
+- viewport or device profile used
+- color scheme checked
+- interaction or UI state exercised
+- browser tool used
+- issues fixed or remaining gaps

--- a/.agents/skills/intelligence-testing/SKILL.md
+++ b/.agents/skills/intelligence-testing/SKILL.md
@@ -1,0 +1,159 @@
+---
+name: intelligence-testing
+description: "Use when working on application code that should be built with behavior-first TDD: define the real usage story, write the highest-signal failing test first, implement the smallest change to pass it, and refactor only after behavior is protected. Helps choose the right test layer, cover realistic user, API, mobile, and operator scenarios, avoid mock-heavy duplication, and remove speculative defensive branches or fallback logic that cannot be exercised by real usage."
+---
+
+# Intelligence Testing
+
+## Overview
+
+Use this skill when the goal is not just "add tests", but to drive implementation through realistic behavior first.
+
+This skill uses behavior-first TDD:
+
+- Write the real usage story first
+- Turn that story into the best failing test first
+- Implement the smallest production change that makes the test pass
+- Refactor only after the behavior is protected
+
+The default bias is:
+
+- Start from real behavior, not internal functions
+- Prefer the highest-signal failing test that still keeps failures understandable
+- Cover realistic scenarios completely
+- Delete unreachable or speculative logic instead of defending it with artificial tests
+
+If the repository already has project-specific testing rules, follow those rules first and apply this skill as the decision-making lens behind them.
+
+## Core Rules
+
+- Define the real actor first: browser user, mobile user, API consumer, admin, importer operator, scraper run, scheduled job.
+- Describe the task as a usage flow before writing code or tests.
+- Write the failing test before implementation unless the user explicitly asks for another workflow.
+- Test visible behavior, returned API behavior, persisted data behavior, or operator-visible outcomes.
+- Do not add branches for imagined futures unless the product explicitly needs them now.
+- Do not keep fallback logic that no real scenario can trigger.
+- Do not add helper-only tests just to justify dead code.
+- Prefer one strong integration or behavior test over several thin mock-wiring tests.
+- Keep pure unit tests for deterministic logic that is reused or too awkward to reach through behavior tests.
+- Refactor only after the failing test has gone green.
+
+## Token Discipline
+
+- Keep the workflow strict, but keep narration short.
+- Do not narrate every TDD step unless the user asks for that level of detail.
+- Do not dump full scenario lists in routine updates.
+- Report only the essentials by default:
+  - chosen test layer
+  - behavior proved
+  - remaining risk or verification gap
+- Expand reasoning only when the risk is non-obvious, the user asks for depth, or a product decision needs clarification.
+
+## Workflow
+
+### 1. Frame the usage story
+
+Before editing, write the smallest realistic story that proves the task:
+
+- Who is doing the action?
+- What do they do?
+- What should they observe?
+- What can realistically go wrong?
+
+Good examples:
+
+- "User opens the player table, changes season, and sees rows update."
+- "API consumer requests a record detail with an invalid id and gets a clear `400` or `404`."
+- "Importer runs against partially stale upstream data and preserves good local data until the sync succeeds."
+
+### 2. Pick the first failing test
+
+Choose the thinnest test layer that still proves the real behavior, then write that test first.
+
+Behavior-first TDD does not mean unit-test-first by default. It means the first test should live at the most realistic layer for the behavior under change.
+
+Use this bias:
+
+- UI rendering, labels, interaction, loading, empty, and error states: behavior tests with Testing Library first
+- Cross-page flows, browser routing, responsive behavior, keyboard flows, or shared shell behavior: E2E tests first
+- Endpoint + service + database composition: integration tests through the real HTTP boundary and real temporary DB or realistic fixtures first
+- Pure scoring, parsing, mapping, normalization, and reducer logic: focused unit tests first
+- Scraping/import pipelines: realistic input fixtures plus integration-style verification of normalized output, stored records, or operator-visible summaries first
+
+Read [references/scenario-matrix.md](./references/scenario-matrix.md) when the task spans multiple layers or includes UI, API, and import behavior together.
+
+### 3. Go red on realistic behavior
+
+Make the first test fail for the right reason.
+
+- The failure should prove the requested behavior does not exist yet or is currently wrong.
+- The test should describe the user, caller, or operator-visible outcome.
+- Avoid starting with internal helper assertions unless the logic is genuinely pure and isolated.
+- Keep the initial failing test narrow enough to guide implementation, but real enough to matter.
+
+### 4. Go green with the smallest change
+
+Implement the smallest production change that makes the failing test pass.
+
+- Prefer simpler production code over defensive indirection
+- Add only the logic justified by the failing scenario
+- Resist adding future-facing branches while the first behavior is still being proven
+- If the implementation exposes dead parameters, impossible states, or duplicate paths, simplify them instead of preserving them
+
+### 5. Expand to the realistic scenario set
+
+After the first test is green, add the remaining realistic scenarios for the task.
+
+Cover only scenarios that a real user or system can actually hit, but cover those thoroughly.
+
+Default checklist:
+
+- Success path
+- Loading or in-progress state when visible
+- Empty state when valid
+- Invalid input that users or callers can really send
+- Upstream/API/DB/network failure that the product intentionally handles
+- Persistence/cache/reload behavior when the feature depends on it
+- Accessibility behavior for interactive UI
+- Navigation, deep link, or parameter behavior when routing is involved
+
+Do not invent branches only because "something might happen someday." If a branch cannot be described as a realistic path, simplify or delete it.
+
+### 6. Refactor after protection exists
+
+Once the behavior is protected:
+
+- Remove dead parameters, impossible unions, and unused fallbacks
+- Collapse duplicated logic once a single real flow proves behavior
+- Improve naming, structure, and extraction without changing protected behavior
+- Keep the test suite focused on observable outcomes, not new internals created during refactor
+
+### 7. Verify at the right depth
+
+After implementation:
+
+- Run the repo's normal quality gate when practical
+- Run the most relevant high-signal test layer for the touched behavior
+- Report any unverified risk clearly if environment limits block full validation
+
+## Anti-Patterns
+
+- Testing component methods instead of user-visible behavior
+- Mocking most of the stack and then claiming integration confidence
+- Preserving unreachable branches and covering them with isolated tests
+- Adding "just in case" fallbacks without a concrete scenario
+- Duplicating the same happy path in unit, integration, and E2E suites
+- Using TDD as an excuse to start from internal helper tests when the behavior belongs at UI, route, or integration level
+- Hiding product uncertainty inside defensive logic instead of clarifying the expected behavior
+
+## Expected Behavior When This Skill Is Used
+
+When applying this skill to a task:
+
+1. State the primary real usage flow being protected.
+2. Choose the highest-signal first failing test intentionally.
+3. Implement only enough production code to make that test pass.
+4. Add the remaining realistic scenarios that must be covered.
+5. Refactor only after protection exists.
+6. Prefer simplifying code over defending imaginary cases.
+7. Finish by reporting what real behavior was verified and what remains unverified.

--- a/.agents/skills/intelligence-testing/agents/openai.yaml
+++ b/.agents/skills/intelligence-testing/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Intelligence Testing"
+  short_description: "Drive software work with behavior-first TDD"
+  default_prompt: "Use $intelligence-testing to drive this task with behavior-first TDD and realistic test scenarios."

--- a/.agents/skills/intelligence-testing/references/scenario-matrix.md
+++ b/.agents/skills/intelligence-testing/references/scenario-matrix.md
@@ -1,0 +1,116 @@
+# Scenario Matrix
+
+Use this file when a task needs a more concrete behavior-first TDD checklist.
+
+For each area below:
+
+- Start with the highest-signal failing test for the requested behavior
+- Make it pass with the smallest implementation
+- Then add the rest of the realistic scenarios
+
+## Web UI
+
+Prefer behavior tests for local component/page work and E2E when the behavior depends on routing, browser layout, shared shell state, or full-page interactions.
+
+Best first failing tests:
+
+- A user-visible behavior test for a single screen interaction
+- An E2E test first only when the behavior genuinely depends on routing, layout, or full browser flow
+
+Typical realistic scenarios:
+
+- First render shows the expected title, controls, and initial data state
+- Loading indicator appears only while data is unresolved
+- Empty state is clear and not confused with an error
+- Error state explains failure and leaves the screen usable
+- Search, filters, sort, tabs, dialogs, and drawers work through visible controls
+- URL params, deep links, and back/forward navigation keep the right state
+- Keyboard focus, labels, and roles still support the main flow
+- Refresh, cache reuse, or retry behavior works if the feature depends on it
+
+Avoid:
+
+- Testing private methods
+- Driving branches through CSS selectors when accessible queries exist
+- Mocking core state services if the user flow can exercise the real ones
+
+## Mobile App
+
+Prefer React Native Testing Library behavior tests for screen logic and route-level tests for Expo Router wiring. Use device-level or end-to-end checks only when touch, platform, or navigation integration truly matters.
+
+Best first failing tests:
+
+- A screen-level behavior test for the visible user action
+- A route-level test first when params or navigation wiring are the real behavior under change
+
+Typical realistic scenarios:
+
+- Screen loads with API data and keeps visible state stable through refresh
+- Empty/error/loading states are distinct and understandable
+- Search, filters, and sort react to real text entry and presses
+- Detail routes reject invalid params cleanly
+- Required accessibility labels and roles exist for navigation and alerts
+- Secrets stay out of URLs, rendered UI, logs, and cache keys
+
+Avoid:
+
+- Snapshot-heavy tests with little behavioral meaning
+- Hardcoded locale strings when shared translation helpers already define the output shape
+- Keeping optional branches that no actual route or screen can reach
+
+## Backend API
+
+Prefer integration tests through the HTTP boundary when behavior spans routing, services, queries, persistence, auth, caching, or schema validation.
+
+Best first failing tests:
+
+- A route/integration test first when the contract depends on multiple layers
+- A focused unit test first only when the changed logic is truly pure
+
+Typical realistic scenarios:
+
+- Happy path returns the expected response shape and status
+- Invalid params return the intended `400` or `404`
+- Auth-protected routes reject missing or invalid credentials
+- Empty datasets return stable response shapes
+- Cache headers, ETags, or pagination behave consistently when part of the contract
+- Data imported to the database is the data the route later returns
+- OpenAPI or response-schema expectations still match live responses
+
+Avoid:
+
+- Mocking the database for flows that are really route-plus-data behavior
+- Duplicating the same happy path in route, service, and query tests
+- Writing tests that only prove parameter forwarding or internal delegation
+
+## Importers, Scrapers, And Sync Jobs
+
+Treat these like operator-facing product features, not just scripts.
+
+Best first failing tests:
+
+- A realistic fixture or integration-style test for the observable sync/import outcome
+- A pure parser/mapping unit test first only after extracting deterministic logic out of the CLI or browser shell
+
+Typical realistic scenarios:
+
+- Valid upstream input normalizes into the expected stored or emitted output
+- Partial bad input fails clearly without corrupting already good data
+- Re-runs are idempotent when the workflow expects repeat execution
+- Logs or summaries expose the outcome an operator actually needs
+- Retry or backoff logic is covered only when the tool really uses it in production
+- Pure parsing rules are extracted into testable modules when the Playwright or CLI shell itself is not the right unit-test surface
+
+Avoid:
+
+- Pulling CLI entrypoints directly into unit suites when extracted pure logic would be cleaner
+- Adding broad fallback parsing branches for shapes that have never been observed
+- Marking a sync as "safe" without proving what happens to existing data on failure
+
+## Cross-Cutting Heuristics
+
+- If a branch cannot be tied to a realistic scenario, remove it.
+- If a test does not describe observable behavior, question whether it belongs.
+- If a unit test and an integration test prove the same thing, keep the one with better signal.
+- If coverage pressure encourages fake scenarios, simplify the code instead.
+- If the task changes behavior across UI and API, make sure both the user-visible result and the server contract are validated.

--- a/.agents/skills/local-first-verification/SKILL.md
+++ b/.agents/skills/local-first-verification/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: local-first-verification
+description: Use when deciding how to verify a change locally before handoff, review, or commit. Helps choose the cheapest meaningful checks that still prove the touched behavior, coordinate local environment assumptions, avoid both under-testing and wasteful over-testing, keep fixtures and mocks honest, and report only real residual risk.
+---
+
+# Local First Verification
+
+## Overview
+
+Use this skill when a change needs verification, but not every task needs the heaviest possible check immediately.
+
+The goal is to verify changes locally in the cheapest order that still provides honest confidence:
+
+- start with the most relevant low-cost checks
+- escalate only when risk or uncertainty requires it
+- do not confuse speed with shallow verification
+- do not confuse expensive verification with meaningful verification
+
+## Core Rules
+
+- Match verification depth to the behavior changed.
+- Prefer the cheapest check that can actually fail for the right reason.
+- Escalate when the cheaper check cannot prove the real behavior.
+- Verify user-visible behavior with user-visible checks.
+- Verify integration boundaries with integration checks.
+- Keep mocks and fixtures aligned with current runtime behavior.
+- Coordinate with local services, ports, credentials, and background processes before expensive runs.
+- Report only what was truly verified, not what was merely assumed.
+
+## Token Discipline
+
+- Do not narrate every command or every check.
+- Summarize only:
+  - checks run
+  - behavior covered
+  - gaps or blocked verification
+- Expand only when a failure, environment issue, or hidden risk needs explanation.
+
+## Workflow
+
+### 1. Identify the touched surface
+
+Classify the change:
+
+- pure logic
+- UI behavior
+- routing or navigation
+- API contract
+- persistence or caching
+- environment or config
+- styling or accessibility
+- cross-layer integration
+
+Read [references/verification-matrix.md](./references/verification-matrix.md) when the right check depth is not obvious.
+
+### 2. Choose the first meaningful check
+
+Good starting points:
+
+- typecheck or lint for type-level or structural edits
+- focused unit or behavior tests for isolated logic or local UI changes
+- integration tests for API, DB, caching, or multi-layer flows
+- browser or device verification for visual, responsive, or interaction-sensitive changes
+
+Start with a check that is cheap and relevant, not merely familiar.
+
+### 3. Confirm local assumptions
+
+Before heavier verification, confirm what the run depends on:
+
+- required local servers
+- ports already in use
+- environment variables or credentials
+- fixture or mock mode versus live mode
+- generated artifacts already up to date
+
+Do not burn time debugging a failing verification flow that was invalid before it started.
+
+### 4. Escalate only when needed
+
+Escalate when:
+
+- the first check cannot observe the changed behavior
+- the change crosses boundaries
+- production risk is higher than local signal so far
+- the repo's standard quality gate is required before finishing
+
+Examples:
+
+- from unit test to integration test
+- from behavior test to E2E
+- from local mock mode to live local backend
+- from targeted test to full verify
+
+### 5. Keep fixtures and mocks honest
+
+When a change touches contract, routing, request shape, or serialized output:
+
+- update fixtures
+- update mocks
+- verify they still represent real runtime behavior
+
+Do not let passing local tests hide drift between mock mode and live mode.
+
+### 6. Stop when confidence is sufficient and honest
+
+The goal is not maximal command count. Stop when:
+
+- the changed behavior has been proved at the right depth
+- the repo's required gate has passed, if applicable
+- remaining uncertainty is minor and explicitly reported
+
+## Anti-Patterns
+
+- Running only cheap checks that cannot observe the actual change
+- Jumping straight to the heaviest check for every small edit
+- Treating fixture mode as enough when the contract or runtime behavior changed
+- Claiming full confidence after typecheck only
+- Re-running large verification commands repeatedly without learning from the first failure
+- Hiding blocked verification behind vague language
+
+## Expected Behavior When This Skill Is Used
+
+When applying this skill to a task:
+
+1. Identify what changed and what kind of signal it needs.
+2. Run the cheapest meaningful verification first.
+3. Escalate only when the cheaper check is insufficient.
+4. Keep local assumptions, fixtures, and mocks honest.
+5. Report verified behavior and any real gaps briefly.

--- a/.agents/skills/local-first-verification/agents/openai.yaml
+++ b/.agents/skills/local-first-verification/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Local First Verification"
+  short_description: "Choose the cheapest honest local verification path"
+  default_prompt: "Use $local-first-verification to choose and run the right local verification depth for this task."

--- a/.agents/skills/local-first-verification/references/verification-matrix.md
+++ b/.agents/skills/local-first-verification/references/verification-matrix.md
@@ -1,0 +1,58 @@
+# Verification Matrix
+
+Use this matrix to choose the first meaningful local check.
+
+## Change Type To First Check
+
+### Pure logic or utility code
+
+- start with focused unit tests
+- add typecheck if signatures or generics changed
+
+### UI behavior inside one screen or component
+
+- start with behavior tests
+- escalate to browser or device checks only if layout, focus, routing, or visual state matters
+
+### Styling only
+
+- start with browser or device verification
+- add visual or behavior tests only when styles affect interaction states
+
+### Route, navigation, or deep-link behavior
+
+- start with route-level behavior or integration tests
+- escalate to E2E if the full shell or browser history matters
+
+### Backend route, cache, DB, or auth behavior
+
+- start with integration tests through the real boundary
+- add unit tests only for extracted pure logic
+
+### API contract or generated client changes
+
+- start with contract regeneration or validation plus integration verification
+- then verify at least one affected consumer path
+
+### Build, config, or environment changes
+
+- start with the narrowest command that proves the config works
+- escalate to the standard project gate if the config affects the full app
+
+## Escalation Signals
+
+Escalate when:
+
+- the changed behavior is not visible to the current test layer
+- mocks or fixtures may have drifted from runtime
+- multiple layers changed together
+- accessibility or visual behavior is part of the outcome
+- the repo requires a full gate before completion
+
+## Reporting Pattern
+
+Keep the final summary short:
+
+- what was verified
+- at what layer
+- what was not verified and why

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,13 @@ See `README.md` for project overview and `package.json` for available npm comman
 
 # Project documentation
 - Read accessibility, codebase structure, coding standards, component guide, development guide, project overview, project requirements, project testing, roadmap, and styling guide docs via `docs/README.md` and its subpages.
-- Use the installed `angular-developer` skill and official Angular docs for generic Angular guidance.
+- Use the project-local skills in `.agents/skills/` when their trigger matches the task.
+- Use `intelligence-testing` as the starting point for new tasks that touch testing or behavior protection. Apply the repo's testing rules first, then use the skill's behavior-first TDD lens.
+- Use `api-contract-sync` when backend contracts, OpenAPI, generated API types, fixtures, or consumer assumptions may drift.
+- Use `local-first-verification` when choosing the right local verification depth before handoff, review, or commit.
+- Use `browser-ui-verification` for web UI work with real browser, layout, theme, responsive, or interaction risk.
+- Use `accessibility-first-ui` for UI work that affects semantics, focus, labels, status messaging, or contrast.
+- Use the installed `angular-developer` skill and official Angular docs for generic Angular guidance only.
 - Use repo docs for project-specific workflow, architecture, testing, accessibility, routing/shell structure, and deliberate overrides.
 - If repo docs conflict with generic Angular guidance, follow the repo docs for this project.
 - When a local doc drifts into generic Angular tutorial material, trim it back to the repo-specific rule instead of expanding it further.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,8 +67,7 @@ If a proposed change would alter user-visible application behavior or semantics,
 
 ## Browser Automation Rules
 - For manual browser automation and visual inspection that previously used Playwright MCP, prefer the device-wide `agent-browser` CLI.
-- Typical workflow: `agent-browser open <url>`, `agent-browser wait --load networkidle`, `agent-browser snapshot -i`, interact via refs such as `@e2`, then `agent-browser close` when finished.
-- When checking theme-sensitive UI, use explicit browser media settings such as `agent-browser --color-scheme dark open <url>` or `agent-browser set media dark`.
+- Use the `browser-ui-verification` skill for the generic browser-inspection workflow and command patterns.
 - Use agent-browser only when the task includes real theming or styling risk that benefits from browser inspection.
 - Do not use agent-browser for routine non-visual changes that do not meaningfully affect rendering, such as pure data wiring, copy-only tweaks, or simple column-order updates.
 - If using agent-browser during a task, close the browser after you are done with it and no longer need it. Do not leave sessions open across unrelated steps or future sessions.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,8 +69,7 @@ If a proposed change would alter user-visible application behavior or semantics,
 
 ## Browser Automation Rules
 - For manual browser automation and visual inspection that previously used Playwright MCP, prefer the device-wide `agent-browser` CLI.
-- Typical workflow: `agent-browser open <url>`, `agent-browser wait --load networkidle`, `agent-browser snapshot -i`, interact via refs such as `@e2`, then `agent-browser close` when finished.
-- When checking theme-sensitive UI, use explicit browser media settings such as `agent-browser --color-scheme dark open <url>` or `agent-browser set media dark`.
+- Use the `browser-ui-verification` skill for the generic browser-inspection workflow and command patterns.
 - Use agent-browser only when the task includes real theming or styling risk that benefits from browser inspection.
 - Do not use agent-browser for routine non-visual changes that do not meaningfully affect rendering, such as pure data wiring, copy-only tweaks, or simple column-order updates.
 - If using agent-browser during a task, close the browser after you are done with it and no longer need it. Do not leave sessions open across unrelated steps or future sessions.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,13 @@ Keep this file aligned with `AGENTS.md`; if wording diverges, treat `AGENTS.md` 
 
 # Project documentation
 - Read accessibility, codebase structure, coding standards, component guide, development guide, project overview, project requirements, project testing, roadmap, and styling guide docs via @docs/README.md and its subpages.
-- Use the installed `angular-developer` skill and official Angular docs for generic Angular guidance.
+- Use the project-local skills in `.agents/skills/` when their trigger matches the task.
+- Use `intelligence-testing` as the starting point for new tasks that touch testing or behavior protection. Apply the repo's testing rules first, then use the skill's behavior-first TDD lens.
+- Use `api-contract-sync` when backend contracts, OpenAPI, generated API types, fixtures, or consumer assumptions may drift.
+- Use `local-first-verification` when choosing the right local verification depth before handoff, review, or commit.
+- Use `browser-ui-verification` for web UI work with real browser, layout, theme, responsive, or interaction risk.
+- Use `accessibility-first-ui` for UI work that affects semantics, focus, labels, status messaging, or contrast.
+- Use the installed `angular-developer` skill and official Angular docs for generic Angular guidance only.
 - Use repo docs for project-specific workflow, architecture, testing, accessibility, routing/shell structure, and deliberate overrides.
 - If repo docs conflict with generic Angular guidance, follow the repo docs for this project.
 - When a local doc drifts into generic Angular tutorial material, trim it back to the repo-specific rule instead of expanding it further.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ For contributor and agent guidance, start at [docs/README.md](docs/README.md).
 
 The docs in this repo intentionally focus on project-specific architecture, workflow, testing, accessibility, and local exceptions rather than re-teaching generic Angular concepts.
 
+This repo also carries project-local agent skills under `.agents/skills/`. Keep those committed when the repo workflow depends on them, and use the matching skill when a task touches testing strategy, API contract drift, verification depth, browser UI validation, or accessibility-first UI work.
+
 For CSS/theming work specifically, read [docs/styling-guide.md](docs/styling-guide.md) before changing shared styles, tokens, or Material overrides.
 
 ## Features

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,9 @@
 
 These docs are intentionally project-specific.
 
-Use the installed `angular-developer` skill and official Angular docs for generic framework guidance. Use the docs in this directory for this repo's architecture, workflow, testing rules, accessibility requirements, and deliberate overrides of generic Angular guidance.
+Use the project-local skills in `.agents/skills/` when they match the task. In particular, start testing-related work with `intelligence-testing`, use `api-contract-sync` for contract drift, `local-first-verification` for local check depth, `browser-ui-verification` for browser-risk UI work, and `accessibility-first-ui` for accessible UI implementation. Use `angular-developer` and official Angular docs only for generic framework guidance.
+
+Use the docs in this directory for this repo's architecture, workflow, testing rules, accessibility requirements, and deliberate overrides of generic Angular guidance.
 
 If a local doc conflicts with generic Angular guidance, follow the local doc for work in this repo.
 
@@ -30,3 +32,11 @@ If a local doc conflicts with generic Angular guidance, follow the local doc for
 - When a repo rule intentionally overrides generic Angular guidance, document that override in the most specific relevant guide
 - Use the real code as the source of truth for exact component/service APIs when signatures move faster than docs
 - Keep `docs/plans/` as local gitignored working memory for approved plans, not as committed product documentation
+
+## Installed Skills
+
+- `intelligence-testing`: starting point for tasks that add or change tests or rely on behavior-first TDD.
+- `api-contract-sync`: use when backend contracts, generated types, fixtures, or consumer assumptions might drift.
+- `local-first-verification`: use to choose the cheapest honest local verification path before review or commit.
+- `browser-ui-verification`: use for web UI changes with real browser, theme, responsive, or interaction risk.
+- `accessibility-first-ui`: use for UI work where semantics, focus, labels, contrast, and state announcements matter from the start.

--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -4,6 +4,8 @@ Accessibility is a **core, non-negotiable requirement** of this project.
 
 If a feature is not usable with keyboard and assistive technologies, it is considered incomplete.
 
+Start UI accessibility work with the installed `accessibility-first-ui` skill, then apply the concrete repo patterns and constraints in this guide.
+
 ## Goals
 
 - Keep the UI usable for:
@@ -201,6 +203,7 @@ Before you consider a feature “done”:
 
 - Add behavior tests for keyboard handlers when you introduce keyboard behavior.
 - Test through user-visible behavior using Testing Library accessible queries.
+- Use the installed `intelligence-testing` skill when deciding the first failing accessibility behavior test.
 
 ### E2E tests (Playwright)
 
@@ -209,6 +212,8 @@ For major interaction changes, add/extend Playwright tests to cover:
 - Keyboard navigation through the feature
 - Opening/closing dialogs with keyboard
 - Focus landing in the correct place after actions
+
+For layout, clipping, theme, contrast, or focus-visibility risk that tests cannot fully prove, use the installed `browser-ui-verification` skill and the repo's `agent-browser` workflow before handoff.
 
 ## References
 

--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -2,7 +2,9 @@
 
 This guide focuses on local setup, commands, and repo-specific operational notes.
 
-Use the installed `angular-developer` skill and official Angular docs for generic framework guidance. Follow `AGENTS.md` and `CLAUDE.md` for the authoritative task workflow, review pause, verify, and commit rules.
+Use the project-local skills in `.agents/skills/` when they match the task, especially `intelligence-testing` for testing-related work, `local-first-verification` for local check strategy, and `browser-ui-verification` for browser-risk UI changes. Use `angular-developer` and official Angular docs for generic framework guidance only. Follow `AGENTS.md` and `CLAUDE.md` for the authoritative task workflow, review pause, verify, and commit rules.
+
+The upstream source for the repo-local skills is [maestor/agent-skills](https://github.com/maestor/agent-skills). Its README documents the `skills.sh` install source as `npx skills add maestor/agent-skills --skill <skill-name>`. This repo vendors the selected skills under `.agents/skills/` so they stay project-local and available automatically in future sessions.
 
 Explicit user instructions in chat override those repo workflow defaults. Treat the documented workflow as the fallback when the user has not said otherwise.
 

--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -261,23 +261,15 @@ npx playwright test --headed
 
 ### Manual Browser Automation For Agent Work
 
-Use the device-wide `agent-browser` CLI for ad hoc browser inspection tasks that are not Playwright E2E tests.
-
-Recommended flow:
-
-```bash
-agent-browser open http://localhost:4200
-agent-browser wait --load networkidle
-agent-browser snapshot -i
-agent-browser click @e2
-agent-browser close
-```
+Use the installed `browser-ui-verification` skill plus the device-wide `agent-browser` CLI for ad hoc browser inspection tasks that are not Playwright E2E tests.
 
 Notes:
 
 - Prefer `agent-browser` for manual UI/theme inspection that older workflow text may still call "Playwright MCP".
+- Use the skill for the generic browser workflow, command patterns, and browser-matrix decisions instead of repeating them in repo docs.
 - Keep Playwright for automated E2E coverage (`npm run e2e`, `npx playwright test`, `npm run perf:audit`).
-- For dark-mode checks, use explicit browser media settings such as `agent-browser --color-scheme dark open http://localhost:4200`.
+- Coordinate before changing ports or stopping an already running local frontend session on `http://localhost:4200`.
+- Close browser sessions after inspection.
 
 ### Angular CLI Commands
 ```bash
@@ -350,6 +342,7 @@ The API endpoint is configured in the service layer. Check:
    - Update translation files for new UI text
 
 5. **Write tests**
+   - Start with `intelligence-testing` for the behavior-first test plan
    - Component tests (`*.spec.ts`) using `@testing-library/angular` with accessible queries
    - Update E2E tests if needed
 

--- a/docs/project-requirements.md
+++ b/docs/project-requirements.md
@@ -2,7 +2,7 @@
 
 This file defines repo-local quality gates and deliberate overrides.
 
-Use the installed `angular-developer` skill and official Angular docs for generic Angular guidance. Use this file for the requirements that are specific to this project and its workflow.
+Use the project-local skills in `.agents/skills/` when their trigger matches the task. Use `angular-developer` and official Angular docs for generic Angular guidance only. Use this file for the requirements that are specific to this project and its workflow.
 
 ## Non-Negotiable Requirements
 
@@ -23,6 +23,7 @@ See `docs/accessibility.md`.
 ### Tested Changes Are Required
 
 - New or changed behavior must be covered by tests
+- Start testing-related work with `intelligence-testing`
 - Aim for full coverage of touched logic, including edge and error cases
 - Prefer removing dead logic over writing tests for impossible states
 
@@ -37,6 +38,8 @@ npm run verify
 ```
 
 That runs linting, coverage-enabled tests, and the production build.
+
+Use `local-first-verification` while iterating to choose the cheapest honest local checks before this final gate.
 
 ### Documentation-Only Batches
 
@@ -89,6 +92,9 @@ These rules override generic Angular examples when they conflict.
 - E2E uses Playwright, not Cypress
 - UI tests mock only approved external/platform boundaries such as `ApiService`, `ViewportService`, and `PwaUpdateService`
 - Do not add `data-testid` or `data-cy` attributes just to support routine testing
+- API contract changes should use `api-contract-sync`
+- Web UI changes with browser risk should use `browser-ui-verification`
+- UI accessibility work should use `accessibility-first-ui`
 
 See `docs/project-testing.md` for the full testing workflow.
 

--- a/docs/project-testing.md
+++ b/docs/project-testing.md
@@ -22,7 +22,7 @@ Note: avoid hard-coding a "current test count" in docs; it becomes stale quickly
 Every contribution must include tests for all new/changed behavior.
 
 - **Rule**: new/changed logic should be tested (include error and edge cases)
-- **Starting bias**: frame the real usage story first, choose the highest-signal failing test first, and only then implement the smallest production change
+- **Starting bias**: use `intelligence-testing` for the story-first TDD workflow and realistic scenario selection
 - **CI Gate**: `npm run verify` must pass (tests + production build)
 - **Coverage thresholds**: `npm run verify` enforces minimum coverage of 93% statements, 85% branches, 94% functions, and 95% lines via `angular.json` (`architect.test.options.coverageThresholds`)
 - **Branch coverage note**: Angular's generated `ngDevMode` signal-branch coverage noise is no longer skewing the branch baseline, so branch coverage is now a more reliable regression signal. Do not use that as a reason to skip meaningful behavior coverage.

--- a/docs/project-testing.md
+++ b/docs/project-testing.md
@@ -6,6 +6,8 @@ This project uses **Testing Library** (`@testing-library/angular`) with **Vitest
 
 This repo's testing rules override generic Angular examples when they conflict. In particular, this repo prefers Testing Library for UI behavior coverage and Playwright for E2E coverage; do not import Cypress- or raw-DOM-selector-first testing habits from generic framework references.
 
+Start testing-related tasks with the installed `intelligence-testing` skill. Use it as the decision-making lens for behavior-first TDD and realistic scenario selection, then apply the repo-specific rules in this file for concrete test layers and commands.
+
 ## Test Statistics
 
 - **Total Test Files / Tests**: Run `npm test` to see the current count and status
@@ -20,6 +22,7 @@ Note: avoid hard-coding a "current test count" in docs; it becomes stale quickly
 Every contribution must include tests for all new/changed behavior.
 
 - **Rule**: new/changed logic should be tested (include error and edge cases)
+- **Starting bias**: frame the real usage story first, choose the highest-signal failing test first, and only then implement the smallest production change
 - **CI Gate**: `npm run verify` must pass (tests + production build)
 - **Coverage thresholds**: `npm run verify` enforces minimum coverage of 93% statements, 85% branches, 94% functions, and 95% lines via `angular.json` (`architect.test.options.coverageThresholds`)
 - **Branch coverage note**: Angular's generated `ngDevMode` signal-branch coverage noise is no longer skewing the branch baseline, so branch coverage is now a more reliable regression signal. Do not use that as a reason to skip meaningful behavior coverage.
@@ -70,6 +73,7 @@ Interpretation rules:
 
 ### Local Safety Policy
 
+- Use the installed `local-first-verification` skill when deciding how far to escalate local checks while iterating.
 - Do not run partial or targeted test commands as a normal workflow. Use the full suite commands (`npm test`, `npm run test:coverage`, `npm run verify`) unless the user explicitly asks for isolated debugging.
 - Run only one heavy test command at a time. Do not start a new `npm run verify` while another `verify`, coverage run, or full E2E run is still active.
 - Leave cooldown time between repeated `npm run verify` runs on local machines. Wait about 2 minutes after a failed or completed `verify` before starting the next one.


### PR DESCRIPTION
## Summary
- add five project-local workflow skills under `.agents/skills/`
- align AGENTS, CLAUDE, README, and docs so future sessions automatically use the right skill for testing, contract sync, verification depth, browser UI validation, and accessibility-first UI work
- reduce duplicated generic browser/testing instructions now owned by the new skills, while keeping repo-specific workflow rules in the docs

## What changed
- vendored these repo-local skills from `maestor/agent-skills`:
  - `intelligence-testing`
  - `api-contract-sync`
  - `local-first-verification`
  - `browser-ui-verification`
  - `accessibility-first-ui`
- documented `intelligence-testing` as the starting point for testing-related tasks
- documented when to use each new skill from repo instructions and contributor docs
- trimmed generic `agent-browser` walkthrough duplication from repo docs and pointed those cases to `browser-ui-verification`
- kept repo-specific Playwright, backend, port, review, and verification rules in place

## Testing
- not run (`npm run verify` skipped because both commits were docs/workflow-only)

## Commits
- `ca2c8b2` `Docs: Add project-local workflow skills`
- `ba04603` `Docs: Reduce duplicated skill instructions`
