### PR TITLE
Improvement: Codebase quality

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ This UI talks to a separate backend (see [node-fantrax-stats-parser](https://git
 - Vercel rewrites `/api/<path>` to a Serverless Function (`/api/proxy`) which:
 	- forwards the request to your real backend (`API_URL`)
 	- injects a secret `x-api-key` header (`API_KEY`) so the browser never sees the key
+	- only allows the UI's known read endpoints via `GET` and `OPTIONS`
+	- strips client `Authorization` and does not forward upstream `Set-Cookie` headers back to the browser
 
 **Vercel environment variables (required)**
 

--- a/angular.json
+++ b/angular.json
@@ -20,9 +20,7 @@
             "outputPath": "dist/fantrax-stats-parser-ui",
             "index": "src/index.html",
             "browser": "src/main.ts",
-            "polyfills": [
-              "zone.js"
-            ],
+            "polyfills": ["zone.js"],
             "tsConfig": "tsconfig.app.json",
             "inlineStyleLanguage": "scss",
             "assets": [
@@ -41,13 +39,10 @@
                 "output": "fonts"
               }
             ],
-            "styles": [
-              "src/theme.scss",
-              "src/styles.scss"
-            ],
+            "styles": ["src/theme.scss", "src/styles.scss"],
             "scripts": [],
             "server": "src/main.server.ts",
-            "outputMode": "static",
+            "outputMode": "static"
           },
           "configurations": {
             "production": {
@@ -101,13 +96,11 @@
           "options": {
             "tsConfig": "tsconfig.spec.json",
             "runnerConfig": "vitest.config.ts",
-            "setupFiles": [
-              "src/test-setup.ts"
-            ],
+            "setupFiles": ["src/test-setup.ts"],
             "coverageThresholds": {
               "branches": 85,
-              "statements": 93,
-              "functions": 94,
+              "statements": 94,
+              "functions": 95,
               "lines": 95
             },
             "coverageExclude": [

--- a/api/proxy.js
+++ b/api/proxy.js
@@ -16,6 +16,38 @@
  */
 
 const rateLimitState = new Map();
+const ALLOWED_METHODS = ['GET', 'OPTIONS'];
+const REPORT_TYPE_PATTERN = '(regular|playoffs|both)';
+const CAREER_HIGHLIGHT_TYPES = [
+  'most-teams-played',
+  'most-teams-owned',
+  'same-team-seasons-played',
+  'same-team-seasons-owned',
+  'most-stanley-cups',
+  'reunion-king',
+  'stash-king',
+  'regular-grinder-without-playoffs',
+  'most-trades',
+  'most-claims',
+  'most-drops',
+];
+const ALLOWED_PATH_PATTERNS = [
+  /^teams$/,
+  /^last-modified$/,
+  /^leaderboard\/(regular|playoffs|transactions|finals)$/,
+  new RegExp(`^seasons/${REPORT_TYPE_PATTERN}$`),
+  new RegExp(`^players/combined/${REPORT_TYPE_PATTERN}$`),
+  new RegExp(`^players/season/${REPORT_TYPE_PATTERN}/\\d{4}$`),
+  new RegExp(`^goalies/combined/${REPORT_TYPE_PATTERN}$`),
+  new RegExp(`^goalies/season/${REPORT_TYPE_PATTERN}/\\d{4}$`),
+  /^career\/players$/,
+  /^career\/goalies$/,
+  new RegExp(
+    `^career/highlights/(${CAREER_HIGHLIGHT_TYPES.map(escapeForRegExp).join('|')})$`,
+  ),
+  /^draft\/original$/,
+  /^draft\/entry$/,
+];
 
 function toOrigin(value) {
   if (!value) return null;
@@ -82,8 +114,8 @@ function applyCors(req, res, allowedOrigins) {
     res.setHeader('access-control-allow-origin', requestOrigin);
     res.setHeader('vary', 'Origin');
   }
-  res.setHeader('access-control-allow-methods', 'GET,POST,PUT,PATCH,DELETE,OPTIONS');
-  res.setHeader('access-control-allow-headers', 'content-type,authorization');
+  res.setHeader('access-control-allow-methods', ALLOWED_METHODS.join(','));
+  res.setHeader('access-control-allow-headers', 'content-type');
   res.setHeader('access-control-max-age', '86400');
 }
 
@@ -154,19 +186,19 @@ function joinPaths(basePathname, extraPath) {
   return `${a.startsWith('/') ? a : `/${a}`}/${b}`;
 }
 
+function normalizeProxyPath(path) {
+  return String(path || '').replace(/^\/+/, '').replace(/\/+$/, '');
+}
+
+function isAllowedProxyPath(path) {
+  const normalizedPath = normalizeProxyPath(path);
+  return ALLOWED_PATH_PATTERNS.some((pattern) => pattern.test(normalizedPath));
+}
+
 function sendJson(res, statusCode, body) {
   res.statusCode = statusCode;
   res.setHeader('content-type', 'application/json');
   res.end(JSON.stringify(body));
-}
-
-function readRawBody(req) {
-  return new Promise((resolve, reject) => {
-    const chunks = [];
-    req.on('data', (chunk) => chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)));
-    req.on('end', () => resolve(Buffer.concat(chunks)));
-    req.on('error', reject);
-  });
 }
 
 async function handler(req, res) {
@@ -182,9 +214,19 @@ async function handler(req, res) {
     // other websites from using your proxy via browser fetch.
     applyCors(req, res, allowedOrigins);
 
-    if (String(req.method || '').toUpperCase() === 'OPTIONS') {
+    const method = String(req.method || '').toUpperCase();
+
+    if (method === 'OPTIONS') {
       res.statusCode = 204;
       res.end();
+      return;
+    }
+
+    if (method !== 'GET') {
+      sendJson(res, 405, {
+        error: 'Method not allowed',
+        allowedMethods: ALLOWED_METHODS,
+      });
       return;
     }
 
@@ -242,8 +284,16 @@ async function handler(req, res) {
     }
 
     const incomingUrl = new URL(req.url || '/', 'http://localhost');
-    const path = incomingUrl.searchParams.get('path') || '';
+    const path = normalizeProxyPath(incomingUrl.searchParams.get('path') || '');
     incomingUrl.searchParams.delete('path');
+
+    if (!isAllowedProxyPath(path)) {
+      sendJson(res, 404, {
+        error: 'Path not allowed',
+        path,
+      });
+      return;
+    }
 
     const target = new URL(base.toString());
     target.pathname = joinPaths(target.pathname, path);
@@ -252,9 +302,6 @@ async function handler(req, res) {
     }
 
     console.log('[proxy] forward', { method: req.method, target: target.toString() });
-
-    const method = String(req.method || 'GET').toUpperCase();
-
     const headers = {
       'x-api-key': apiKey,
     };
@@ -265,14 +312,7 @@ async function handler(req, res) {
     const accept = normalizeHeader(req.headers['accept']);
     if (accept) headers['accept'] = accept;
 
-    const auth = normalizeHeader(req.headers['authorization']);
-    if (auth) headers['authorization'] = auth;
-
     const init = { method, headers };
-
-    if (!['GET', 'HEAD'].includes(method)) {
-      init.body = await readRawBody(req);
-    }
 
     let upstream;
     try {
@@ -294,9 +334,6 @@ async function handler(req, res) {
 
     const cc = upstream.headers.get('cache-control');
     if (cc) res.setHeader('cache-control', cc);
-
-    const setCookie = upstream.headers.get('set-cookie');
-    if (setCookie) res.setHeader('set-cookie', setCookie);
 
     const data = Buffer.from(await upstream.arrayBuffer());
     res.end(data);

--- a/api/proxy.spec.js
+++ b/api/proxy.spec.js
@@ -1,0 +1,192 @@
+import { Readable } from 'node:stream';
+import { createRequire } from 'node:module';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const require = createRequire(import.meta.url);
+const proxyModule = require('./proxy.js');
+const handler = proxyModule;
+
+function createRequest({
+  method = 'GET',
+  url = '/api/proxy?path=teams',
+  headers = {},
+  body,
+  remoteAddress = '127.0.0.1',
+} = {}) {
+  const chunks = body ? [Buffer.from(body)] : [];
+  const req = Readable.from(chunks);
+  req.method = method;
+  req.url = url;
+  req.headers = headers;
+  req.socket = { remoteAddress };
+  return req;
+}
+
+function createResponse() {
+  return {
+    statusCode: 200,
+    headers: new Map(),
+    body: Buffer.alloc(0),
+    ended: false,
+    setHeader(name, value) {
+      this.headers.set(String(name).toLowerCase(), value);
+    },
+    getHeader(name) {
+      return this.headers.get(String(name).toLowerCase());
+    },
+    end(data) {
+      if (data !== undefined) {
+        this.body = Buffer.isBuffer(data) ? data : Buffer.from(String(data));
+      }
+      this.ended = true;
+    },
+  };
+}
+
+describe('Vercel proxy handler', () => {
+  const originalEnv = {
+    ALLOWED_ORIGINS: process.env.ALLOWED_ORIGINS,
+    API_KEY: process.env.API_KEY,
+    API_URL: process.env.API_URL,
+    RATE_LIMIT_MAX: process.env.RATE_LIMIT_MAX,
+    RATE_LIMIT_WINDOW_SEC: process.env.RATE_LIMIT_WINDOW_SEC,
+  };
+
+  beforeEach(() => {
+    process.env.ALLOWED_ORIGINS = 'https://ffhl-stats.vercel.app';
+    process.env.API_KEY = 'server-secret';
+    process.env.API_URL = 'https://backend.example.com/api';
+    process.env.RATE_LIMIT_MAX = '20';
+    process.env.RATE_LIMIT_WINDOW_SEC = '60';
+    vi.restoreAllMocks();
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  afterEach(() => {
+    process.env.ALLOWED_ORIGINS = originalEnv.ALLOWED_ORIGINS;
+    process.env.API_KEY = originalEnv.API_KEY;
+    process.env.API_URL = originalEnv.API_URL;
+    process.env.RATE_LIMIT_MAX = originalEnv.RATE_LIMIT_MAX;
+    process.env.RATE_LIMIT_WINDOW_SEC = originalEnv.RATE_LIMIT_WINDOW_SEC;
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('forwards allowlisted read endpoints with the server API key only', async () => {
+    fetch.mockResolvedValue(
+      new Response(JSON.stringify([{ id: '1', name: 'Colorado Avalanche' }]), {
+        status: 200,
+        headers: {
+          'cache-control': 'public, max-age=60',
+          'content-type': 'application/json',
+          'set-cookie': 'should-not-leak=1',
+        },
+      }),
+    );
+
+    const req = createRequest({
+      url: '/api/proxy?path=teams',
+      headers: {
+        origin: 'https://ffhl-stats.vercel.app',
+        accept: 'application/json',
+        authorization: 'Bearer browser-token',
+      },
+    });
+    const res = createResponse();
+
+    await handler(req, res);
+
+    expect(fetch).toHaveBeenCalledWith(
+      new URL('https://backend.example.com/api/teams'),
+      {
+        method: 'GET',
+        headers: {
+          accept: 'application/json',
+          'x-api-key': 'server-secret',
+        },
+      },
+    );
+    expect(res.statusCode).toBe(200);
+    expect(res.getHeader('access-control-allow-origin')).toBe(
+      'https://ffhl-stats.vercel.app',
+    );
+    expect(res.getHeader('set-cookie')).toBeUndefined();
+    expect(JSON.parse(res.body.toString('utf8'))).toEqual([
+      { id: '1', name: 'Colorado Avalanche' },
+    ]);
+  });
+
+  it('forwards allowlisted dynamic read endpoints with their query params', async () => {
+    fetch.mockResolvedValue(
+      new Response(JSON.stringify([]), {
+        status: 200,
+        headers: {
+          'content-type': 'application/json',
+        },
+      }),
+    );
+
+    const req = createRequest({
+      url: '/api/proxy?path=players/season/playoffs/2024&teamId=29',
+      headers: {
+        origin: 'https://ffhl-stats.vercel.app',
+      },
+    });
+    const res = createResponse();
+
+    await handler(req, res);
+
+    expect(fetch).toHaveBeenCalledWith(
+      new URL('https://backend.example.com/api/players/season/playoffs/2024?teamId=29'),
+      {
+        method: 'GET',
+        headers: {
+          'x-api-key': 'server-secret',
+        },
+      },
+    );
+    expect(res.statusCode).toBe(200);
+  });
+
+  it('rejects mutation methods before reaching the backend', async () => {
+    const req = createRequest({
+      method: 'POST',
+      url: '/api/proxy?path=teams',
+      headers: {
+        origin: 'https://ffhl-stats.vercel.app',
+        'content-type': 'application/json',
+      },
+      body: '{"name":"Should not be forwarded"}',
+    });
+    const res = createResponse();
+
+    await handler(req, res);
+
+    expect(fetch).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(405);
+    expect(JSON.parse(res.body.toString('utf8'))).toEqual({
+      error: 'Method not allowed',
+      allowedMethods: ['GET', 'OPTIONS'],
+    });
+  });
+
+  it('rejects unknown rewritten paths before reaching the backend', async () => {
+    const req = createRequest({
+      url: '/api/proxy?path=admin/secrets',
+      headers: {
+        origin: 'https://ffhl-stats.vercel.app',
+      },
+    });
+    const res = createResponse();
+
+    await handler(req, res);
+
+    expect(fetch).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(404);
+    expect(JSON.parse(res.body.toString('utf8'))).toEqual({
+      error: 'Path not allowed',
+      path: 'admin/secrets',
+    });
+  });
+});

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -44,29 +44,7 @@ These topics came from the 2026-04 codebase audit. They are intentionally scoped
 
 Detailed implementation notes live in local working memory at `docs/plans/2026-04-29-codebase-health-refactor-plan.md`.
 
-### Critical priority
-
-#### Fix per-game stat data corruption (~2-4h)
-
-`StatsService` currently derives per-game rows by dividing every non-fixed property by `games`. That turns non-numeric fields such as `id` into `NaN`, which can break row identity and comparison state when stats-per-game mode is active. Score breakdown objects are not used for points-per-game mode; the mode should rely on the existing `scoreAdjustedByGames` value instead of trying to recalculate or preserve score breakdowns for that view.
-
-Expected direction:
-- Add focused behavior coverage for stats-per-game rows preserving identity/meta fields and using `scoreAdjustedByGames` for score display/comparison.
-- Replace broad object-entry division with an allowlist of numeric stat fields or a typed stat-transform helper.
-- Drop or ignore unused score breakdown fields in the per-game view unless another real consumer still requires them.
-- Keep impossible fallback branches out of the final implementation.
-
 ### High priority
-
-#### Reduce initial bundle and root-shell eager imports (~1-2 days)
-
-The production build passes but warns that the initial bundle exceeds the `1 MB` warning budget. Audit evidence points to eager root-shell imports, eager settings drawer dependencies, global Material component theme output, and large shared Material modules.
-
-Expected direction:
-- Keep the root shell lightweight.
-- Lazy-load drawer content and route-specific controls where practical.
-- Split stats-only drawer dependencies away from browse-route startup.
-- Re-run `npm run build -- --stats-json` and compare initial bundle contributors before and after.
 
 #### Fix desktop layout shift in table routes (~4-8h)
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -46,15 +46,6 @@ Detailed implementation notes live in local working memory at `docs/plans/2026-0
 
 ### High priority
 
-#### Fix desktop layout shift in table routes (~4-8h)
-
-`npm run perf:audit` reported desktop CLS around `0.19-0.22` on `/`, `/career/players`, and `/leaderboards/regular`. The shift source is the table wrapper moving vertically while route headers, subtitles, and table content settle.
-
-Expected direction:
-- Reserve stable vertical space around route subtitle/tabs/table shells.
-- Verify the front page, career players, and regular leaderboards in the perf audit.
-- Avoid solving this with arbitrary fixed heights that hurt mobile or empty/error states.
-
 #### Harden the Vercel API proxy (~4-8h)
 
 The production proxy is intentionally server-side, but its forwarding surface is broader than the current UI appears to need: it accepts common mutation methods, forwards arbitrary paths, and passes through client `Authorization` while also injecting the server-side API key.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -46,15 +46,6 @@ Detailed implementation notes live in local working memory at `docs/plans/2026-0
 
 ### High priority
 
-#### Harden the Vercel API proxy (~4-8h)
-
-The production proxy is intentionally server-side, but its forwarding surface is broader than the current UI appears to need: it accepts common mutation methods, forwards arbitrary paths, and passes through client `Authorization` while also injecting the server-side API key.
-
-Expected direction:
-- Restrict allowed methods and paths to the public read endpoints used by this UI.
-- Stop forwarding client authorization unless a documented use case requires it.
-- Keep CORS and rate-limit behavior covered with focused proxy tests or script-level checks.
-
 ### Medium priority
 
 #### Decompose `StatsTableComponent` (~1-3 days)

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -12,66 +12,10 @@ Star/bookmark players, persisted in localStorage. Add a "Suosikit" filter toggle
 
 ### Low priority
 
-#### Extend Player Card Navigation (~3-4h)
-
-Additional navigation methods for player card: mouse drag/swipe gestures and optional visible navigation buttons (← →) for mouse-only users. Configurable via settings. Lower priority since keyboard and touch/trackpad already provide full navigation capability.
-
 #### URL-Persisted Filter State (~4-6h)
 
 Encode stats table filter state (team, season, report type, per-game mode, etc.) in URL query parameters so users can share and bookmark specific views. Lower priority since player card deep linking already exists.
 
-#### Manual Dark/Light Mode Toggle (~2-3h)
-
-Override the current auto-only system-preference-based theme. Persist choice in localStorage.
-
 #### Remember Sort Column (~1-2h)
 
 Persist the user's last sort column and direction per table (players/goalies) in localStorage across sessions.
-
-## E2E Testing
-
-### Test data management
-
-- Add test data builder utilities
-
-### Advanced testing
-
-- Visual regression testing (Playwright screenshot comparison)
-
-## Codebase health and refactoring
-
-These topics came from the 2026-04 codebase audit. They are intentionally scoped so a future session can pick one priority band, read the linked local plan, and implement it without needing the original audit conversation.
-
-Detailed implementation notes live in local working memory at `docs/plans/2026-04-29-codebase-health-refactor-plan.md`.
-
-### High priority
-
-### Medium priority
-
-#### Decompose `StatsTableComponent` (~1-3 days)
-
-`StatsTableComponent` owns too many responsibilities: table rendering, filtering, sorting, loading progress, expansion, keyboard navigation, player-card lazy opening, prefetching, and focus restoration. It is well covered but high blast radius.
-
-Expected direction:
-- Extract behavior by responsibility rather than by line count.
-- Keep existing accessibility behavior protected before moving code.
-- Prefer helpers/directives/services that match the current table split instead of building a universal table abstraction.
-
-#### Move chart colors to shared theme tokens (~2-4h)
-
-Player-card graph code still hard-codes chart colors. Future chart work should use shared app/theme chart tokens so light and dark mode stay consistent.
-
-Expected direction:
-- Define a small shared chart palette through theme/app tokens.
-- Read those tokens where Chart.js datasets are built.
-- Validate player-card graphs in light and dark mode.
-
-### Low priority
-
-#### Track dev/build dependency advisories (~1-2h)
-
-`npm audit` reports a moderate PostCSS advisory through the Angular build toolchain. It is not a runtime app dependency, but it should be cleared when Angular/Vite/PostCSS updates make that safe.
-
-#### Make local perf tooling fully explicit (~1-2h)
-
-`npm run perf:audit` uses `npx tsx`, which may download `tsx` in a fresh environment. Add `tsx` as a dev dependency or replace the command with already-installed tooling so performance audits are reproducible offline after install.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -37,3 +37,81 @@ Persist the user's last sort column and direction per table (players/goalies) in
 ### Advanced testing
 
 - Visual regression testing (Playwright screenshot comparison)
+
+## Codebase health and refactoring
+
+These topics came from the 2026-04 codebase audit. They are intentionally scoped so a future session can pick one priority band, read the linked local plan, and implement it without needing the original audit conversation.
+
+Detailed implementation notes live in local working memory at `docs/plans/2026-04-29-codebase-health-refactor-plan.md`.
+
+### Critical priority
+
+#### Fix per-game stat data corruption (~2-4h)
+
+`StatsService` currently derives per-game rows by dividing every non-fixed property by `games`. That turns non-numeric fields such as `id` into `NaN`, which can break row identity and comparison state when stats-per-game mode is active. Score breakdown objects are not used for points-per-game mode; the mode should rely on the existing `scoreAdjustedByGames` value instead of trying to recalculate or preserve score breakdowns for that view.
+
+Expected direction:
+- Add focused behavior coverage for stats-per-game rows preserving identity/meta fields and using `scoreAdjustedByGames` for score display/comparison.
+- Replace broad object-entry division with an allowlist of numeric stat fields or a typed stat-transform helper.
+- Drop or ignore unused score breakdown fields in the per-game view unless another real consumer still requires them.
+- Keep impossible fallback branches out of the final implementation.
+
+### High priority
+
+#### Reduce initial bundle and root-shell eager imports (~1-2 days)
+
+The production build passes but warns that the initial bundle exceeds the `1 MB` warning budget. Audit evidence points to eager root-shell imports, eager settings drawer dependencies, global Material component theme output, and large shared Material modules.
+
+Expected direction:
+- Keep the root shell lightweight.
+- Lazy-load drawer content and route-specific controls where practical.
+- Split stats-only drawer dependencies away from browse-route startup.
+- Re-run `npm run build -- --stats-json` and compare initial bundle contributors before and after.
+
+#### Fix desktop layout shift in table routes (~4-8h)
+
+`npm run perf:audit` reported desktop CLS around `0.19-0.22` on `/`, `/career/players`, and `/leaderboards/regular`. The shift source is the table wrapper moving vertically while route headers, subtitles, and table content settle.
+
+Expected direction:
+- Reserve stable vertical space around route subtitle/tabs/table shells.
+- Verify the front page, career players, and regular leaderboards in the perf audit.
+- Avoid solving this with arbitrary fixed heights that hurt mobile or empty/error states.
+
+#### Harden the Vercel API proxy (~4-8h)
+
+The production proxy is intentionally server-side, but its forwarding surface is broader than the current UI appears to need: it accepts common mutation methods, forwards arbitrary paths, and passes through client `Authorization` while also injecting the server-side API key.
+
+Expected direction:
+- Restrict allowed methods and paths to the public read endpoints used by this UI.
+- Stop forwarding client authorization unless a documented use case requires it.
+- Keep CORS and rate-limit behavior covered with focused proxy tests or script-level checks.
+
+### Medium priority
+
+#### Decompose `StatsTableComponent` (~1-3 days)
+
+`StatsTableComponent` owns too many responsibilities: table rendering, filtering, sorting, loading progress, expansion, keyboard navigation, player-card lazy opening, prefetching, and focus restoration. It is well covered but high blast radius.
+
+Expected direction:
+- Extract behavior by responsibility rather than by line count.
+- Keep existing accessibility behavior protected before moving code.
+- Prefer helpers/directives/services that match the current table split instead of building a universal table abstraction.
+
+#### Move chart colors to shared theme tokens (~2-4h)
+
+Player-card graph code still hard-codes chart colors. Future chart work should use shared app/theme chart tokens so light and dark mode stay consistent.
+
+Expected direction:
+- Define a small shared chart palette through theme/app tokens.
+- Read those tokens where Chart.js datasets are built.
+- Validate player-card graphs in light and dark mode.
+
+### Low priority
+
+#### Track dev/build dependency advisories (~1-2h)
+
+`npm audit` reports a moderate PostCSS advisory through the Angular build toolchain. It is not a runtime app dependency, but it should be cleared when Angular/Vite/PostCSS updates make that safe.
+
+#### Make local perf tooling fully explicit (~1-2h)
+
+`npm run perf:audit` uses `npx tsx`, which may download `tsx` in a fresh environment. Add `tsx` as a dev dependency or replace the command with already-installed tooling so performance audits are reproducible offline after install.

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -16,12 +16,8 @@
     (openedStart)="onSettingsDrawerOpenedStart()"
     (openedChange)="onSettingsDrawerOpenedChange($event)"
   >
-    @if (hasInitializedSettingsDrawerContent) {
-      <app-settings-drawer
-        [mode]="settingsDrawerRouteConfig.mode"
-        [statsContext]="settingsDrawerRouteConfig.statsContext"
-        (closeRequested)="closeSettingsDrawer()"
-      />
+    @if (hasInitializedSettingsDrawerContent && settingsDrawerComponent; as drawerComponent) {
+      <ng-container *ngComponentOutlet="drawerComponent; inputs: settingsDrawerInputs" />
     }
   </mat-sidenav>
 

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,5 +1,5 @@
-import { AsyncPipe, DOCUMENT } from '@angular/common';
-import { Component, DestroyRef, ElementRef, Injector, OnInit, ViewChild, inject } from '@angular/core';
+import { AsyncPipe, DOCUMENT, NgComponentOutlet } from '@angular/common';
+import { Component, DestroyRef, ElementRef, Injector, OnInit, Type, ViewChild, inject } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { MatBottomSheet, MatBottomSheetModule } from '@angular/material/bottom-sheet';
 import { MatButtonModule } from '@angular/material/button';
@@ -33,7 +33,6 @@ import { FooterVisibilityService } from '@services/footer-visibility.service';
 import { PwaUpdateService } from '@services/pwa-update.service';
 import { SeoService } from '@services/seo.service';
 import { TeamService } from '@services/team.service';
-import { SettingsDrawerComponent } from '@shared/settings-drawer/settings-drawer.component';
 import {
   getSettingsDrawerRouteConfig,
   resolveRootRouteGroup,
@@ -58,6 +57,15 @@ let globalNavComponentPromise: Promise<
 function loadGlobalNavComponent() {
   globalNavComponentPromise ??= import('@shared/global-nav/global-nav.component');
   return globalNavComponentPromise;
+}
+
+let settingsDrawerComponentPromise: Promise<
+  typeof import('@shared/settings-drawer/settings-drawer.component')
+> | null = null;
+
+function loadSettingsDrawerComponent() {
+  settingsDrawerComponentPromise ??= import('@shared/settings-drawer/settings-drawer.component');
+  return settingsDrawerComponentPromise;
 }
 
 type RootRouteUiState = {
@@ -116,6 +124,7 @@ export function buildRootRouteUiState(url: string): RootRouteUiState {
   imports: [
     RouterOutlet,
     AsyncPipe,
+    NgComponentOutlet,
     TranslateModule,
     MatDialogModule,
     MatButtonModule,
@@ -125,7 +134,6 @@ export function buildRootRouteUiState(url: string): RootRouteUiState {
     MatTooltipModule,
     MatBottomSheetModule,
     FooterComponent,
-    SettingsDrawerComponent,
   ],
   templateUrl: './app.component.html',
   styleUrl: './app.component.scss',
@@ -190,10 +198,19 @@ export class AppComponent implements OnInit {
   private readonly translateService = inject(TranslateService);
   private readonly router = inject(Router);
   private readonly footerVisibilityService = inject(FooterVisibilityService);
+  settingsDrawerComponent: Type<unknown> | null = null;
 
   hasInitializedSettingsDrawerContent = false;
   isSettingsDrawerOpen = false;
   isSettingsDrawerSurfaceVisible = false;
+
+  get settingsDrawerInputs(): Record<string, unknown> {
+    return {
+      mode: this.settingsDrawerRouteConfig.mode,
+      statsContext: this.settingsDrawerRouteConfig.statsContext,
+      closeDrawer: () => this.closeSettingsDrawer(),
+    };
+  }
 
   ngOnInit(): void {
     void this.seoService;
@@ -354,6 +371,7 @@ export class AppComponent implements OnInit {
 
   toggleSettingsDrawer(): void {
     this.hasInitializedSettingsDrawerContent = true;
+    void this.ensureSettingsDrawerContentLoaded();
 
     if (!(this.settingsDrawer?.opened ?? this.isSettingsDrawerOpen)) {
       this.isSettingsDrawerSurfaceVisible = true;
@@ -392,6 +410,15 @@ export class AppComponent implements OnInit {
     }
 
     void this.injector.get(StartFromSeasonSyncService);
+  }
+
+  private async ensureSettingsDrawerContentLoaded(): Promise<void> {
+    if (this.settingsDrawerComponent) {
+      return;
+    }
+
+    const { SettingsDrawerComponent } = await loadSettingsDrawerComponent();
+    this.settingsDrawerComponent = SettingsDrawerComponent;
   }
 
   private restoreFocusAfterSettingsDrawerClose(): void {

--- a/src/app/services/comparison.service.ts
+++ b/src/app/services/comparison.service.ts
@@ -2,10 +2,9 @@ import { computed, DestroyRef, inject, Injectable, signal } from '@angular/core'
 import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
 import { distinctUntilChanged, map, skip } from 'rxjs';
 import { Player, Goalie } from './api.service';
-import { TeamService } from './team.service';
 import { FilterService } from './filter.service';
+import { TeamService } from './team.service';
 import { SettingsService } from './settings.service';
-import { StatsService } from './stats.service';
 
 export type OrderedComparison = {
   playerA: Player | Goalie;
@@ -15,10 +14,9 @@ export type OrderedComparison = {
 @Injectable({ providedIn: 'root' })
 export class ComparisonService {
   private readonly destroyRef = inject(DestroyRef);
-  private readonly teamService = inject(TeamService);
   private readonly filterService = inject(FilterService);
+  private readonly teamService = inject(TeamService);
   private readonly settingsService = inject(SettingsService);
-  private readonly statsService = inject(StatsService);
 
   private readonly selectedPlayersState = signal<(Player | Goalie)[]>([]);
   readonly selectionSignal = this.selectedPlayersState.asReadonly();
@@ -29,29 +27,11 @@ export class ComparisonService {
 
   readonly orderedSelectionSignal = computed<OrderedComparison | null>(() => {
     const selection = this.selectionSignal();
-    const playerFilters = this.filterService.playerFiltersSignal();
-    const goalieFilters = this.filterService.goalieFiltersSignal();
 
     if (selection.length < 2) {
       return null;
     }
-    let [a, b] = selection;
-
-    // Check if we should use per-game stats
-    const isGoalie = (p: Player | Goalie): p is Goalie => 'wins' in p;
-    const aIsGoalie = isGoalie(a);
-    const bIsGoalie = isGoalie(b);
-    const statsPerGame = aIsGoalie ? goalieFilters.statsPerGame : playerFilters.statsPerGame;
-
-    if (statsPerGame) {
-      // Transform to per-game stats
-      a = aIsGoalie
-        ? this.statsService.getGoalieStatsPerGame([a as Goalie])[0]
-        : this.statsService.getPlayerStatsPerGame([a as Player])[0];
-      b = bIsGoalie
-        ? this.statsService.getGoalieStatsPerGame([b as Goalie])[0]
-        : this.statsService.getPlayerStatsPerGame([b as Player])[0];
-    }
+    const [a, b] = selection;
 
     return a.score >= b.score
       ? { playerA: a, playerB: b }

--- a/src/app/services/stats.service.spec.ts
+++ b/src/app/services/stats.service.spec.ts
@@ -1,0 +1,64 @@
+import { TestBed } from '@angular/core/testing';
+
+import type { Goalie, Player } from './api.service';
+import { StatsService } from './stats.service';
+
+import playersFixture from '../../../e2e/fixtures/data/players--combined--regular.json';
+import goaliesFixtureData from '../../../e2e/fixtures/data/goalies--combined--regular--startFrom=2012.json';
+
+describe('StatsService', () => {
+  let service: StatsService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [StatsService],
+    });
+
+    service = TestBed.inject(StatsService);
+  });
+
+  it('preserves player identity fields while converting numeric stats to per-game values', () => {
+    const player = (playersFixture as Player[])[0];
+
+    const [result] = service.getPlayerStatsPerGame([player]);
+
+    expect(result.id).toBe(player.id);
+    expect(result.name).toBe(player.name);
+    expect(result.position).toBe(player.position);
+    expect(result.games).toBe(player.games);
+    expect(result.seasons).toBe(player.seasons);
+    expect(result.scores).toEqual(player.scores);
+    expect(result.score).toBe(player.scoreAdjustedByGames);
+    expect(result.scoreAdjustedByGames).toBe(player.scoreAdjustedByGames);
+    expect(result.goals).toBe(Number((player.goals / player.games).toFixed(2)));
+    expect(result.blocks).toBe(Number((player.blocks / player.games).toFixed(2)));
+  });
+
+  it('keeps goalie rate fields intact and avoids NaN/Infinity when games are zero', () => {
+    const goalieSeason = {
+      ...(goaliesFixtureData as Goalie[])[0].seasons?.[0],
+      name: 'Jake Oettinger',
+      games: 0,
+      wins: 6,
+      saves: 396,
+      shutouts: 1,
+      goals: 0,
+      assists: 0,
+      points: 0,
+      penalties: 2,
+      ppp: 0,
+      shp: 0,
+    } as Goalie;
+
+    const [result] = service.getGoalieStatsPerGame([goalieSeason]);
+
+    expect(result.id).toBe(goalieSeason.id);
+    expect(result.gaa).toBe(goalieSeason.gaa);
+    expect(result.savePercent).toBe(goalieSeason.savePercent);
+    expect(result.wins).toBe(0);
+    expect(result.saves).toBe(0);
+    expect(result.shutouts).toBe(0);
+    expect(result.penalties).toBe(0);
+    expect(result.score).toBe(goalieSeason.scoreAdjustedByGames);
+  });
+});

--- a/src/app/services/stats.service.ts
+++ b/src/app/services/stats.service.ts
@@ -1,49 +1,68 @@
 import { Injectable } from '@angular/core';
 import { Player, Goalie } from './api.service';
 
+const COMMON_PER_GAME_FIELDS = [
+  'goals',
+  'assists',
+  'points',
+  'penalties',
+  'ppp',
+  'shp',
+] as const;
+
+const PLAYER_PER_GAME_FIELDS = [
+  ...COMMON_PER_GAME_FIELDS,
+  'plusMinus',
+  'shots',
+  'hits',
+  'blocks',
+] as const satisfies readonly (keyof Player)[];
+
+const GOALIE_PER_GAME_FIELDS = [
+  ...COMMON_PER_GAME_FIELDS,
+  'wins',
+  'saves',
+  'shutouts',
+] as const satisfies readonly (keyof Goalie)[];
+
 @Injectable({
   providedIn: 'root',
 })
 export class StatsService {
   getPlayerStatsPerGame(data: Player[]): Player[] {
-    return this.getStatsPerGame(data, [
-      'name',
-      'season',
-      'games',
-      'plusMinus',
-      'position',
-      'scoreByPosition',
-      'scoreByPositionAdjustedByGames',
-      'scoresByPosition',
-    ]);
+    return this.getStatsPerGame(data, PLAYER_PER_GAME_FIELDS);
   }
 
   getGoalieStatsPerGame(data: Goalie[]): Goalie[] {
-    return this.getStatsPerGame(data, ['name', 'season', 'games', 'gaa', 'savePercent']);
+    return this.getStatsPerGame(data, GOALIE_PER_GAME_FIELDS);
   }
 
   private getStatsPerGame<
-    T extends { games: number; scoreAdjustedByGames: number, season?: number }
-  >(data: T[], fixedFields: string[]): T[] {
+    T extends { games: number; score: number; scoreAdjustedByGames: number }
+  >(data: T[], statFields: readonly (keyof T)[]): T[] {
     return data.map((item) => {
-      const { games, scoreAdjustedByGames, season, ...rest } = item;
-      // Create the per-game stats for the dynamic fields
-      const perGameStats = Object.fromEntries(
-        Object.entries(rest).map(([key, value]) => [
-          key,
-          this.format((value as number) / games),
-        ])
-      );
+      const perGameItem = {
+        ...item,
+        score: item.scoreAdjustedByGames,
+      } as T;
 
-      // Combine the fixed fields with the per-game stats
-      return {
-        ...perGameStats,
-        score: scoreAdjustedByGames,
-        scoreAdjustedByGames: scoreAdjustedByGames,
-        seasons: (item as Record<string, unknown>)['seasons'], // Preserve seasons if they exist
-        ...Object.fromEntries(fixedFields.map((field) => [field, (item as Record<string, unknown>)[field]])),
-      } as unknown as T;
+      statFields.forEach((field) => {
+        const value = item[field];
+        if (typeof value === 'number') {
+          perGameItem[field] = this.toPerGameValue(value, item.games) as T[keyof T];
+        }
+      });
+
+      return perGameItem;
     });
+  }
+
+  private toPerGameValue(value: number, games: number): number {
+    if (games <= 0) {
+      return 0;
+    }
+
+    return this.format(value / games);
   }
 
   private format(value: number) {

--- a/src/app/shared/comparison-bar/comparison-bar.component.spec.ts
+++ b/src/app/shared/comparison-bar/comparison-bar.component.spec.ts
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/angular';
+import { fireEvent, render, screen, within } from '@testing-library/angular';
 
 import { AppComponent } from '../../app.component';
 import {
@@ -126,6 +126,10 @@ describe('Comparison flow — desktop user behavior', { timeout: 150_000 }, () =
 
   it('shows stats-only comparison content when stats-per-game is enabled', async () => {
     const { fixture } = await render(AppComponent, getBehaviorTestConfig({ isMobile: false }));
+    const selectedPlayers = slicedPlayers.slice(0, 2);
+    const expectedPerGameGoals = selectedPlayers.map((player) =>
+      (player.goals / player.games).toFixed(2)
+    );
 
     await waitForBehaviorAssertion(fixture, () => {
       expect(screen.getByText(slicedPlayers[0].name)).toBeInTheDocument();
@@ -136,12 +140,32 @@ describe('Comparison flow — desktop user behavior', { timeout: 150_000 }, () =
     fireEvent.click(statsModeToggle);
 
     await vi.waitFor(() => {
+      fixture.detectChanges();
       expect(statsModeToggle).toHaveAttribute('aria-checked', 'true');
+      const updatedFirstPlayerRow = screen
+        .getByText(selectedPlayers[0].name)
+        .closest('tr');
+
+      expect(updatedFirstPlayerRow).not.toBeNull();
+      expect(
+        within(updatedFirstPlayerRow as HTMLElement).getByText(expectedPerGameGoals[0])
+      ).toBeInTheDocument();
     });
 
-    const [firstCheckbox, secondCheckbox] = screen.getAllByRole('checkbox');
-    fireEvent.click(firstCheckbox);
-    fireEvent.click(secondCheckbox);
+    const firstPlayerRow = screen.getByText(selectedPlayers[0].name).closest('tr');
+    const secondPlayerRow = screen.getByText(selectedPlayers[1].name).closest('tr');
+
+    expect(firstPlayerRow).not.toBeNull();
+    expect(secondPlayerRow).not.toBeNull();
+
+    fireEvent.click(within(firstPlayerRow as HTMLElement).getByRole('checkbox'));
+    fireEvent.click(within(secondPlayerRow as HTMLElement).getByRole('checkbox'));
+
+    await vi.waitFor(() => {
+      expect(screen.getByRole('status')).toHaveTextContent(selectedPlayers[0].name);
+      expect(screen.getByRole('status')).toHaveTextContent(selectedPlayers[1].name);
+    });
+
     fireEvent.click(screen.getByRole('button', { name: 'comparison.compare' }));
 
     await screen.findByRole('button', { name: 'a11y.closeComparisonDialog' }, { timeout: 15000 });
@@ -152,5 +176,14 @@ describe('Comparison flow — desktop user behavior', { timeout: 150_000 }, () =
     expect(
       screen.getByText('tableColumn.scoreAdjustedByGames', { selector: '.stat-label' })
     ).toBeInTheDocument();
+
+    const goalsRow = screen
+      .getByText('tableColumn.goals', { selector: '.stat-label' })
+      .closest('.stat-row-desktop');
+
+    expect(goalsRow).not.toBeNull();
+    expectedPerGameGoals.forEach((goalsValue) => {
+      expect(within(goalsRow as HTMLElement).getByText(goalsValue)).toBeInTheDocument();
+    });
   });
 });

--- a/src/app/shared/comparison-dialog/comparison-radar/comparison-radar.component.ts
+++ b/src/app/shared/comparison-dialog/comparison-radar/comparison-radar.component.ts
@@ -5,6 +5,10 @@ import type { ChartConfiguration, ChartData, TooltipItem } from 'chart.js';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import type { Player, Goalie, PlayerScores } from '@services/api.service';
 import { StatsContext } from '@shared/types/context.types';
+import {
+  getChartSeriesColors,
+  resolveThemedCssColorVar,
+} from '@shared/utils/chart-theme.utils';
 
 @Component({
   selector: 'app-comparison-radar',
@@ -30,9 +34,14 @@ export class ComparisonRadarComponent implements OnInit {
   }
 
   private buildRadarChartOptions(): void {
-    const textColor = this.resolveCssColorVar('--mat-sys-on-surface', '#1f1f1f');
-    const gridColor = this.resolveCssColorVar('--mat-sys-outline-variant', 'rgba(0,0,0,0.2)');
-    const tooltipBg = this.resolveCssColorVar(
+    const textColor = resolveThemedCssColorVar(this.document, '--mat-sys-on-surface', '#1f1f1f');
+    const gridColor = resolveThemedCssColorVar(
+      this.document,
+      '--mat-sys-outline-variant',
+      'rgba(0,0,0,0.2)',
+    );
+    const tooltipBg = resolveThemedCssColorVar(
+      this.document,
       '--mat-sys-surface-container-high',
       'rgba(0,0,0,0.8)',
       'backgroundColor',
@@ -118,32 +127,38 @@ export class ComparisonRadarComponent implements OnInit {
     this.radarChartData = {
       labels,
       datasets: [
-        {
+        (() => {
+          const seriesColors = getChartSeriesColors(this.document, 0);
+          return {
           label: playerA.name,
           data: dataA,
           fill: true,
-          backgroundColor: 'rgba(25, 118, 210, 0.3)',
-          borderColor: '#1976d2',
-          pointBackgroundColor: '#1976d2',
-          pointBorderColor: '#fff',
-          pointHoverBackgroundColor: '#fff',
-          pointHoverBorderColor: '#1976d2',
+          backgroundColor: seriesColors.fillColor,
+          borderColor: seriesColors.lineColor,
+          pointBackgroundColor: seriesColors.pointBackgroundColor,
+          pointBorderColor: seriesColors.pointBorderColor,
+          pointHoverBackgroundColor: seriesColors.pointHoverBackgroundColor,
+          pointHoverBorderColor: seriesColors.pointHoverBorderColor,
           pointRadius: 4,
           pointHoverRadius: 6,
-        },
-        {
+          };
+        })(),
+        (() => {
+          const seriesColors = getChartSeriesColors(this.document, 1);
+          return {
           label: playerB.name,
           data: dataB,
           fill: true,
-          backgroundColor: 'rgba(255, 152, 0, 0.3)',
-          borderColor: '#ff9800',
-          pointBackgroundColor: '#ff9800',
-          pointBorderColor: '#fff',
-          pointHoverBackgroundColor: '#fff',
-          pointHoverBorderColor: '#ff9800',
+          backgroundColor: seriesColors.fillColor,
+          borderColor: seriesColors.lineColor,
+          pointBackgroundColor: seriesColors.pointBackgroundColor,
+          pointBorderColor: seriesColors.pointBorderColor,
+          pointHoverBackgroundColor: seriesColors.pointHoverBackgroundColor,
+          pointHoverBorderColor: seriesColors.pointHoverBorderColor,
           pointRadius: 4,
           pointHoverRadius: 6,
-        },
+          };
+        })(),
       ],
     };
   }
@@ -171,65 +186,39 @@ export class ComparisonRadarComponent implements OnInit {
     this.radarChartData = {
       labels,
       datasets: [
-        {
+        (() => {
+          const seriesColors = getChartSeriesColors(this.document, 0);
+          return {
           label: goalieA.name,
           data: dataA,
           fill: true,
-          backgroundColor: 'rgba(25, 118, 210, 0.3)',
-          borderColor: '#1976d2',
-          pointBackgroundColor: '#1976d2',
-          pointBorderColor: '#fff',
-          pointHoverBackgroundColor: '#fff',
-          pointHoverBorderColor: '#1976d2',
+          backgroundColor: seriesColors.fillColor,
+          borderColor: seriesColors.lineColor,
+          pointBackgroundColor: seriesColors.pointBackgroundColor,
+          pointBorderColor: seriesColors.pointBorderColor,
+          pointHoverBackgroundColor: seriesColors.pointHoverBackgroundColor,
+          pointHoverBorderColor: seriesColors.pointHoverBorderColor,
           pointRadius: 4,
           pointHoverRadius: 6,
-        },
-        {
+          };
+        })(),
+        (() => {
+          const seriesColors = getChartSeriesColors(this.document, 1);
+          return {
           label: goalieB.name,
           data: dataB,
           fill: true,
-          backgroundColor: 'rgba(255, 152, 0, 0.3)',
-          borderColor: '#ff9800',
-          pointBackgroundColor: '#ff9800',
-          pointBorderColor: '#fff',
-          pointHoverBackgroundColor: '#fff',
-          pointHoverBorderColor: '#ff9800',
+          backgroundColor: seriesColors.fillColor,
+          borderColor: seriesColors.lineColor,
+          pointBackgroundColor: seriesColors.pointBackgroundColor,
+          pointBorderColor: seriesColors.pointBorderColor,
+          pointHoverBackgroundColor: seriesColors.pointHoverBackgroundColor,
+          pointHoverBorderColor: seriesColors.pointHoverBorderColor,
           pointRadius: 4,
           pointHoverRadius: 6,
-        },
+          };
+        })(),
       ],
     };
-  }
-
-  private resolveCssColorVar(
-    name: string,
-    fallback: string,
-    cssProperty: 'color' | 'backgroundColor' = 'color',
-  ): string {
-    try {
-      const body = this.document.body;
-      if (!body) return fallback;
-
-      const probe = this.document.createElement('span');
-      probe.setAttribute('aria-hidden', 'true');
-      probe.style.position = 'absolute';
-      probe.style.width = '0';
-      probe.style.height = '0';
-      probe.style.overflow = 'hidden';
-
-      if (cssProperty === 'backgroundColor') {
-        probe.style.backgroundColor = `var(${name})`;
-      } else {
-        probe.style.color = `var(${name})`;
-      }
-
-      body.appendChild(probe);
-      const computed = getComputedStyle(probe)[cssProperty];
-      probe.remove();
-
-      return computed?.trim() ? computed.trim() : fallback;
-    } catch {
-      return fallback;
-    }
   }
 }

--- a/src/app/shared/player-card/player-card-graphs/player-card-graphs.component.ts
+++ b/src/app/shared/player-card/player-card-graphs/player-card-graphs.component.ts
@@ -21,6 +21,10 @@ import type {
 } from '@services/api.service';
 import type { PositionFilter } from '@services/filter.service';
 import { formatSeasonShort } from '@shared/utils/season.utils';
+import {
+  getChartSeriesColors,
+  resolveThemedCssColorVar,
+} from '@shared/utils/chart-theme.utils';
 
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
@@ -346,9 +350,14 @@ export class PlayerCardGraphsComponent implements AfterViewInit, OnDestroy {
   }
 
   private applyThemeToChartOptions(): void {
-    const textColor = this.resolveCssColorVar('--mat-sys-on-surface', '#1f1f1f');
-    const gridColor = this.resolveCssColorVar('--mat-sys-outline-variant', 'rgba(0,0,0,0.2)');
-    const tooltipBg = this.resolveCssColorVar(
+    const textColor = resolveThemedCssColorVar(this.document, '--mat-sys-on-surface', '#1f1f1f');
+    const gridColor = resolveThemedCssColorVar(
+      this.document,
+      '--mat-sys-outline-variant',
+      'rgba(0,0,0,0.2)',
+    );
+    const tooltipBg = resolveThemedCssColorVar(
+      this.document,
       '--mat-sys-surface-container-high',
       'rgba(0,0,0,0.8)',
       'backgroundColor',
@@ -406,88 +415,15 @@ export class PlayerCardGraphsComponent implements AfterViewInit, OnDestroy {
     };
   }
 
-  private resolveCssColorVar(
-    name: string,
-    fallback: string,
-    cssProperty: 'color' | 'backgroundColor' = 'color',
-  ): string {
-    try {
-      const body = this.document.body;
-      if (!body) {
-        return fallback;
-      }
-
-      const root = this.document.documentElement;
-      const rootStyle = root ? getComputedStyle(root) : undefined;
-      const computedSchemeRaw =
-        (rootStyle as CSSStyleDeclaration & { colorScheme?: string })?.colorScheme ||
-        rootStyle?.getPropertyValue('color-scheme') ||
-        '';
-      const schemeTokens = computedSchemeRaw.trim().split(/\s+/).filter(Boolean);
-      const schemeToken = schemeTokens.length === 1 ? schemeTokens[0] : undefined;
-
-      const scheme: 'light' | 'dark' | undefined =
-        schemeToken === 'dark' || schemeToken === 'light'
-          ? (schemeToken as 'light' | 'dark')
-          : undefined;
-
-      const usedScheme = this.detectUsedColorScheme(body, scheme);
-
-      const probe = this.createHiddenProbeElement();
-      if (usedScheme) {
-        probe.style.setProperty('color-scheme', usedScheme);
-      }
-
-      if (cssProperty === 'backgroundColor') {
-        probe.style.backgroundColor = `var(${name})`;
-      } else {
-        probe.style.color = `var(${name})`;
-      }
-
-      body.appendChild(probe);
-      const computed = getComputedStyle(probe)[cssProperty];
-      probe.remove();
-
-      return computed?.trim() ? computed.trim() : fallback;
-    } catch {
-      return fallback;
-    }
-  }
-
-  private createHiddenProbeElement(): HTMLSpanElement {
-    const el = this.document.createElement('span');
-    el.setAttribute('aria-hidden', 'true');
-    el.style.position = 'absolute';
-    el.style.width = '0';
-    el.style.height = '0';
-    el.style.overflow = 'hidden';
-    return el;
-  }
-
-  private detectUsedColorScheme(
-    body: HTMLElement,
-    knownScheme: 'light' | 'dark' | undefined,
-  ): 'light' | 'dark' | undefined {
-    if (knownScheme) {
-      return knownScheme;
-    }
-
-    const schemeProbe = this.createHiddenProbeElement();
-    schemeProbe.style.color = 'light-dark(rgb(1, 2, 3), rgb(4, 5, 6))';
-    body.appendChild(schemeProbe);
-
-    const observed = getComputedStyle(schemeProbe).color?.trim();
-    schemeProbe.remove();
-
-    if (observed === 'rgb(1, 2, 3)') return 'light';
-    if (observed === 'rgb(4, 5, 6)') return 'dark';
-    return undefined;
-  }
-
   private applyThemeToRadarChartOptions(): void {
-    const textColor = this.resolveCssColorVar('--mat-sys-on-surface', '#1f1f1f');
-    const outlineColor = this.resolveCssColorVar('--mat-sys-outline-variant', 'rgba(0,0,0,0.2)');
-    const tooltipBg = this.resolveCssColorVar(
+    const textColor = resolveThemedCssColorVar(this.document, '--mat-sys-on-surface', '#1f1f1f');
+    const outlineColor = resolveThemedCssColorVar(
+      this.document,
+      '--mat-sys-outline-variant',
+      'rgba(0,0,0,0.2)',
+    );
+    const tooltipBg = resolveThemedCssColorVar(
+      this.document,
       '--mat-sys-surface-container-high',
       'rgba(0,0,0,0.8)',
       'backgroundColor',
@@ -596,19 +532,22 @@ export class PlayerCardGraphsComponent implements AfterViewInit, OnDestroy {
     this.radarChartData = {
       labels,
       datasets: [
-        {
+        (() => {
+          const seriesColors = getChartSeriesColors(this.document, 0);
+          return {
           label: player.name,
           data,
           fill: true,
-          backgroundColor: 'rgba(25, 118, 210, 0.3)',
-          borderColor: '#1976d2',
-          pointBackgroundColor: '#1976d2',
-          pointBorderColor: '#fff',
-          pointHoverBackgroundColor: '#fff',
-          pointHoverBorderColor: '#1976d2',
+          backgroundColor: seriesColors.fillColor,
+          borderColor: seriesColors.lineColor,
+          pointBackgroundColor: seriesColors.pointBackgroundColor,
+          pointBorderColor: seriesColors.pointBorderColor,
+          pointHoverBackgroundColor: seriesColors.pointHoverBackgroundColor,
+          pointHoverBorderColor: seriesColors.pointHoverBorderColor,
           pointRadius: 4,
           pointHoverRadius: 6,
-        },
+          };
+        })(),
       ],
     };
   }
@@ -637,19 +576,22 @@ export class PlayerCardGraphsComponent implements AfterViewInit, OnDestroy {
     this.radarChartData = {
       labels,
       datasets: [
-        {
+        (() => {
+          const seriesColors = getChartSeriesColors(this.document, 0);
+          return {
           label: goalie.name,
           data,
           fill: true,
-          backgroundColor: 'rgba(25, 118, 210, 0.3)',
-          borderColor: '#1976d2',
-          pointBackgroundColor: '#1976d2',
-          pointBorderColor: '#fff',
-          pointHoverBackgroundColor: '#fff',
-          pointHoverBorderColor: '#1976d2',
+          backgroundColor: seriesColors.fillColor,
+          borderColor: seriesColors.lineColor,
+          pointBackgroundColor: seriesColors.pointBackgroundColor,
+          pointBorderColor: seriesColors.pointBorderColor,
+          pointHoverBackgroundColor: seriesColors.pointHoverBackgroundColor,
+          pointHoverBorderColor: seriesColors.pointHoverBorderColor,
           pointRadius: 4,
           pointHoverRadius: 6,
-        },
+          };
+        })(),
       ],
     };
   }
@@ -673,8 +615,6 @@ export class PlayerCardGraphsComponent implements AfterViewInit, OnDestroy {
 
   private updateChartData(sortedSeasons: (PlayerSeasonStats | GoalieSeasonStats)[]): void {
     const activeKeys = this.chartStatKeys.filter((key) => this.chartSelections[key]);
-
-    const palette = ['#1976d2', '#d32f2f', '#388e3c', '#fbc02d', '#7b1fa2', '#00838f'];
 
     const seasonByYear = new Map<number, PlayerSeasonStats | GoalieSeasonStats>();
     sortedSeasons.forEach((season) => {
@@ -709,12 +649,13 @@ export class PlayerCardGraphsComponent implements AfterViewInit, OnDestroy {
       });
 
       const translatedLabel = this.translateService.instant(`tableColumn.${key}`);
+      const seriesColors = getChartSeriesColors(this.document, index);
 
       return {
         data,
         label: translatedLabel || `tableColumn.${key}`,
-        borderColor: palette[index % palette.length],
-        backgroundColor: palette[index % palette.length],
+        borderColor: seriesColors.lineColor,
+        backgroundColor: seriesColors.lineColor,
         fill: false,
         tension: 0.2,
         pointRadius: 3,

--- a/src/app/shared/settings-drawer/settings-drawer.component.html
+++ b/src/app/shared/settings-drawer/settings-drawer.component.html
@@ -6,7 +6,7 @@
     <button
       mat-icon-button
       type="button"
-      (click)="closeRequested.emit()"
+      (click)="requestClose()"
       [attr.aria-label]="'a11y.closeSettingsDrawer' | translate"
       [matTooltip]="'a11y.closeSettingsDrawer' | translate"
     >

--- a/src/app/shared/settings-drawer/settings-drawer.component.ts
+++ b/src/app/shared/settings-drawer/settings-drawer.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, computed, inject, input, output } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, inject, input } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
@@ -35,7 +35,7 @@ import { TopControlsComponent } from '@shared/top-controls/top-controls.componen
 export class SettingsDrawerComponent {
   readonly mode = input.required<SettingsDrawerMode>();
   readonly statsContext = input<StatsContext | undefined>(undefined);
-  readonly closeRequested = output<void>();
+  readonly closeDrawer = input<(() => void) | undefined>(undefined);
 
   private readonly apiService = inject(ApiService);
   private readonly drawerContextService = inject(DrawerContextService);
@@ -71,5 +71,9 @@ export class SettingsDrawerComponent {
       hour: '2-digit',
       minute: '2-digit',
     });
+  }
+
+  requestClose(): void {
+    this.closeDrawer()?.();
   }
 }

--- a/src/app/shared/stats-table/stats-table-player-card.service.ts
+++ b/src/app/shared/stats-table/stats-table-player-card.service.ts
@@ -1,0 +1,158 @@
+import { Injectable, Injector, inject, OnDestroy } from '@angular/core';
+import { MatDialog } from '@angular/material/dialog';
+
+import { Goalie, Player } from '@services/api.service';
+import type { PlayerCardDialogData } from '@shared/player-card/player-card.component';
+
+let playerCardComponentPromise: Promise<
+  typeof import('@shared/player-card/player-card.component')
+> | null = null;
+
+function loadPlayerCardComponent() {
+  playerCardComponentPromise ??= import('@shared/player-card/player-card.component');
+  return playerCardComponentPromise;
+}
+
+type NetworkInformationLike = {
+  saveData?: boolean;
+  effectiveType?: string;
+};
+
+type PlayerCardPrefetchEnvironment = Pick<Window, 'matchMedia' | 'navigator'> | null | undefined;
+
+export function shouldSchedulePlayerCardPrefetch(
+  env: PlayerCardPrefetchEnvironment,
+): boolean {
+  if (typeof env?.matchMedia !== 'function') {
+    return false;
+  }
+
+  if (env.matchMedia('(max-width: 768px)').matches) {
+    return false;
+  }
+
+  if (!env.matchMedia('(hover: hover) and (pointer: fine)').matches) {
+    return false;
+  }
+
+  const connection = (env.navigator as Navigator & { connection?: NetworkInformationLike })
+    .connection;
+  if (connection?.saveData) {
+    return false;
+  }
+
+  return !['slow-2g', '2g', '3g'].includes(
+    connection?.effectiveType?.toLowerCase() ?? '',
+  );
+}
+
+type OpenPlayerCardOptions = {
+  row: Player | Goalie;
+  allRows: (Player | Goalie)[];
+  onNavigate(newIndex: number): void;
+  onClose(navigatedIndex: number): void;
+};
+
+@Injectable()
+export class StatsTablePlayerCardService implements OnDestroy {
+  private readonly injector = inject(Injector);
+
+  private openingPlayerCard = false;
+  private playerCardPrefetchScheduled = false;
+  private playerCardPrefetchIdleId?: number;
+  private playerCardPrefetchTimerId?: ReturnType<typeof setTimeout>;
+
+  async openPlayerCard(options: OpenPlayerCardOptions): Promise<void> {
+    if (this.openingPlayerCard) {
+      return;
+    }
+
+    this.openingPlayerCard = true;
+
+    let navigatedIndex = options.allRows.indexOf(options.row);
+
+    const dialogData: PlayerCardDialogData = {
+      player: options.row,
+      navigationContext: {
+        allPlayers: options.allRows,
+        currentIndex: navigatedIndex,
+        onNavigate: (newIndex: number) => {
+          navigatedIndex = newIndex;
+          options.onNavigate(newIndex);
+        },
+      },
+    };
+
+    try {
+      const { PlayerCardComponent } = await loadPlayerCardComponent();
+      const dialogRef = this.injector.get(MatDialog).open(PlayerCardComponent, {
+        data: dialogData,
+        maxWidth: '95vw',
+        width: 'auto',
+        panelClass: 'player-card-dialog',
+      });
+
+      dialogRef.afterClosed().subscribe(() => {
+        options.onClose(navigatedIndex);
+      });
+    } finally {
+      this.openingPlayerCard = false;
+    }
+  }
+
+  onPlayerCardPrefetchIntent(clickable: boolean): void {
+    if (this.playerCardPrefetchScheduled || !clickable) {
+      return;
+    }
+
+    if (typeof window === 'undefined' || !shouldSchedulePlayerCardPrefetch(window)) {
+      return;
+    }
+
+    this.playerCardPrefetchScheduled = true;
+    this.schedulePlayerCardPrefetch();
+  }
+
+  ngOnDestroy(): void {
+    this.clearPlayerCardPrefetch();
+  }
+
+  private schedulePlayerCardPrefetch(): void {
+    const warmPlayerCardChunk = () => {
+      void loadPlayerCardComponent();
+    };
+
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    if ('requestIdleCallback' in window) {
+      this.playerCardPrefetchIdleId = window.requestIdleCallback(() => {
+        this.playerCardPrefetchIdleId = undefined;
+        warmPlayerCardChunk();
+      }, { timeout: 2000 });
+      return;
+    }
+
+    this.playerCardPrefetchTimerId = setTimeout(() => {
+      this.playerCardPrefetchTimerId = undefined;
+      warmPlayerCardChunk();
+    }, 1500);
+  }
+
+  private clearPlayerCardPrefetch(): void {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    if (this.playerCardPrefetchIdleId !== undefined && 'cancelIdleCallback' in window) {
+      window.cancelIdleCallback(this.playerCardPrefetchIdleId);
+      this.playerCardPrefetchIdleId = undefined;
+    }
+
+    if (this.playerCardPrefetchTimerId !== undefined) {
+      clearTimeout(this.playerCardPrefetchTimerId);
+      this.playerCardPrefetchTimerId = undefined;
+    }
+  }
+}

--- a/src/app/shared/stats-table/stats-table.component.spec.ts
+++ b/src/app/shared/stats-table/stats-table.component.spec.ts
@@ -11,8 +11,11 @@ import { PlayerCardDialogData } from '@shared/player-card/player-card.component'
 import {
   StatsTableComponent,
   TableRow,
-  shouldSchedulePlayerCardPrefetch,
 } from './stats-table.component';
+import {
+  shouldSchedulePlayerCardPrefetch,
+  StatsTablePlayerCardService,
+} from './stats-table-player-card.service';
 import {
   polyfillJsdom,
   provideDisabledMaterialAnimations,
@@ -98,10 +101,11 @@ describe('StatsTableComponent — user behavior', () => {
       componentProperties,
     });
 
-    const statsTable = view.fixture.debugElement.query(By.directive(StatsTableComponent))
-      .componentInstance as StatsTableComponent;
+    const statsTableDebug = view.fixture.debugElement.query(By.directive(StatsTableComponent));
+    const statsTable = statsTableDebug.componentInstance as StatsTableComponent;
+    const playerCardService = statsTableDebug.injector.get(StatsTablePlayerCardService);
 
-    return { ...view, close$, open, statsTable };
+    return { ...view, close$, open, statsTable, playerCardService };
   }
 
   function getDataRows(): HTMLElement[] {
@@ -458,17 +462,17 @@ describe('StatsTableComponent — user behavior', () => {
         })),
       });
 
-      const { statsTable } = await setup();
+      const { statsTable, playerCardService } = await setup();
       await screen.findByText('Alpha Center');
 
-      const statsTableInternal = statsTable as any;
+      const playerCardServiceInternal = playerCardService as any;
 
       statsTable.onPlayerCardPrefetchIntent();
-      expect(statsTableInternal.playerCardPrefetchTimerId).toBeDefined();
+      expect(playerCardServiceInternal.playerCardPrefetchTimerId).toBeDefined();
 
       vi.runOnlyPendingTimers();
 
-      expect(statsTableInternal.playerCardPrefetchTimerId).toBeUndefined();
+      expect(playerCardServiceInternal.playerCardPrefetchTimerId).toBeUndefined();
     } finally {
       Object.defineProperty(window, 'matchMedia', {
         configurable: true,
@@ -494,21 +498,21 @@ describe('StatsTableComponent — user behavior', () => {
         value: cancelIdleCallback,
       });
 
-      const { fixture, statsTable } = await setup();
+      const { fixture, playerCardService } = await setup();
       await screen.findByText('Alpha Center');
 
       const timerId = setTimeout(() => {}, 1500);
-      const componentWithPrefetchState = statsTable as any;
+      const serviceWithPrefetchState = playerCardService as any;
 
-      componentWithPrefetchState.playerCardPrefetchIdleId = 123;
-      componentWithPrefetchState.playerCardPrefetchTimerId = timerId;
+      serviceWithPrefetchState.playerCardPrefetchIdleId = 123;
+      serviceWithPrefetchState.playerCardPrefetchTimerId = timerId;
 
       fixture.destroy();
 
       expect(cancelIdleCallback).toHaveBeenCalledWith(123);
       expect(clearTimeoutSpy).toHaveBeenCalledWith(timerId);
-      expect(componentWithPrefetchState.playerCardPrefetchIdleId).toBeUndefined();
-      expect(componentWithPrefetchState.playerCardPrefetchTimerId).toBeUndefined();
+      expect(serviceWithPrefetchState.playerCardPrefetchIdleId).toBeUndefined();
+      expect(serviceWithPrefetchState.playerCardPrefetchTimerId).toBeUndefined();
     } finally {
       clearTimeoutSpy.mockRestore();
       if (previousCancelIdleCallback) {
@@ -522,7 +526,7 @@ describe('StatsTableComponent — user behavior', () => {
 
   it('no-ops prefetch scheduling helpers when window is unavailable', async () => {
     const windowDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'window');
-    const { statsTable } = await setup();
+    const { playerCardService } = await setup();
     await screen.findByText('Alpha Center');
 
     try {
@@ -532,11 +536,11 @@ describe('StatsTableComponent — user behavior', () => {
       });
 
       expect(() => {
-        (statsTable as any).schedulePlayerCardPrefetch();
+        (playerCardService as any).schedulePlayerCardPrefetch();
       }).not.toThrow();
 
       expect(() => {
-        (statsTable as any).clearPlayerCardPrefetch();
+        (playerCardService as any).clearPlayerCardPrefetch();
       }).not.toThrow();
     } finally {
       if (windowDescriptor) {

--- a/src/app/shared/stats-table/stats-table.component.ts
+++ b/src/app/shared/stats-table/stats-table.component.ts
@@ -4,7 +4,6 @@ import {
   Component,
   ElementRef,
   effect,
-  Injector,
   PLATFORM_ID,
   inject,
   input,
@@ -24,7 +23,6 @@ import { SortDirection } from '@angular/material/sort';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatIconModule } from '@angular/material/icon';
-import { MatDialog } from '@angular/material/dialog';
 import { Column, ColumnIcon } from '@shared/column.types';
 import { formatStatDisplayValue } from '@shared/utils/stat-value-format.utils';
 import {
@@ -37,51 +35,11 @@ import {
   CareerGoalieListItem,
 } from '@services/api.service';
 import { ExpandedRowViewModel } from '@shared/table-row-expansion.types';
-import type { PlayerCardDialogData } from '@shared/player-card/player-card.component';
+import {
+  StatsTablePlayerCardService,
+} from './stats-table-player-card.service';
 
 const ROW_NUMBER_COLUMN = '__rowNumber';
-
-let playerCardComponentPromise: Promise<
-  typeof import('@shared/player-card/player-card.component')
-> | null = null;
-
-function loadPlayerCardComponent() {
-  playerCardComponentPromise ??= import('@shared/player-card/player-card.component');
-  return playerCardComponentPromise;
-}
-
-type NetworkInformationLike = {
-  saveData?: boolean;
-  effectiveType?: string;
-};
-
-type PlayerCardPrefetchEnvironment = Pick<Window, 'matchMedia' | 'navigator'> | null | undefined;
-
-export function shouldSchedulePlayerCardPrefetch(
-  env: PlayerCardPrefetchEnvironment,
-): boolean {
-  if (typeof env?.matchMedia !== 'function') {
-    return false;
-  }
-
-  if (env.matchMedia('(max-width: 768px)').matches) {
-    return false;
-  }
-
-  if (!env.matchMedia('(hover: hover) and (pointer: fine)').matches) {
-    return false;
-  }
-
-  const connection = (env.navigator as Navigator & { connection?: NetworkInformationLike })
-    .connection;
-  if (connection?.saveData) {
-    return false;
-  }
-
-  return !['slow-2g', '2g', '3g'].includes(
-    connection?.effectiveType?.toLowerCase() ?? '',
-  );
-}
 
 export type TableRow =
   | Player
@@ -110,12 +68,13 @@ export type TableRow =
   ],
   templateUrl: './stats-table.component.html',
   styleUrl: './stats-table.component.scss',
+  providers: [StatsTablePlayerCardService],
 })
 export class StatsTableComponent implements AfterViewInit, OnDestroy {
   private cdr = inject(ChangeDetectorRef);
-  private readonly injector = inject(Injector);
   private readonly platformId = inject(PLATFORM_ID);
   private translate = inject(TranslateService);
+  private readonly playerCardService = inject(StatsTablePlayerCardService);
 
   readonly dataInput = input.required<TableRow[]>({ alias: 'data' });
   readonly columnsInput = input.required<Column[]>({ alias: 'columns' });
@@ -167,10 +126,6 @@ export class StatsTableComponent implements AfterViewInit, OnDestroy {
   private previousLoading?: boolean;
   private previousTableId?: string;
   private previousShowPositionColumn?: boolean;
-  private playerCardPrefetchScheduled = false;
-  private openingPlayerCard = false;
-  private playerCardPrefetchIdleId?: number;
-  private playerCardPrefetchTimerId?: ReturnType<typeof setTimeout>;
 
   loadingProgress = 0;
   loadingBuffer = 0;
@@ -328,7 +283,6 @@ export class StatsTableComponent implements AfterViewInit, OnDestroy {
 
   ngOnDestroy(): void {
     this.clearLoadingProgressTimer();
-    this.clearPlayerCardPrefetch();
   }
 
   private onLoadingChanged(isLoading: boolean) {
@@ -546,46 +500,18 @@ export class StatsTableComponent implements AfterViewInit, OnDestroy {
   }
 
   async selectItem(data: TableRow): Promise<void> {
-    if (this.openingPlayerCard) {
-      return;
-    }
-
-    this.openingPlayerCard = true;
-
-    // Track navigated index in a closure so CDK focus restoration
-    // (which triggers onRowFocus) cannot overwrite it before afterClosed fires.
-    let navigatedIndex = this.dataSource.filteredData.indexOf(data);
-
-    const dialogData: PlayerCardDialogData = {
-      player: data as Player | Goalie,
-      navigationContext: {
-        allPlayers: this.dataSource.filteredData as (Player | Goalie)[],
-        currentIndex: navigatedIndex,
-        onNavigate: (newIndex: number) => {
-          navigatedIndex = newIndex;
-          this.activeRowIndex = newIndex;
-          this.scrollRowIntoView(newIndex);
-          this.cdr.detectChanges();
-        },
+    await this.playerCardService.openPlayerCard({
+      row: data as Player | Goalie,
+      allRows: this.dataSource.filteredData as (Player | Goalie)[],
+      onNavigate: (newIndex) => {
+        this.activeRowIndex = newIndex;
+        this.scrollRowIntoView(newIndex);
+        this.cdr.detectChanges();
       },
-    };
-
-    try {
-      const { PlayerCardComponent } = await loadPlayerCardComponent();
-      const dialogRef = this.injector.get(MatDialog).open(PlayerCardComponent, {
-        data: dialogData,
-        maxWidth: '95vw',
-        width: 'auto',
-        panelClass: 'player-card-dialog',
-      });
-
-      // Focus the navigated-to row when dialog closes.
-      dialogRef.afterClosed().subscribe(() => {
+      onClose: (navigatedIndex) => {
         this.focusRow(navigatedIndex);
-      });
-    } finally {
-      this.openingPlayerCard = false;
-    }
+      },
+    });
   }
 
   onRowSelectToggle(row: TableRow): void {
@@ -593,55 +519,7 @@ export class StatsTableComponent implements AfterViewInit, OnDestroy {
   }
 
   onPlayerCardPrefetchIntent(): void {
-    if (this.playerCardPrefetchScheduled || !this.clickable) {
-      return;
-    }
-
-    if (typeof window === 'undefined' || !shouldSchedulePlayerCardPrefetch(window)) {
-      return;
-    }
-
-    this.playerCardPrefetchScheduled = true;
-    this.schedulePlayerCardPrefetch();
-  }
-
-  private schedulePlayerCardPrefetch(): void {
-    const warmPlayerCardChunk = () => {
-      void loadPlayerCardComponent();
-    };
-
-    if (typeof window === 'undefined') {
-      return;
-    }
-
-    if ('requestIdleCallback' in window) {
-      this.playerCardPrefetchIdleId = window.requestIdleCallback(() => {
-        this.playerCardPrefetchIdleId = undefined;
-        warmPlayerCardChunk();
-      }, { timeout: 2000 });
-      return;
-    }
-
-    this.playerCardPrefetchTimerId = setTimeout(() => {
-      this.playerCardPrefetchTimerId = undefined;
-      warmPlayerCardChunk();
-    }, 1500);
-  }
-
-  private clearPlayerCardPrefetch(): void {
-    if (typeof window === 'undefined') {
-      return;
-    }
-
-    if (this.playerCardPrefetchIdleId !== undefined && 'cancelIdleCallback' in window) {
-      window.cancelIdleCallback(this.playerCardPrefetchIdleId);
-      this.playerCardPrefetchIdleId = undefined;
-    }
-
-    if (this.playerCardPrefetchTimerId !== undefined) {
-      clearTimeout(this.playerCardPrefetchTimerId);
-      this.playerCardPrefetchTimerId = undefined;
-    }
+    this.playerCardService.onPlayerCardPrefetchIntent(this.clickable);
   }
 
   onSearchKeydown(event: KeyboardEvent): void {

--- a/src/app/shared/styles/_shell-header.scss
+++ b/src/app/shared/styles/_shell-header.scss
@@ -3,11 +3,13 @@
   justify-content: center;
   align-items: center;
   gap: 8px;
+  min-height: 56px;
+  padding: 8px 0;
 }
 
 .title-row h1 {
-  margin-top: 0.3em;
-  margin-bottom: 0.3em;
+  margin: 0;
+  line-height: 1.1;
   text-align: center;
 }
 
@@ -23,7 +25,8 @@
 }
 
 .route-subtitle {
-  margin: -6px 8px 8px 8px;
+  min-height: calc(0.9rem * 1.2);
+  margin: 0 8px 12px;
   padding: 0 4px;
   font-size: 0.9rem;
   font-weight: 400;
@@ -39,6 +42,7 @@
     align-items: center;
     justify-content: initial;
     margin: 0 8px;
+    min-height: auto;
     padding: 6px 0;
   }
 

--- a/src/app/shared/utils/chart-theme.utils.spec.ts
+++ b/src/app/shared/utils/chart-theme.utils.spec.ts
@@ -1,0 +1,42 @@
+import { getChartSeriesColors } from './chart-theme.utils';
+
+describe('chart theme utilities', () => {
+  afterEach(() => {
+    document.documentElement.removeAttribute('style');
+    document.body.removeAttribute('style');
+  });
+
+  it('reads the configured chart token colors for a series', () => {
+    document.documentElement.style.setProperty('--app-chart-series-1', 'rgb(10, 20, 30)');
+    document.documentElement.style.setProperty(
+      '--app-chart-series-1-fill',
+      'rgba(10, 20, 30, 0.25)',
+    );
+    document.documentElement.style.setProperty('--mat-sys-surface', 'rgb(240, 241, 242)');
+
+    const colors = getChartSeriesColors(document, 0);
+
+    expect(colors).toEqual({
+      lineColor: 'rgb(10, 20, 30)',
+      fillColor: 'rgba(10, 20, 30, 0.25)',
+      pointBackgroundColor: 'rgb(10, 20, 30)',
+      pointBorderColor: 'rgb(240, 241, 242)',
+      pointHoverBackgroundColor: 'rgb(240, 241, 242)',
+      pointHoverBorderColor: 'rgb(10, 20, 30)',
+    });
+  });
+
+  it('wraps the palette index so longer line-chart selections still get shared theme colors', () => {
+    document.documentElement.style.setProperty('--app-chart-series-1', 'rgb(10, 20, 30)');
+    document.documentElement.style.setProperty(
+      '--app-chart-series-1-fill',
+      'rgba(10, 20, 30, 0.25)',
+    );
+    document.documentElement.style.setProperty('--mat-sys-surface', 'rgb(240, 241, 242)');
+
+    const colors = getChartSeriesColors(document, 6);
+
+    expect(colors.lineColor).toBe('rgb(10, 20, 30)');
+    expect(colors.fillColor).toBe('rgba(10, 20, 30, 0.25)');
+  });
+});

--- a/src/app/shared/utils/chart-theme.utils.ts
+++ b/src/app/shared/utils/chart-theme.utils.ts
@@ -1,0 +1,174 @@
+type ChartSeriesTokenConfig = {
+  strokeVar: string;
+  strokeFallback: string;
+  fillVar: string;
+  fillFallback: string;
+};
+
+export type ChartSeriesColors = {
+  lineColor: string;
+  fillColor: string;
+  pointBackgroundColor: string;
+  pointBorderColor: string;
+  pointHoverBackgroundColor: string;
+  pointHoverBorderColor: string;
+};
+
+const CHART_SERIES_TOKENS: readonly ChartSeriesTokenConfig[] = [
+  {
+    strokeVar: '--app-chart-series-1',
+    strokeFallback: '#1976d2',
+    fillVar: '--app-chart-series-1-fill',
+    fillFallback: 'rgba(25, 118, 210, 0.3)',
+  },
+  {
+    strokeVar: '--app-chart-series-2',
+    strokeFallback: '#ff9800',
+    fillVar: '--app-chart-series-2-fill',
+    fillFallback: 'rgba(255, 152, 0, 0.3)',
+  },
+  {
+    strokeVar: '--app-chart-series-3',
+    strokeFallback: '#388e3c',
+    fillVar: '--app-chart-series-3-fill',
+    fillFallback: 'rgba(56, 142, 60, 0.3)',
+  },
+  {
+    strokeVar: '--app-chart-series-4',
+    strokeFallback: '#fbc02d',
+    fillVar: '--app-chart-series-4-fill',
+    fillFallback: 'rgba(251, 192, 45, 0.3)',
+  },
+  {
+    strokeVar: '--app-chart-series-5',
+    strokeFallback: '#7b1fa2',
+    fillVar: '--app-chart-series-5-fill',
+    fillFallback: 'rgba(123, 31, 162, 0.3)',
+  },
+  {
+    strokeVar: '--app-chart-series-6',
+    strokeFallback: '#00838f',
+    fillVar: '--app-chart-series-6-fill',
+    fillFallback: 'rgba(0, 131, 143, 0.3)',
+  },
+] as const;
+
+function createHiddenProbeElement(document: Document): HTMLSpanElement {
+  const el = document.createElement('span');
+  el.setAttribute('aria-hidden', 'true');
+  el.style.position = 'absolute';
+  el.style.width = '0';
+  el.style.height = '0';
+  el.style.overflow = 'hidden';
+  return el;
+}
+
+function detectUsedColorScheme(
+  document: Document,
+  body: HTMLElement,
+  knownScheme: 'light' | 'dark' | undefined,
+): 'light' | 'dark' | undefined {
+  if (knownScheme) {
+    return knownScheme;
+  }
+
+  const schemeProbe = createHiddenProbeElement(document);
+  schemeProbe.style.color = 'light-dark(rgb(1, 2, 3), rgb(4, 5, 6))';
+  body.appendChild(schemeProbe);
+
+  const observed = getComputedStyle(schemeProbe).color?.trim();
+  schemeProbe.remove();
+
+  if (observed === 'rgb(1, 2, 3)') return 'light';
+  if (observed === 'rgb(4, 5, 6)') return 'dark';
+  return undefined;
+}
+
+export function resolveThemedCssColorVar(
+  document: Document,
+  name: string,
+  fallback: string,
+  cssProperty: 'color' | 'backgroundColor' = 'color',
+): string {
+  try {
+    const body = document.body;
+    if (!body) {
+      return fallback;
+    }
+
+    const root = document.documentElement;
+    const rootStyle = root ? getComputedStyle(root) : undefined;
+    const directRootValue = rootStyle?.getPropertyValue(name)?.trim();
+    const computedSchemeRaw =
+      (rootStyle as CSSStyleDeclaration & { colorScheme?: string })?.colorScheme ||
+      rootStyle?.getPropertyValue('color-scheme') ||
+      '';
+    const schemeTokens = computedSchemeRaw.trim().split(/\s+/).filter(Boolean);
+    const schemeToken = schemeTokens.length === 1 ? schemeTokens[0] : undefined;
+
+    const scheme: 'light' | 'dark' | undefined =
+      schemeToken === 'dark' || schemeToken === 'light'
+        ? (schemeToken as 'light' | 'dark')
+        : undefined;
+
+    const usedScheme = detectUsedColorScheme(document, body, scheme);
+    const probe = createHiddenProbeElement(document);
+    if (usedScheme) {
+      probe.style.setProperty('color-scheme', usedScheme);
+    }
+
+    if (cssProperty === 'backgroundColor') {
+      probe.style.backgroundColor = `var(${name})`;
+    } else {
+      probe.style.color = `var(${name})`;
+    }
+
+    body.appendChild(probe);
+    const computed = getComputedStyle(probe)[cssProperty];
+    probe.remove();
+
+    const resolved = computed?.trim();
+    if (resolved && !resolved.startsWith('var(')) {
+      return resolved;
+    }
+
+    if (directRootValue && !directRootValue.startsWith('var(')) {
+      return directRootValue;
+    }
+
+    return fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+export function getChartSeriesColors(document: Document, index: number): ChartSeriesColors {
+  const normalizedIndex = ((index % CHART_SERIES_TOKENS.length) + CHART_SERIES_TOKENS.length) %
+    CHART_SERIES_TOKENS.length;
+  const tokenConfig = CHART_SERIES_TOKENS[normalizedIndex];
+  const pointContrastColor = resolveThemedCssColorVar(
+    document,
+    '--mat-sys-surface',
+    '#ffffff',
+  );
+  const lineColor = resolveThemedCssColorVar(
+    document,
+    tokenConfig.strokeVar,
+    tokenConfig.strokeFallback,
+  );
+  const fillColor = resolveThemedCssColorVar(
+    document,
+    tokenConfig.fillVar,
+    tokenConfig.fillFallback,
+    'backgroundColor',
+  );
+
+  return {
+    lineColor,
+    fillColor,
+    pointBackgroundColor: lineColor,
+    pointBorderColor: pointContrastColor,
+    pointHoverBackgroundColor: pointContrastColor,
+    pointHoverBorderColor: lineColor,
+  };
+}

--- a/src/styles/_shared-table-shells.scss
+++ b/src/styles/_shared-table-shells.scss
@@ -115,7 +115,8 @@ app-stats-table {
     overflow-x: auto;
     overflow-y: auto;
     width: 100%;
-    max-height: calc(100vh - 120px);
+    max-height: calc(var(--app-height) - 120px);
+    scrollbar-gutter: stable;
   }
 
   .mat-mdc-table {
@@ -233,7 +234,7 @@ app-virtual-table {
   .table-container--virtual {
     background: var(--mat-sys-surface);
     color: var(--mat-sys-on-surface);
-    max-height: calc(100vh - 200px);
+    max-height: calc(var(--app-height) - 200px);
     overflow-y: hidden;
   }
 
@@ -296,7 +297,7 @@ app-virtual-table {
   }
 
   .virtual-viewport {
-    height: calc(100vh - 200px);
+    height: calc(var(--app-height) - 200px);
     width: 100%;
     background: var(--mat-sys-surface);
     scrollbar-gutter: stable;

--- a/src/theme.scss
+++ b/src/theme.scss
@@ -84,6 +84,18 @@ $theme: mat.define-theme(
     var(--mat-sys-primary-container) 70%,
     var(--mat-sys-surface-container-high) 30%
   );
+  --app-chart-series-1: light-dark(#1976d2, #8ab4f8);
+  --app-chart-series-1-fill: color-mix(in srgb, var(--app-chart-series-1) 30%, transparent);
+  --app-chart-series-2: light-dark(#ff9800, #ffb74d);
+  --app-chart-series-2-fill: color-mix(in srgb, var(--app-chart-series-2) 30%, transparent);
+  --app-chart-series-3: light-dark(#388e3c, #81c784);
+  --app-chart-series-3-fill: color-mix(in srgb, var(--app-chart-series-3) 30%, transparent);
+  --app-chart-series-4: light-dark(#fbc02d, #ffd54f);
+  --app-chart-series-4-fill: color-mix(in srgb, var(--app-chart-series-4) 30%, transparent);
+  --app-chart-series-5: light-dark(#7b1fa2, #ba68c8);
+  --app-chart-series-5-fill: color-mix(in srgb, var(--app-chart-series-5) 30%, transparent);
+  --app-chart-series-6: light-dark(#00838f, #4dd0e1);
+  --app-chart-series-6-fill: color-mix(in srgb, var(--app-chart-series-6) 30%, transparent);
 }
 
 @media (prefers-color-scheme: dark) {


### PR DESCRIPTION
## Summary

This branch completes the codebase-health workstream from the audit and cleans up the roadmap afterward.

### What changed

- Fix per-game stats transformation so row identity and non-stat metadata are preserved, and use the correct per-game score source.
- Lazy-load the settings drawer from the root shell to reduce the initial bundle.
- Stabilize the desktop route/table shell to remove the measured CLS regression.
- Harden the Vercel API proxy to an explicit read-only allowlist and stop forwarding sensitive headers/cookies.
- Extract player-card workflow responsibilities out of `StatsTableComponent` into a dedicated service.
- Move player-card and comparison chart colors to shared theme tokens so light and dark mode stay aligned.
- Remove completed roadmap items, including the codebase-health section and the requested cleanup sections.

### Outcome

- Production initial bundle dropped from about `1.04 MB` to about `805 kB`.
- Desktop CLS on audited routes dropped from about `0.19-0.20` to about `0.005-0.017`.
- Chart rendering now uses a shared token-backed palette across player-card graphs and comparison radar views.
- The roadmap now reflects the remaining actual work instead of completed audit follow-ups.

## Testing

- `npm run verify`
- `npm run build -- --stats-json`
- `npm run perf:audit`
- `npx vitest run api/proxy.spec.js`
- Browser validation on `localhost:4200` for player-card graphs and comparison radar in light and dark mode
